### PR TITLE
feat(chat): improve media handling and caching for user messages

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -656,7 +656,7 @@ export class GatewayManager extends EventEmitter {
   /**
    * Wait for Gateway to be ready by checking if the port is accepting connections
    */
-  private async waitForReady(retries = 120, interval = 1000): Promise<void> {
+  private async waitForReady(retries = 600, interval = 1000): Promise<void> {
     for (let i = 0; i < retries; i++) {
       // Early exit if the gateway process has already exited
       if (this.process && (this.process.exitCode !== null || this.process.signalCode !== null)) {

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -115,9 +115,10 @@ const electronAPI = {
         'log:getFilePath',
         'log:getDir',
         'log:listFiles',
-        // File staging
+        // File staging & media
         'file:stage',
         'file:stageBuffer',
+        'media:getThumbnails',
         // Chat send with media (reads staged files in main process)
         'chat:sendWithMedia',
         // OpenClaw extras

--- a/src/pages/Chat/ChatMessage.tsx
+++ b/src/pages/Chat/ChatMessage.tsx
@@ -105,35 +105,41 @@ export const ChatMessage = memo(function ChatMessage({
           />
         )}
 
-        {/* Images (from assistant/channel content blocks) */}
+        {/* Images from content blocks (Gateway session data — persists across history reloads) */}
         {images.length > 0 && (
           <div className="flex flex-wrap gap-2">
             {images.map((img, i) => (
               <img
-                key={i}
+                key={`content-${i}`}
                 src={`data:${img.mimeType};base64,${img.data}`}
                 alt="attachment"
-                className="max-w-xs rounded-lg border"
+                className={cn(
+                  'rounded-lg border',
+                  isUser ? 'max-w-[200px] max-h-48' : 'max-w-xs',
+                )}
               />
             ))}
           </div>
         )}
 
-        {/* File attachments (user-uploaded files) */}
+        {/* File attachments (local preview — shown before history reload) */}
+        {/* Only show _attachedFiles images if no content-block images (avoid duplicates) */}
         {attachedFiles.length > 0 && (
           <div className="flex flex-wrap gap-2">
-            {attachedFiles.map((file, i) => (
-              file.mimeType.startsWith('image/') && file.preview ? (
+            {attachedFiles.map((file, i) => {
+              // Skip image attachments if we already have images from content blocks
+              if (file.mimeType.startsWith('image/') && file.preview && images.length > 0) return null;
+              return file.mimeType.startsWith('image/') && file.preview ? (
                 <img
-                  key={i}
+                  key={`local-${i}`}
                   src={file.preview}
                   alt={file.fileName}
-                  className="max-w-xs max-h-48 rounded-lg border"
+                  className="max-w-[200px] max-h-48 rounded-lg border"
                 />
               ) : (
-                <FileCard key={i} file={file} />
-              )
-            ))}
+                <FileCard key={`local-${i}`} file={file} />
+              );
+            })}
           </div>
         )}
       </div>

--- a/src/pages/Setup/index.tsx
+++ b/src/pages/Setup/index.tsx
@@ -519,7 +519,7 @@ function RuntimeContent({ onStatusChange }: RuntimeContentProps) {
         }
         return prev;
       });
-    }, 120 * 1000); // 120 seconds — enough for gateway to fully initialize
+    }, 600 * 1000); // 600 seconds — enough for gateway to fully initialize
 
     return () => {
       if (gatewayTimeoutRef.current) {


### PR DESCRIPTION
- Increased the retry duration for Gateway readiness from 120 to 600 seconds.
- Enhanced image attachment processing in the chat by implementing a local image cache.
- Added functionality to extract media file references from user messages.
- Improved the display of images and file attachments in the chat interface.
- Implemented loading of missing image previews from disk for better user experience.