### PR TITLE
技能配置问题

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -31,7 +31,7 @@ import {
   buildDeviceAuthPayload,
   type DeviceIdentity,
 } from '../utils/device-identity';
-import { syncGatewayTokenToConfig, syncBrowserConfigToOpenClaw } from '../utils/openclaw-auth';
+import { syncGatewayTokenToConfig, syncBrowserConfigToOpenClaw, sanitizeOpenClawConfig } from '../utils/openclaw-auth';
 
 /**
  * Gateway connection status
@@ -730,6 +730,15 @@ export class GatewayManager extends EventEmitter {
     
     // Get or generate gateway token
     const gatewayToken = await getSetting('gatewayToken');
+
+    // Strip stale/invalid keys from openclaw.json that would cause the
+    // Gateway's strict config validation to reject the file on startup
+    // (e.g. `skills.enabled` left by an older version).
+    try {
+      await sanitizeOpenClawConfig();
+    } catch (err) {
+      logger.warn('Failed to sanitize openclaw.json:', err);
+    }
 
     // Write our token into openclaw.json before starting the process.
     // Without --dev the gateway authenticates using the token in

--- a/tests/unit/sanitize-config.test.ts
+++ b/tests/unit/sanitize-config.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Tests for openclaw.json config sanitization before Gateway start.
+ *
+ * Uses a temp directory with real file I/O to avoid fs/promises mock complexity.
+ */
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, writeFile, readFile, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+let tempDir: string;
+let configPath: string;
+
+async function writeConfig(data: unknown): Promise<void> {
+  await writeFile(configPath, JSON.stringify(data, null, 2), 'utf-8');
+}
+
+async function readConfig(): Promise<Record<string, unknown>> {
+  const raw = await readFile(configPath, 'utf-8');
+  return JSON.parse(raw);
+}
+
+/**
+ * Standalone version of the sanitization logic for testing.
+ * Mirrors the logic in openclaw-auth.ts#sanitizeOpenClawConfig.
+ */
+async function sanitizeConfig(filePath: string): Promise<boolean> {
+  let raw: string;
+  try {
+    raw = await readFile(filePath, 'utf-8');
+  } catch {
+    return false;
+  }
+
+  const config = JSON.parse(raw) as Record<string, unknown>;
+  let modified = false;
+
+  const skills = config.skills;
+  if (skills && typeof skills === 'object' && !Array.isArray(skills)) {
+    const skillsObj = skills as Record<string, unknown>;
+    const VALID_SKILLS_KEYS = new Set(['allowBundled', 'load', 'install', 'limits', 'entries']);
+    for (const key of Object.keys(skillsObj)) {
+      if (!VALID_SKILLS_KEYS.has(key)) {
+        delete skillsObj[key];
+        modified = true;
+      }
+    }
+  }
+
+  if (modified) {
+    await writeFile(filePath, JSON.stringify(config, null, 2), 'utf-8');
+  }
+  return modified;
+}
+
+beforeEach(async () => {
+  tempDir = await mkdtemp(join(tmpdir(), 'clawx-test-'));
+  configPath = join(tempDir, 'openclaw.json');
+});
+
+afterEach(async () => {
+  await rm(tempDir, { recursive: true, force: true });
+});
+
+describe('sanitizeOpenClawConfig', () => {
+  it('removes skills.enabled at the top level of skills', async () => {
+    await writeConfig({
+      skills: {
+        enabled: true,
+        entries: {
+          'my-skill': { enabled: true, apiKey: 'abc' },
+        },
+      },
+      gateway: { mode: 'local' },
+    });
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(true);
+
+    const result = await readConfig();
+    expect(result.skills).not.toHaveProperty('enabled');
+    const skills = result.skills as Record<string, unknown>;
+    const entries = skills.entries as Record<string, Record<string, unknown>>;
+    expect(entries['my-skill'].enabled).toBe(true);
+    expect(entries['my-skill'].apiKey).toBe('abc');
+    expect(result.gateway).toEqual({ mode: 'local' });
+  });
+
+  it('does nothing when config is already valid', async () => {
+    const original = {
+      skills: {
+        entries: { 'my-skill': { enabled: true } },
+      },
+    };
+    await writeConfig(original);
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(false);
+
+    const result = await readConfig();
+    expect(result).toEqual(original);
+  });
+
+  it('handles config with no skills section', async () => {
+    const original = { gateway: { mode: 'local' } };
+    await writeConfig(original);
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(false);
+  });
+
+  it('handles empty config', async () => {
+    await writeConfig({});
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(false);
+  });
+
+  it('returns false for missing config file', async () => {
+    const modified = await sanitizeConfig(join(tempDir, 'nonexistent.json'));
+    expect(modified).toBe(false);
+  });
+
+  it('removes multiple unknown keys from skills', async () => {
+    await writeConfig({
+      skills: {
+        enabled: true,
+        disabled: false,
+        someOther: 'value',
+        entries: { 'x': { enabled: false } },
+        allowBundled: ['web-search'],
+      },
+    });
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(true);
+
+    const result = await readConfig();
+    const skills = result.skills as Record<string, unknown>;
+    expect(Object.keys(skills).sort()).toEqual(['allowBundled', 'entries']);
+    const entries = skills.entries as Record<string, Record<string, unknown>>;
+    expect(entries['x'].enabled).toBe(false);
+  });
+
+  it('preserves all valid skills keys', async () => {
+    const original = {
+      skills: {
+        allowBundled: ['web-search'],
+        load: { extraDirs: ['/my/dir'], watch: true },
+        install: { preferBrew: false },
+        limits: { maxSkillsInPrompt: 5 },
+        entries: { 'a-skill': { enabled: true, apiKey: 'key', env: { FOO: 'bar' } } },
+      },
+    };
+    await writeConfig(original);
+
+    const modified = await sanitizeConfig(configPath);
+    expect(modified).toBe(false);
+
+    const result = await readConfig();
+    expect(result).toEqual(original);
+  });
+});


### PR DESCRIPTION
Remove unrecognized `skills.enabled` key from OpenClaw config to prevent Gateway crashes.

The Gateway was crashing due to strict Zod schema validation rejecting the `skills.enabled` key at the top level of the `skills` object in `~/.openclaw/openclaw.json`. This fix introduces a sanitization step to remove such invalid keys before the Gateway process starts, resolving the startup failure.

---
<p><a href="https://cursor.com/agents/bc-18426037-69d3-455b-95c6-9ceb5d5fca87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-18426037-69d3-455b-95c6-9ceb5d5fca87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

