### PR TITLE
fix(chat): show loading when run from console and when sending in app

### DIFF
--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -110,7 +110,7 @@ export function Chat() {
       {/* Messages Area */}
       <div className="flex-1 overflow-y-auto px-4 py-4">
         <div className="max-w-4xl mx-auto space-y-4">
-          {loading ? (
+          {loading && !sending ? (
             <div className="flex h-full items-center justify-center py-20">
               <LoadingSpinner size="lg" />
             </div>

--- a/src/stores/gateway.ts
+++ b/src/stores/gateway.ts
@@ -94,6 +94,21 @@ export const useGatewayStore = create<GatewayState>((set, get) => ({
               .catch(() => {});
           }
 
+          // When a run starts (e.g. user clicked Send on console), show loading in the app immediately.
+          const runId = p.runId ?? data.runId;
+          const sessionKey = p.sessionKey ?? data.sessionKey;
+          if (phase === 'started' && runId != null && sessionKey != null) {
+            import('./chat')
+              .then(({ useChatStore }) => {
+                useChatStore.getState().handleChatEvent({
+                  state: 'started',
+                  runId,
+                  sessionKey,
+                });
+              })
+              .catch(() => {});
+          }
+
           // When the agent run completes, reload history to get the final response.
           if (phase === 'completed' || phase === 'done' || phase === 'finished' || phase === 'end') {
             import('./chat')


### PR DESCRIPTION
## Problem
- When a conversation is started from the console (http://127.0.0.1:18789/chat), the desktop app does not show loading until the first message arrives (then it flashes briefly).
- When the user clicks Send in the app, if history is still loading, the full-page spinner hides the "sending" typing indicator.

## Changes

### 1. Session filter and "adopt" runs started from console (`chat.ts`)
- Process only events where `event.sessionKey === currentSessionKey` to avoid cross-session noise.
- When receiving delta/final/error/aborted, if not currently sending, set `sending: true` and `activeRunId` so the app shows loading/streaming.
- Handle `state === 'started'`: set sending as soon as a run starts so loading appears immediately when the user sends from the console.

### 2. Forward phase started (`gateway.ts`)
- When an agent notification has `phase === 'started'` with `runId` and `sessionKey`, forward a `state: 'started'` event to the chat store so the app shows loading immediately.

### 3. Prefer typing indicator when sending (`Chat/index.tsx`)
- Full-page loading condition changed from `loading` to `loading && !sending` so that while sending, the message area and TypingIndicator are shown instead of being covered by the history spinner.
