### PR TITLE
feat: add Memory page with i18n and sidebar entry

### DIFF
--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -184,6 +184,9 @@ export function registerIpcHandlers(
 
   // File staging handlers (upload/send separation)
   registerFileHandlers();
+
+  // Memory handlers
+  registerMemoryHandlers();
 }
 
 /**
@@ -2255,3 +2258,117 @@ function registerSessionHandlers(): void {
   });
 }
 
+/**
+ * Memory IPC handlers
+ * Read memory files from ~/.openclaw/workspace/
+ */
+function registerMemoryHandlers(): void {
+  const MEMORY_DIR = join(homedir(), '.openclaw', 'workspace');
+  const MEMORY_FILE = join(MEMORY_DIR, 'MEMORY.md');
+  const DAILY_LOGS_DIR = join(MEMORY_DIR, 'memory');
+
+  // List all memory files with stats
+  ipcMain.handle('memory:list', async () => {
+    try {
+      const fsP = await import('fs/promises');
+      const files: Array<{
+        path: string;
+        name: string;
+        size: number;
+        lastModified: string;
+        type: 'long-term' | 'daily';
+      }> = [];
+
+      let longTermSize = 0;
+      let dailyLogCount = 0;
+      let totalSize = 0;
+
+      // Check MEMORY.md (long-term memory)
+      try {
+        const stat = await fsP.stat(MEMORY_FILE);
+        if (stat.isFile()) {
+          files.push({
+            path: MEMORY_FILE,
+            name: 'MEMORY.md',
+            size: stat.size,
+            lastModified: stat.mtime.toISOString(),
+            type: 'long-term',
+          });
+          longTermSize = stat.size;
+          totalSize += stat.size;
+        }
+      } catch {
+        // MEMORY.md doesn't exist, that's fine
+      }
+
+      // Check daily logs directory
+      try {
+        const entries = await fsP.readdir(DAILY_LOGS_DIR, { withFileTypes: true });
+        for (const entry of entries) {
+          if (entry.isFile() && entry.name.endsWith('.md')) {
+            const filePath = join(DAILY_LOGS_DIR, entry.name);
+            const stat = await fsP.stat(filePath);
+            files.push({
+              path: filePath,
+              name: entry.name,
+              size: stat.size,
+              lastModified: stat.mtime.toISOString(),
+              type: 'daily',
+            });
+            totalSize += stat.size;
+            dailyLogCount++;
+          }
+        }
+      } catch {
+        // memory/ directory doesn't exist, that's fine
+      }
+
+      // Sort daily logs by name (date) descending
+      files.sort((a, b) => {
+        if (a.type === 'long-term') return -1;
+        if (b.type === 'long-term') return 1;
+        return b.name.localeCompare(a.name);
+      });
+
+      // Get stats
+      const stats = {
+        totalFiles: files.length,
+        totalSize,
+        longTermSize,
+        dailyLogCount,
+      };
+
+      // Read MEMORY.md content for preview
+      let longTermMemory = '';
+      try {
+        longTermMemory = await fsP.readFile(MEMORY_FILE, 'utf-8');
+      } catch {
+        // File doesn't exist
+      }
+
+      return { success: true, files, stats, longTermMemory };
+    } catch (error) {
+      return { success: false, error: String(error), files: [], stats: null };
+    }
+  });
+
+  // Get specific memory file content
+  ipcMain.handle('memory:get', async (_, filePath: string) => {
+    try {
+      const fsP = await import('fs/promises');
+      // Security: only allow reading from memory directory
+      const normalizedPath = filePath.replace(/\.\./g, '');
+      const allowedDirs = [MEMORY_DIR, DAILY_LOGS_DIR];
+      const isAllowed = allowedDirs.some(dir => normalizedPath.startsWith(dir));
+
+      if (!isAllowed) {
+        return { success: false, error: 'Access denied' };
+      }
+
+      const content = await fsP.readFile(normalizedPath, 'utf-8');
+      return { success: true, content };
+    } catch (error) {
+      return { success: false, error: String(error) };
+    }
+  });
+}

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,6 +17,7 @@ import {
   Terminal,
   ExternalLink,
   Trash2,
+  Brain,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useSettingsStore } from '@/stores/settings';
@@ -109,6 +110,7 @@ export function Sidebar() {
   const [sessionToDelete, setSessionToDelete] = useState<{ key: string; label: string } | null>(null);
 
   const navItems = [
+    { to: '/memory', icon: <Brain className="h-5 w-5" />, label: t('sidebar.memory') },
     { to: '/cron', icon: <Clock className="h-5 w-5" />, label: t('sidebar.cronTasks') },
     { to: '/skills', icon: <Puzzle className="h-5 w-5" />, label: t('sidebar.skills') },
     { to: '/channels', icon: <Radio className="h-5 w-5" />, label: t('sidebar.channels') },

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -10,6 +10,7 @@ import enChannels from './locales/en/channels.json';
 import enSkills from './locales/en/skills.json';
 import enCron from './locales/en/cron.json';
 import enSetup from './locales/en/setup.json';
+import enMemory from './locales/en/memory.json';
 
 // ZH
 import zhCommon from './locales/zh/common.json';
@@ -20,6 +21,7 @@ import zhChannels from './locales/zh/channels.json';
 import zhSkills from './locales/zh/skills.json';
 import zhCron from './locales/zh/cron.json';
 import zhSetup from './locales/zh/setup.json';
+import zhMemory from './locales/zh/memory.json';
 
 // JA
 import jaCommon from './locales/ja/common.json';
@@ -30,6 +32,7 @@ import jaChannels from './locales/ja/channels.json';
 import jaSkills from './locales/ja/skills.json';
 import jaCron from './locales/ja/cron.json';
 import jaSetup from './locales/ja/setup.json';
+import jaMemory from './locales/ja/memory.json';
 
 export const SUPPORTED_LANGUAGES = [
     { code: 'en', label: 'English' },
@@ -49,6 +52,7 @@ const resources = {
         skills: enSkills,
         cron: enCron,
         setup: enSetup,
+        memory: enMemory,
     },
     zh: {
         common: zhCommon,
@@ -59,6 +63,7 @@ const resources = {
         skills: zhSkills,
         cron: zhCron,
         setup: zhSetup,
+        memory: zhMemory,
     },
     ja: {
         common: jaCommon,
@@ -69,6 +74,7 @@ const resources = {
         skills: jaSkills,
         cron: jaCron,
         setup: jaSetup,
+        memory: jaMemory,
     },
 };
 
@@ -79,7 +85,7 @@ i18n
         lng: 'en', // will be overridden by settings store
         fallbackLng: 'en',
         defaultNS: 'common',
-        ns: ['common', 'settings', 'dashboard', 'chat', 'channels', 'skills', 'cron', 'setup'],
+        ns: ['common', 'settings', 'dashboard', 'chat', 'channels', 'skills', 'cron', 'setup', 'memory'],
         interpolation: {
             escapeValue: false, // React already escapes
         },

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "Chat",
         "newChat": "New Chat",
+        "memory": "Memory",
         "cronTasks": "Cron Tasks",
         "skills": "Skills",
         "channels": "Channels",

--- a/src/i18n/locales/en/memory.json
+++ b/src/i18n/locales/en/memory.json
@@ -1,0 +1,22 @@
+{
+    "title": "Memory",
+    "overview": "Memory Overview",
+    "overviewDescription": "View and manage AI assistant memory files",
+    "searchPlaceholder": "Search memory files...",
+    "files": "files",
+    "longTermMemory": "Long-term Memory",
+    "dailyLogs": "Daily Logs",
+    "noMemoryFiles": "No memory files",
+    "refresh": "Refresh",
+    "emptyFile": "File is empty",
+    "totalFiles": "Total Files",
+    "totalSize": "Total Size",
+    "longTermSize": "Long-term Memory Size",
+    "dailyLogCount": "Daily Log Count",
+    "aboutMemory": "About Memory System",
+    "aboutMemoryDesc1": "The memory system helps the AI assistant remember important information across sessions.",
+    "aboutMemoryDesc2": "There are two types of memory:",
+    "longTermInfo": "Refined, persistent memory storing important events and decisions.",
+    "dailyLogsInfo": "Raw daily work logs for review and distillation.",
+    "longTermDescription": "Refined long-term memory containing important events and decisions."
+}

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "チャット",
         "newChat": "新しいチャット",
+        "memory": "メモリ",
         "cronTasks": "定期タスク",
         "skills": "スキル",
         "channels": "チャンネル",

--- a/src/i18n/locales/ja/memory.json
+++ b/src/i18n/locales/ja/memory.json
@@ -1,0 +1,22 @@
+{
+    "title": "メモリ",
+    "overview": "メモリ概要",
+    "overviewDescription": "AIアシスタントのメモリファイルを表示・管理",
+    "searchPlaceholder": "メモリファイルを検索...",
+    "files": "ファイル",
+    "longTermMemory": "長期メモリ",
+    "dailyLogs": "日次ログ",
+    "noMemoryFiles": "メモリファイルがありません",
+    "refresh": "更新",
+    "emptyFile": "ファイルは空です",
+    "totalFiles": "総ファイル数",
+    "totalSize": "合計サイズ",
+    "longTermSize": "長期メモリサイズ",
+    "dailyLogCount": "日次ログ数",
+    "aboutMemory": "メモリシステムについて",
+    "aboutMemoryDesc1": "メモリシステムはAIアシスタントがセッションをまたいで重要な情報を記憶するのに役立ちます。",
+    "aboutMemoryDesc2": "メモリには2種類あります：",
+    "longTermInfo": "重要なイベントと決定を保存する、洗練された永続的なメモリ。",
+    "dailyLogsInfo": "レビューと抽出のための生の日次作業ログ。",
+    "longTermDescription": "重要なイベントと決定を含む洗練された長期メモリ。"
+}

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "聊天",
         "newChat": "新对话",
+        "memory": "记忆",
         "cronTasks": "定时任务",
         "skills": "技能",
         "channels": "频道",

--- a/src/i18n/locales/zh/memory.json
+++ b/src/i18n/locales/zh/memory.json
@@ -1,0 +1,22 @@
+{
+    "title": "记忆",
+    "overview": "记忆概览",
+    "overviewDescription": "查看和管理 AI 助手的记忆文件",
+    "searchPlaceholder": "搜索记忆文件...",
+    "files": "个文件",
+    "longTermMemory": "长期记忆",
+    "dailyLogs": "每日日志",
+    "noMemoryFiles": "暂无记忆文件",
+    "refresh": "刷新",
+    "emptyFile": "文件内容为空",
+    "totalFiles": "总文件数",
+    "totalSize": "总大小",
+    "longTermSize": "长期记忆大小",
+    "dailyLogCount": "每日日志数",
+    "aboutMemory": "关于记忆系统",
+    "aboutMemoryDesc1": "记忆系统帮助 AI 助手记住重要信息，实现跨会话的连续性。",
+    "aboutMemoryDesc2": "记忆分为两种类型：",
+    "longTermInfo": "经过提炼的、持久的记忆，存储重要事件和决策。",
+    "dailyLogsInfo": "每日工作的原始记录，用于回顾和提炼。",
+    "longTermDescription": "经过提炼的长期记忆，包含重要事件和决策。"
+}

--- a/src/pages/Memory/index.tsx
+++ b/src/pages/Memory/index.tsx
@@ -1,0 +1,338 @@
+/**
+ * Memory Page
+ * Browse and manage AI agent memory (MEMORY.md and daily logs)
+ */
+import { useEffect, useState } from 'react';
+import {
+  Brain,
+  FileText,
+  Calendar,
+  Search,
+  RefreshCw,
+  Clock,
+  HardDrive,
+  ChevronRight,
+  FolderOpen,
+} from 'lucide-react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { useTranslation } from 'react-i18next';
+
+interface MemoryFile {
+  path: string;
+  name: string;
+  size: number;
+  lastModified: string;
+  type: 'long-term' | 'daily';
+}
+
+interface MemoryStats {
+  totalFiles: number;
+  totalSize: number;
+  longTermSize: number;
+  dailyLogCount: number;
+  oldestLog?: string;
+  newestLog?: string;
+}
+
+export function Memory() {
+  const { t } = useTranslation('memory');
+  const [loading, setLoading] = useState(true);
+  const [memoryFiles, setMemoryFiles] = useState<MemoryFile[]>([]);
+  const [stats, setStats] = useState<MemoryStats | null>(null);
+  const [longTermMemory, setLongTermMemory] = useState<string>('');
+  const [selectedFile, setSelectedFile] = useState<string | null>(null);
+  const [fileContent, setFileContent] = useState<string>('');
+  const [searchQuery, setSearchQuery] = useState('');
+
+  useEffect(() => {
+    fetchMemoryFiles();
+  }, []);
+
+  const fetchMemoryFiles = async () => {
+    setLoading(true);
+    try {
+      const result = await window.electron.ipcRenderer.invoke('memory:list');
+      if (result.success) {
+        setMemoryFiles(result.files || []);
+        setStats(result.stats || null);
+        // Load MEMORY.md content
+        if (result.longTermMemory) {
+          setLongTermMemory(result.longTermMemory);
+        }
+      }
+    } catch (error) {
+      console.error('Failed to fetch memory files:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const loadFileContent = async (path: string) => {
+    try {
+      const result = await window.electron.ipcRenderer.invoke('memory:get', path);
+      if (result.success) {
+        setFileContent(result.content || '');
+        setSelectedFile(path);
+      }
+    } catch (error) {
+      console.error('Failed to load file content:', error);
+    }
+  };
+
+  const formatDate = (dateString: string) => {
+    const date = new Date(dateString);
+    return date.toLocaleString();
+  };
+
+  const formatSize = (bytes: number) => {
+    if (bytes < 1024) return `${bytes} B`;
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(2)} MB`;
+  };
+
+  // Filter files by search query
+  const filteredFiles = memoryFiles.filter(file =>
+    file.name.toLowerCase().includes(searchQuery.toLowerCase())
+  );
+
+  // Group files by type
+  const longTermFiles = filteredFiles.filter(f => f.type === 'long-term');
+  const dailyFiles = filteredFiles.filter(f => f.type === 'daily').sort((a, b) =>
+    b.name.localeCompare(a.name)
+  ); // Sort by date descending
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center h-full">
+        <RefreshCw className="h-8 w-8 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex h-full">
+      {/* Left sidebar - File list */}
+      <div className="w-80 border-r bg-muted/30 flex flex-col">
+        {/* Header */}
+        <div className="p-4 border-b">
+          <div className="flex items-center gap-2 mb-3">
+            <Brain className="h-5 w-5" />
+            <h2 className="font-semibold">{t('title')}</h2>
+          </div>
+          <div className="relative">
+            <Search className="absolute left-2 top-2.5 h-4 w-4 text-muted-foreground" />
+            <Input
+              placeholder={t('searchPlaceholder')}
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              className="pl-8"
+            />
+          </div>
+        </div>
+
+        {/* Stats */}
+        {stats && (
+          <div className="p-3 border-b bg-muted/50 text-xs text-muted-foreground">
+            <div className="flex items-center gap-4">
+              <div className="flex items-center gap-1">
+                <FileText className="h-3 w-3" />
+                <span>{stats.totalFiles} {t('files')}</span>
+              </div>
+              <div className="flex items-center gap-1">
+                <HardDrive className="h-3 w-3" />
+                <span>{formatSize(stats.totalSize)}</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* File list */}
+        <div className="flex-1 overflow-auto">
+          {/* Long-term memory section */}
+          {longTermFiles.length > 0 && (
+            <div className="p-2">
+              <div className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-muted-foreground uppercase">
+                <Brain className="h-3 w-3" />
+                {t('longTermMemory')}
+              </div>
+              {longTermFiles.map((file) => (
+                <button
+                  key={file.path}
+                  onClick={() => loadFileContent(file.path)}
+                  className={`w-full flex items-center gap-2 px-2 py-2 rounded-md text-sm text-left hover:bg-accent transition-colors ${
+                    selectedFile === file.path ? 'bg-accent' : ''
+                  }`}
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-primary" />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate">{file.name}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatSize(file.size)} · {formatDate(file.lastModified)}
+                    </div>
+                  </div>
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Daily logs section */}
+          {dailyFiles.length > 0 && (
+            <div className="p-2">
+              <div className="flex items-center gap-1 px-2 py-1 text-xs font-medium text-muted-foreground uppercase">
+                <Calendar className="h-3 w-3" />
+                {t('dailyLogs')} ({dailyFiles.length})
+              </div>
+              {dailyFiles.map((file) => (
+                <button
+                  key={file.path}
+                  onClick={() => loadFileContent(file.path)}
+                  className={`w-full flex items-center gap-2 px-2 py-2 rounded-md text-sm text-left hover:bg-accent transition-colors ${
+                    selectedFile === file.path ? 'bg-accent' : ''
+                  }`}
+                >
+                  <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                  <div className="flex-1 min-w-0">
+                    <div className="font-medium truncate">{file.name.replace('.md', '')}</div>
+                    <div className="text-xs text-muted-foreground">
+                      {formatSize(file.size)}
+                    </div>
+                  </div>
+                  <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+                </button>
+              ))}
+            </div>
+          )}
+
+          {/* Empty state */}
+          {filteredFiles.length === 0 && (
+            <div className="flex flex-col items-center justify-center py-12 text-muted-foreground">
+              <FolderOpen className="h-12 w-12 mb-2 opacity-50" />
+              <p className="text-sm">{t('noMemoryFiles')}</p>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {/* Right content - File viewer */}
+      <div className="flex-1 flex flex-col">
+        {selectedFile ? (
+          <>
+            {/* File header */}
+            <div className="p-4 border-b bg-muted/30">
+              <div className="flex items-center justify-between">
+                <div className="flex items-center gap-2">
+                  <FileText className="h-5 w-5" />
+                  <h3 className="font-semibold">{selectedFile.split('/').pop()?.split('\\').pop()}</h3>
+                </div>
+                <Button variant="outline" size="sm" onClick={fetchMemoryFiles}>
+                  <RefreshCw className="h-4 w-4 mr-2" />
+                  {t('refresh')}
+                </Button>
+              </div>
+            </div>
+
+            {/* File content */}
+            <div className="flex-1 overflow-auto p-4">
+              <pre className="text-sm whitespace-pre-wrap font-mono bg-muted/50 p-4 rounded-lg">
+                {fileContent || t('emptyFile')}
+              </pre>
+            </div>
+          </>
+        ) : (
+          /* Default view - Overview */
+          <div className="flex-1 overflow-auto p-6">
+            <div className="max-w-4xl mx-auto space-y-6">
+              {/* Header */}
+              <div>
+                <h1 className="text-2xl font-bold flex items-center gap-2">
+                  <Brain className="h-6 w-6" />
+                  {t('overview')}
+                </h1>
+                <p className="text-muted-foreground mt-1">
+                  {t('overviewDescription')}
+                </p>
+              </div>
+
+              {/* Stats cards */}
+              {stats && (
+                <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardDescription>{t('totalFiles')}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">{stats.totalFiles}</div>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardDescription>{t('totalSize')}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">{formatSize(stats.totalSize)}</div>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardDescription>{t('longTermSize')}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">{formatSize(stats.longTermSize)}</div>
+                    </CardContent>
+                  </Card>
+                  <Card>
+                    <CardHeader className="pb-2">
+                      <CardDescription>{t('dailyLogCount')}</CardDescription>
+                    </CardHeader>
+                    <CardContent>
+                      <div className="text-2xl font-bold">{stats.dailyLogCount}</div>
+                    </CardContent>
+                  </Card>
+                </div>
+              )}
+
+              {/* Long-term memory preview */}
+              {longTermMemory && (
+                <Card>
+                  <CardHeader>
+                    <CardTitle className="flex items-center gap-2">
+                      <Brain className="h-5 w-5" />
+                      {t('longTermMemory')}
+                    </CardTitle>
+                    <CardDescription>
+                      {t('longTermDescription')}
+                    </CardDescription>
+                  </CardHeader>
+                  <CardContent>
+                    <pre className="text-sm whitespace-pre-wrap font-mono bg-muted/50 p-4 rounded-lg max-h-96 overflow-auto">
+                      {longTermMemory}
+                    </pre>
+                  </CardContent>
+                </Card>
+              )}
+
+              {/* Info section */}
+              <Card>
+                <CardHeader>
+                  <CardTitle>{t('aboutMemory')}</CardTitle>
+                </CardHeader>
+                <CardContent className="space-y-3 text-sm text-muted-foreground">
+                  <p>{t('aboutMemoryDesc1')}</p>
+                  <p>{t('aboutMemoryDesc2')}</p>
+                  <ul className="list-disc list-inside space-y-1 ml-2">
+                    <li><strong>{t('longTermMemory')}</strong>: {t('longTermInfo')}</li>
+                    <li><strong>{t('dailyLogs')}</strong>: {t('dailyLogsInfo')}</li>
+                  </ul>
+                </CardContent>
+              </Card>
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Add Memory page with i18n support and sidebar entry.
## Changes
- Add Memory page component
- Register memory namespace in i18n
- Add memory translations (zh / en / ja)
- Add Memory entry to sidebar
- Add memory related IPC handlers
## Notes
All changes were made via GitHub web editor.