### PR TITLE
Windows 网关重启弹窗

### DIFF
--- a/electron/gateway/clawhub.ts
+++ b/electron/gateway/clawhub.ts
@@ -106,6 +106,7 @@ export class ClawHubService {
                     ...env,
                     CLAWHUB_WORKDIR: this.workDir,
                 },
+                windowsHide: true,
             });
 
             let stdout = '';

--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -610,7 +610,7 @@ export class GatewayManager extends EventEmitter {
 
       const loaded = await new Promise<boolean>((resolve) => {
         import('child_process').then(cp => {
-          cp.exec(`launchctl print ${serviceTarget}`, { timeout: 5000 }, (err) => {
+          cp.exec(`launchctl print ${serviceTarget}`, { timeout: 5000, windowsHide: true }, (err) => {
             resolve(!err);
           });
         }).catch(() => resolve(false));
@@ -621,7 +621,7 @@ export class GatewayManager extends EventEmitter {
       logger.info(`Unloading launchctl service ${serviceTarget} to prevent auto-respawn`);
       await new Promise<void>((resolve) => {
         import('child_process').then(cp => {
-          cp.exec(`launchctl bootout ${serviceTarget}`, { timeout: 10000 }, (err) => {
+          cp.exec(`launchctl bootout ${serviceTarget}`, { timeout: 10000, windowsHide: true }, (err) => {
             if (err) {
               logger.warn(`Failed to bootout launchctl service: ${err.message}`);
             } else {
@@ -666,7 +666,7 @@ export class GatewayManager extends EventEmitter {
 
         const { stdout } = await new Promise<{ stdout: string }>((resolve, reject) => {
           import('child_process').then(cp => {
-            cp.exec(cmd, { timeout: 5000 }, (err, stdout) => {
+            cp.exec(cmd, { timeout: 5000, windowsHide: true }, (err, stdout) => {
               if (err) resolve({ stdout: '' });
               else resolve({ stdout });
             });
@@ -694,7 +694,7 @@ export class GatewayManager extends EventEmitter {
                   if (process.platform === 'win32') {
                     // On Windows, use taskkill for reliable process group termination
                     import('child_process').then(cp => {
-                      cp.exec(`taskkill /PID ${pid} /T /F`, { timeout: 5000 }, () => { });
+                      cp.exec(`taskkill /PID ${pid} /T /F`, { timeout: 5000, windowsHide: true }, () => { });
                     }).catch(() => { });
                   } else {
                     // SIGTERM first so the gateway can clean up its lock file.
@@ -798,6 +798,7 @@ export class GatewayManager extends EventEmitter {
         detached: false,
         shell: false,
         env: spawnEnv,
+        windowsHide: true,
       });
 
       let settled = false;
@@ -1051,6 +1052,7 @@ export class GatewayManager extends EventEmitter {
         detached: false,
         shell: useShell,
         env: spawnEnv,
+        windowsHide: true,
       });
       const child = this.process;
       this.ownsProcess = true;
@@ -1560,6 +1562,17 @@ export class GatewayManager extends EventEmitter {
 
     this.reconnectTimer = setTimeout(async () => {
       this.reconnectTimer = null;
+
+      // Guard against overlapping start flows — a debouncedRestart() or
+      // manual start() may already be in progress.  Without this check
+      // both the reconnect path and the restart path can call
+      // startProcess() concurrently, spawning two gateway processes that
+      // then fight over the same port.
+      if (this.startLock) {
+        logger.debug('Reconnect skipped: a start flow is already in progress');
+        return;
+      }
+
       try {
         // Try to find existing Gateway first
         const existing = await this.findExistingGateway();

--- a/electron/utils/channel-config.ts
+++ b/electron/utils/channel-config.ts
@@ -526,6 +526,7 @@ export async function validateChannelConfig(channelType: string): Promise<Valida
                     cwd: openclawPath,
                     encoding: 'utf-8',
                     timeout: 30000,
+                    windowsHide: true,
                 },
                 (err, stdout) => {
                     if (err) reject(err);

--- a/electron/utils/openclaw-cli.ts
+++ b/electron/utils/openclaw-cli.ts
@@ -269,6 +269,7 @@ export function generateCompletionCache(): void {
     },
     stdio: 'ignore',
     detached: false,
+    windowsHide: true,
   });
 
   child.on('close', (code) => {
@@ -305,6 +306,7 @@ export function installCompletionToProfile(): void {
       },
       stdio: 'ignore',
       detached: false,
+      windowsHide: true,
     },
   );
 

--- a/electron/utils/uv-setup.ts
+++ b/electron/utils/uv-setup.ts
@@ -53,7 +53,7 @@ function resolveUvBin(): { bin: string; source: 'bundled' | 'path' | 'bundled-fa
 function findUvInPathSync(): boolean {
   try {
     const cmd = process.platform === 'win32' ? 'where.exe uv' : 'which uv';
-    execSync(cmd, { stdio: 'ignore', timeout: 5000 });
+    execSync(cmd, { stdio: 'ignore', timeout: 5000, windowsHide: true });
     return true;
   } catch {
     return false;
@@ -95,6 +95,7 @@ export async function isPythonReady(): Promise<boolean> {
     try {
       const child = spawn(useShell ? quoteForCmd(uvBin) : uvBin, ['python', 'find', '3.12'], {
         shell: useShell,
+        windowsHide: true,
       });
       child.on('close', (code) => resolve(code === 0));
       child.on('error', () => resolve(false));
@@ -121,6 +122,7 @@ async function runPythonInstall(
     const child = spawn(useShell ? quoteForCmd(uvBin) : uvBin, ['python', 'install', '3.12'], {
       shell: useShell,
       env,
+      windowsHide: true,
     });
 
     child.stdout?.on('data', (data) => {
@@ -210,6 +212,7 @@ export async function setupManagedPython(): Promise<void> {
       const child = spawn(verifyShell ? quoteForCmd(uvBin) : uvBin, ['python', 'find', '3.12'], {
         shell: verifyShell,
         env: { ...process.env, ...uvEnv },
+        windowsHide: true,
       });
       let output = '';
       child.stdout?.on('data', (data) => { output += data; });


### PR DESCRIPTION
Add `windowsHide: true` to all subprocess calls and fix a Gateway double-start race condition to prevent terminal pop-ups and port conflicts on Windows.

The issue stemmed from `child_process.exec()` calls on Windows not using `windowsHide: true`, causing `cmd.exe` or `powershell.exe` to open visible console windows during Gateway restarts (e.g., after OAuth or config changes). This was introduced in v0.1.19-alpha.1. Additionally, a race condition in `scheduleReconnect()` allowed the Gateway to be started twice concurrently, leading to port binding failures.

---
<p><a href="https://cursor.com/agents/bc-2cdcca2a-aa78-468f-bb78-c89df1bc2190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2cdcca2a-aa78-468f-bb78-c89df1bc2190"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

