### PR TITLE
fix(gateway): remove --dev flag from gateway startup args

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -568,7 +568,7 @@ export class GatewayManager extends EventEmitter {
     // In packaged Electron app, use process.execPath with ELECTRON_RUN_AS_NODE=1
     // which makes the Electron binary behave as plain Node.js.
     // In development, use system 'node'.
-    const gatewayArgs = ['gateway', '--port', String(this.status.port), '--token', gatewayToken, '--dev', '--allow-unconfigured'];
+    const gatewayArgs = ['gateway', '--port', String(this.status.port), '--token', gatewayToken, '--allow-unconfigured'];
     
     if (app.isPackaged) {
       // Production: use Electron binary as Node.js via ELECTRON_RUN_AS_NODE


### PR DESCRIPTION
## Summary

- Remove `--dev` flag from gateway startup args in `GatewayManager.startProcess()`
- The `--dev` flag caused OpenClaw gateway to run `ensureDevGatewayConfig()` on first startup, which wrote `agents.list: [{ id: "dev", default: true }]` with a C3-PO identity to `~/.openclaw/openclaw.json`
- This made all packaged builds permanently default to the dev workspace (`~/.openclaw/workspace-dev`) instead of the standard "main" agent workspace

## Root cause

`manager.ts:571` always passed `--dev` in `gatewayArgs`:
```
['gateway', '--port', ..., '--token', ..., '--dev', '--allow-unconfigured']
```

OpenClaw's gateway subcommand treats `--dev` as a convenience flag that auto-creates a dev config + workspace (with agent id "dev", identity "C3-PO"). This is intended for OpenClaw CLI development, not for production ClawX usage.

## Test plan

- [ ] Start ClawX with a clean `~/.openclaw/` directory, verify no `agents.list` with `id: "dev"` is created
- [ ] Verify gateway still starts successfully with `--allow-unconfigured`
- [ ] Verify provider/channel config written by ClawX is properly picked up by the gateway

> **Note for existing users**: After this fix, users who already have the stale `agents.list[0].id = "dev"` in their `~/.openclaw/openclaw.json` will need to manually remove the `agents.list` entry (or delete the config file to regenerate).


Made with [Cursor](https://cursor.com)