### PR TITLE
chore: replace clawx.app with claw-x.com and update maintainer email

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -154,7 +154,7 @@ linux:
       arch:
         - x64
   category: Utility
-  maintainer: ClawX Team <team@clawx.app>
+  maintainer: ClawX Team <public@valuecell.ai>
   vendor: ClawX
   synopsis: AI Assistant powered by OpenClaw
   description: |

--- a/resources/cli/posix/openclaw
+++ b/resources/cli/posix/openclaw
@@ -37,7 +37,7 @@ case "$1" in
     echo ""
     echo "To update openclaw, update ClawX:"
     echo "  Open ClawX > Settings > Check for Updates"
-    echo "  Or download the latest version from https://clawx.app"
+    echo "  Or download the latest version from https://claw-x.com"
     echo ""
     ELECTRON_RUN_AS_NODE=1 "$ELECTRON" "$CLI" --version 2>/dev/null || true
     exit 0

--- a/resources/cli/win32/openclaw.cmd
+++ b/resources/cli/win32/openclaw.cmd
@@ -6,7 +6,7 @@ if /i "%1"=="update" (
     echo.
     echo To update openclaw, update ClawX:
     echo   Open ClawX ^> Settings ^> Check for Updates
-    echo   Or download the latest version from https://clawx.app
+    echo   Or download the latest version from https://claw-x.com
     exit /b 0
 )
 


### PR DESCRIPTION
Update domain references from `clawx.app` to `claw-x.com` and set the maintainer email to `public@valuecell.ai` to correct outdated information.

---
<p><a href="https://cursor.com/agents/bc-ef19df85-d783-47ff-ad22-96d86e23170e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ef19df85-d783-47ff-ad22-96d86e23170e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

