### PR TITLE
Mac启动配置问题

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -34,7 +34,7 @@ import {
 import { syncGatewayTokenToConfig, syncBrowserConfigToOpenClaw, sanitizeOpenClawConfig } from '../utils/openclaw-auth';
 import { buildProxyEnv, resolveProxySettings } from '../utils/proxy';
 import { syncProxyConfigToOpenClaw } from '../utils/openclaw-proxy';
-import { shouldAttemptConfigAutoRepair } from './startup-recovery';
+import { buildInvalidConfigRepairGuidance, shouldAttemptConfigAutoRepair } from './startup-recovery';
 import {
   getReconnectSkipReason,
   isLifecycleSuperseded,
@@ -393,6 +393,7 @@ export class GatewayManager extends EventEmitter {
               continue;
             }
             logger.error('OpenClaw doctor repair failed; not retrying Gateway startup');
+            throw new Error(buildInvalidConfigRepairGuidance(error, this.recentStartupStderrLines));
           }
 
           // Retry on transient connect errors

--- a/electron/gateway/startup-recovery.ts
+++ b/electron/gateway/startup-recovery.ts
@@ -58,3 +58,26 @@ export function shouldAttemptConfigAutoRepair(
   return hasInvalidConfigFailureSignal(startupError, startupStderrLines);
 }
 
+function toErrorText(startupError: unknown): string {
+  return startupError instanceof Error
+    ? `${startupError.name}: ${startupError.message}`
+    : String(startupError ?? '');
+}
+
+export function buildInvalidConfigRepairGuidance(
+  startupError: unknown,
+  startupStderrLines: string[],
+): string {
+  const combined = `${startupStderrLines.join('\n')}\n${toErrorText(startupError)}`.toLowerCase();
+  const base =
+    'Gateway startup blocked by invalid OpenClaw config. Automatic doctor repair failed. ' +
+    'Please run: openclaw doctor --fix';
+
+  if (combined.includes('dingtalk')) {
+    return `${base}. If the error mentions dingtalk, remove stale "channels.dingtalk" and ` +
+      `"plugins.allow" entries from ~/.openclaw/openclaw.json, then restart ClawX.`;
+  }
+
+  return base;
+}
+

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -20,6 +20,7 @@ import { isQuitting, setQuitting } from './app-state';
 import { applyProxySettings } from './proxy';
 import { getSetting } from '../utils/store';
 import { ensureBuiltinSkillsInstalled } from '../utils/skill-config';
+import { ensureDingTalkStartupCompatibility } from '../utils/dingtalk-plugin';
 
 // Disable GPU hardware acceleration globally for maximum stability across
 // all GPU configurations (no GPU, integrated, discrete).
@@ -198,6 +199,20 @@ async function initialize(): Promise<void> {
   void ensureBuiltinSkillsInstalled().catch((error) => {
     logger.warn('Failed to install built-in skills:', error);
   });
+
+  // Startup compatibility preflight: if openclaw.json still references DingTalk
+  // from older installs, make sure the bundled DingTalk plugin mirror is
+  // installed before the first Gateway start attempt.
+  try {
+    const dingtalkCompatResult = await ensureDingTalkStartupCompatibility();
+    if (dingtalkCompatResult.detectedConfigReferences && !dingtalkCompatResult.installed) {
+      logger.warn(
+        `DingTalk startup compatibility preflight could not ensure plugin install: ${dingtalkCompatResult.warning || 'unknown reason'}`
+      );
+    }
+  } catch (error) {
+    logger.warn('DingTalk startup compatibility preflight failed:', error);
+  }
 
   // Start Gateway automatically (this seeds missing bootstrap files with full templates)
   const gatewayAutoStart = await getSetting('gatewayAutoStart');

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -3,7 +3,7 @@
  * Registers all IPC handlers for main-renderer communication
  */
 import { ipcMain, BrowserWindow, shell, dialog, app, nativeImage } from 'electron';
-import { existsSync, cpSync, mkdirSync, rmSync } from 'node:fs';
+import { existsSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join, extname, basename } from 'node:path';
 import crypto from 'node:crypto';
@@ -54,6 +54,7 @@ import { deviceOAuthManager, OAuthProviderType } from '../utils/device-oauth';
 import { applyProxySettings } from './proxy';
 import { proxyAwareFetch } from '../utils/proxy-fetch';
 import { getRecentTokenUsageHistory } from '../utils/token-usage';
+import { ensureDingTalkPluginInstalled } from '../utils/dingtalk-plugin';
 
 /**
  * For custom/ollama providers, derive a unique key for OpenClaw config files
@@ -696,56 +697,6 @@ function registerGatewayHandlers(
  * For checking package status and channel configuration
  */
 function registerOpenClawHandlers(gatewayManager: GatewayManager): void {
-  async function ensureDingTalkPluginInstalled(): Promise<{ installed: boolean; warning?: string }> {
-    const targetDir = join(homedir(), '.openclaw', 'extensions', 'dingtalk');
-    const targetManifest = join(targetDir, 'openclaw.plugin.json');
-
-    if (existsSync(targetManifest)) {
-      logger.info('DingTalk plugin already installed from local mirror');
-      return { installed: true };
-    }
-
-    const candidateSources = app.isPackaged
-      ? [
-        join(process.resourcesPath, 'openclaw-plugins', 'dingtalk'),
-        join(process.resourcesPath, 'app.asar.unpacked', 'build', 'openclaw-plugins', 'dingtalk'),
-        join(process.resourcesPath, 'app.asar.unpacked', 'openclaw-plugins', 'dingtalk')
-      ]
-      : [
-        join(app.getAppPath(), 'build', 'openclaw-plugins', 'dingtalk'),
-        join(process.cwd(), 'build', 'openclaw-plugins', 'dingtalk'),
-        join(__dirname, '../../build/openclaw-plugins/dingtalk'),
-      ];
-
-    const sourceDir = candidateSources.find((dir) => existsSync(join(dir, 'openclaw.plugin.json')));
-    if (!sourceDir) {
-      logger.warn('Bundled DingTalk plugin mirror not found in candidate paths', { candidateSources });
-      return {
-        installed: false,
-        warning: `Bundled DingTalk plugin mirror not found. Checked: ${candidateSources.join(' | ')}`,
-      };
-    }
-
-    try {
-      mkdirSync(join(homedir(), '.openclaw', 'extensions'), { recursive: true });
-      rmSync(targetDir, { recursive: true, force: true });
-      cpSync(sourceDir, targetDir, { recursive: true, dereference: true });
-
-      if (!existsSync(targetManifest)) {
-        return { installed: false, warning: 'Failed to install DingTalk plugin mirror (manifest missing).' };
-      }
-
-      logger.info(`Installed DingTalk plugin from bundled mirror: ${sourceDir}`);
-      return { installed: true };
-    } catch (error) {
-      logger.warn('Failed to install DingTalk plugin from bundled mirror:', error);
-      return {
-        installed: false,
-        warning: 'Failed to install bundled DingTalk plugin mirror',
-      };
-    }
-  }
-
   // Get OpenClaw package status
   ipcMain.handle('openclaw:status', () => {
     const status = getOpenClawStatus();

--- a/electron/utils/dingtalk-plugin.ts
+++ b/electron/utils/dingtalk-plugin.ts
@@ -32,6 +32,11 @@ export interface DingTalkStartupCompatibilityResult {
   warning?: string;
 }
 
+export interface DingTalkStartupCompatibilityDeps {
+  isPluginInstalled: () => Promise<boolean>;
+  installPlugin: () => Promise<DingTalkInstallResult>;
+}
+
 export function hasDingTalkConfigReferences(config: Record<string, unknown>): boolean {
   const channels = (config.channels && typeof config.channels === 'object')
     ? config.channels as Record<string, unknown>
@@ -133,6 +138,34 @@ export async function ensureDingTalkPluginInstalled(): Promise<DingTalkInstallRe
   }
 }
 
+export async function runDingTalkStartupCompatibilityPreflight(
+  config: Record<string, unknown>,
+  deps: DingTalkStartupCompatibilityDeps,
+): Promise<DingTalkStartupCompatibilityResult> {
+  if (!hasDingTalkConfigReferences(config)) {
+    return {
+      detectedConfigReferences: false,
+      installAttempted: false,
+      installed: await deps.isPluginInstalled(),
+    };
+  }
+
+  logger.info('Detected DingTalk references in openclaw.json during startup preflight');
+  const installResult = await deps.installPlugin();
+  if (!installResult.installed) {
+    logger.warn(`DingTalk startup preflight could not ensure plugin install: ${installResult.warning || 'unknown reason'}`);
+  } else {
+    logger.info('DingTalk startup preflight ensured plugin installation');
+  }
+
+  return {
+    detectedConfigReferences: true,
+    installAttempted: true,
+    installed: installResult.installed,
+    warning: installResult.warning,
+  };
+}
+
 export async function ensureDingTalkStartupCompatibility(): Promise<DingTalkStartupCompatibilityResult> {
   if (!(await fileExists(OPENCLAW_CONFIG_PATH))) {
     return {
@@ -168,26 +201,8 @@ export async function ensureDingTalkStartupCompatibility(): Promise<DingTalkStar
     };
   }
 
-  if (!hasDingTalkConfigReferences(parsedConfig)) {
-    return {
-      detectedConfigReferences: false,
-      installAttempted: false,
-      installed: await isDingTalkPluginInstalled(),
-    };
-  }
-
-  logger.info('Detected DingTalk references in openclaw.json during startup preflight');
-  const installResult = await ensureDingTalkPluginInstalled();
-  if (!installResult.installed) {
-    logger.warn(`DingTalk startup preflight could not ensure plugin install: ${installResult.warning || 'unknown reason'}`);
-  } else {
-    logger.info('DingTalk startup preflight ensured plugin installation');
-  }
-
-  return {
-    detectedConfigReferences: true,
-    installAttempted: true,
-    installed: installResult.installed,
-    warning: installResult.warning,
-  };
+  return runDingTalkStartupCompatibilityPreflight(parsedConfig, {
+    isPluginInstalled: isDingTalkPluginInstalled,
+    installPlugin: ensureDingTalkPluginInstalled,
+  });
 }

--- a/electron/utils/dingtalk-plugin.ts
+++ b/electron/utils/dingtalk-plugin.ts
@@ -1,0 +1,193 @@
+import { access, cp, mkdir, readFile, rm } from 'fs/promises';
+import { constants } from 'fs';
+import { join } from 'path';
+import { homedir } from 'os';
+import { logger } from './logger';
+
+const DINGTALK_PLUGIN_ID = 'dingtalk';
+const OPENCLAW_HOME_DIR = join(homedir(), '.openclaw');
+const OPENCLAW_CONFIG_PATH = join(OPENCLAW_HOME_DIR, 'openclaw.json');
+const DINGTALK_EXTENSION_DIR = join(OPENCLAW_HOME_DIR, 'extensions', DINGTALK_PLUGIN_ID);
+const DINGTALK_EXTENSION_MANIFEST = join(DINGTALK_EXTENSION_DIR, 'openclaw.plugin.json');
+
+async function fileExists(path: string): Promise<boolean> {
+  try {
+    await access(path, constants.F_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export interface DingTalkInstallResult {
+  installed: boolean;
+  warning?: string;
+  sourceDir?: string;
+}
+
+export interface DingTalkStartupCompatibilityResult {
+  detectedConfigReferences: boolean;
+  installAttempted: boolean;
+  installed: boolean;
+  warning?: string;
+}
+
+export function hasDingTalkConfigReferences(config: Record<string, unknown>): boolean {
+  const channels = (config.channels && typeof config.channels === 'object')
+    ? config.channels as Record<string, unknown>
+    : undefined;
+  if (channels && channels.dingtalk !== undefined) {
+    return true;
+  }
+
+  const plugins = (config.plugins && typeof config.plugins === 'object')
+    ? config.plugins as Record<string, unknown>
+    : undefined;
+  if (!plugins) return false;
+
+  const allow = Array.isArray(plugins.allow) ? plugins.allow as unknown[] : [];
+  if (allow.some((entry) => entry === DINGTALK_PLUGIN_ID)) {
+    return true;
+  }
+
+  const entries = (plugins.entries && typeof plugins.entries === 'object')
+    ? plugins.entries as Record<string, unknown>
+    : undefined;
+  return entries?.dingtalk !== undefined;
+}
+
+export function resolveDingTalkPluginCandidateSources(params: {
+  isPackaged: boolean;
+  resourcesPath: string;
+  appPath: string;
+  cwd: string;
+  currentDir: string;
+}): string[] {
+  if (params.isPackaged) {
+    return [
+      join(params.resourcesPath, 'openclaw-plugins', DINGTALK_PLUGIN_ID),
+      join(params.resourcesPath, 'app.asar.unpacked', 'build', 'openclaw-plugins', DINGTALK_PLUGIN_ID),
+      join(params.resourcesPath, 'app.asar.unpacked', 'openclaw-plugins', DINGTALK_PLUGIN_ID),
+    ];
+  }
+
+  return [
+    join(params.appPath, 'build', 'openclaw-plugins', DINGTALK_PLUGIN_ID),
+    join(params.cwd, 'build', 'openclaw-plugins', DINGTALK_PLUGIN_ID),
+    join(params.currentDir, '../../build/openclaw-plugins', DINGTALK_PLUGIN_ID),
+  ];
+}
+
+export async function isDingTalkPluginInstalled(): Promise<boolean> {
+  return fileExists(DINGTALK_EXTENSION_MANIFEST);
+}
+
+export async function ensureDingTalkPluginInstalled(): Promise<DingTalkInstallResult> {
+  if (await isDingTalkPluginInstalled()) {
+    logger.info('DingTalk plugin already installed from local mirror');
+    return { installed: true };
+  }
+
+  const { app } = await import('electron');
+  const candidateSources = resolveDingTalkPluginCandidateSources({
+    isPackaged: app.isPackaged,
+    resourcesPath: process.resourcesPath,
+    appPath: app.getAppPath(),
+    cwd: process.cwd(),
+    currentDir: __dirname,
+  });
+
+  let sourceDir: string | undefined;
+  for (const dir of candidateSources) {
+    if (await fileExists(join(dir, 'openclaw.plugin.json'))) {
+      sourceDir = dir;
+      break;
+    }
+  }
+
+  if (!sourceDir) {
+    logger.warn('Bundled DingTalk plugin mirror not found in candidate paths', { candidateSources });
+    return {
+      installed: false,
+      warning: `Bundled DingTalk plugin mirror not found. Checked: ${candidateSources.join(' | ')}`,
+    };
+  }
+
+  try {
+    await mkdir(join(OPENCLAW_HOME_DIR, 'extensions'), { recursive: true });
+    await rm(DINGTALK_EXTENSION_DIR, { recursive: true, force: true });
+    await cp(sourceDir, DINGTALK_EXTENSION_DIR, { recursive: true, dereference: true });
+
+    if (!(await fileExists(DINGTALK_EXTENSION_MANIFEST))) {
+      return { installed: false, warning: 'Failed to install DingTalk plugin mirror (manifest missing).' };
+    }
+
+    logger.info(`Installed DingTalk plugin from bundled mirror: ${sourceDir}`);
+    return { installed: true, sourceDir };
+  } catch (error) {
+    logger.warn('Failed to install DingTalk plugin from bundled mirror:', error);
+    return {
+      installed: false,
+      warning: 'Failed to install bundled DingTalk plugin mirror',
+    };
+  }
+}
+
+export async function ensureDingTalkStartupCompatibility(): Promise<DingTalkStartupCompatibilityResult> {
+  if (!(await fileExists(OPENCLAW_CONFIG_PATH))) {
+    return {
+      detectedConfigReferences: false,
+      installAttempted: false,
+      installed: await isDingTalkPluginInstalled(),
+    };
+  }
+
+  let configRaw = '';
+  try {
+    configRaw = await readFile(OPENCLAW_CONFIG_PATH, 'utf-8');
+  } catch (error) {
+    logger.warn('Failed reading openclaw.json during DingTalk startup preflight:', error);
+    return {
+      detectedConfigReferences: false,
+      installAttempted: false,
+      installed: await isDingTalkPluginInstalled(),
+      warning: 'Failed reading openclaw.json during DingTalk startup preflight',
+    };
+  }
+
+  let parsedConfig: Record<string, unknown> = {};
+  try {
+    parsedConfig = JSON.parse(configRaw) as Record<string, unknown>;
+  } catch (error) {
+    logger.warn('Failed parsing openclaw.json during DingTalk startup preflight:', error);
+    return {
+      detectedConfigReferences: false,
+      installAttempted: false,
+      installed: await isDingTalkPluginInstalled(),
+      warning: 'Failed parsing openclaw.json during DingTalk startup preflight',
+    };
+  }
+
+  if (!hasDingTalkConfigReferences(parsedConfig)) {
+    return {
+      detectedConfigReferences: false,
+      installAttempted: false,
+      installed: await isDingTalkPluginInstalled(),
+    };
+  }
+
+  logger.info('Detected DingTalk references in openclaw.json during startup preflight');
+  const installResult = await ensureDingTalkPluginInstalled();
+  if (!installResult.installed) {
+    logger.warn(`DingTalk startup preflight could not ensure plugin install: ${installResult.warning || 'unknown reason'}`);
+  } else {
+    logger.info('DingTalk startup preflight ensured plugin installation');
+  }
+
+  return {
+    detectedConfigReferences: true,
+    installAttempted: true,
+    installed: installResult.installed,
+    warning: installResult.warning,
+  };
+}

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -125,6 +125,13 @@ async function discoverAgentIds(): Promise<string[]> {
 // ── OpenClaw Config Helpers ──────────────────────────────────────
 
 const OPENCLAW_CONFIG_PATH = join(homedir(), '.openclaw', 'openclaw.json');
+const DINGTALK_PLUGIN_MANIFEST_PATH = join(
+  homedir(),
+  '.openclaw',
+  'extensions',
+  'dingtalk',
+  'openclaw.plugin.json'
+);
 
 async function readOpenClawJson(): Promise<Record<string, unknown>> {
   return (await readJsonFile<Record<string, unknown>>(OPENCLAW_CONFIG_PATH)) ?? {};
@@ -132,6 +139,10 @@ async function readOpenClawJson(): Promise<Record<string, unknown>> {
 
 async function writeOpenClawJson(config: Record<string, unknown>): Promise<void> {
   await writeJsonFile(OPENCLAW_CONFIG_PATH, config);
+}
+
+async function isDingTalkPluginInstalled(): Promise<boolean> {
+  return fileExists(DINGTALK_PLUGIN_MANIFEST_PATH);
 }
 
 // ── Exported Functions (all async) ───────────────────────────────
@@ -777,6 +788,39 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
         console.log(`[sanitize] Removing misplaced key "skills.${key}" from openclaw.json`);
         delete skillsObj[key];
         modified = true;
+      }
+    }
+  }
+
+  // ── dingtalk stale config cleanup ──────────────────────────────
+  // If legacy configs still reference DingTalk but the plugin is not installed
+  // under ~/.openclaw/extensions/dingtalk, OpenClaw strict validation fails with:
+  // - channels.dingtalk: unknown channel id: dingtalk
+  // - plugins.allow: plugin not found: dingtalk
+  // In that case we remove only the stale DingTalk references.
+  const dingtalkInstalled = await isDingTalkPluginInstalled();
+  if (!dingtalkInstalled) {
+    const channels = config.channels;
+    if (channels && typeof channels === 'object' && !Array.isArray(channels)) {
+      const channelsObj = channels as Record<string, unknown>;
+      if (channelsObj.dingtalk !== undefined) {
+        console.log('[sanitize] Removing stale key "channels.dingtalk" (plugin not installed)');
+        delete channelsObj.dingtalk;
+        modified = true;
+      }
+    }
+
+    const plugins = config.plugins;
+    if (plugins && typeof plugins === 'object' && !Array.isArray(plugins)) {
+      const pluginsObj = plugins as Record<string, unknown>;
+      const allowRaw = pluginsObj.allow;
+      if (Array.isArray(allowRaw)) {
+        const nextAllow = allowRaw.filter((entry) => entry !== 'dingtalk');
+        if (nextAllow.length !== allowRaw.length) {
+          console.log('[sanitize] Removing stale value "dingtalk" from "plugins.allow" (plugin not installed)');
+          pluginsObj.allow = nextAllow;
+          modified = true;
+        }
       }
     }
   }

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -17,6 +17,7 @@ import {
   getProviderDefaultModel,
   getProviderConfig,
 } from './provider-registry';
+import { logger } from './logger';
 
 const AUTH_STORE_VERSION = 1;
 const AUTH_PROFILE_FILENAME = 'auth-profiles.json';
@@ -785,7 +786,7 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
     const KNOWN_INVALID_SKILLS_ROOT_KEYS = ['enabled', 'disabled'];
     for (const key of KNOWN_INVALID_SKILLS_ROOT_KEYS) {
       if (key in skillsObj) {
-        console.log(`[sanitize] Removing misplaced key "skills.${key}" from openclaw.json`);
+        logger.info(`[sanitize] Removing misplaced key "skills.${key}" from openclaw.json`);
         delete skillsObj[key];
         modified = true;
       }
@@ -804,7 +805,7 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
     if (channels && typeof channels === 'object' && !Array.isArray(channels)) {
       const channelsObj = channels as Record<string, unknown>;
       if (channelsObj.dingtalk !== undefined) {
-        console.log('[sanitize] Removing stale key "channels.dingtalk" (plugin not installed)');
+        logger.info('[sanitize] Removing stale key "channels.dingtalk" (plugin not installed)');
         delete channelsObj.dingtalk;
         modified = true;
       }
@@ -817,7 +818,7 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
       if (Array.isArray(allowRaw)) {
         const nextAllow = allowRaw.filter((entry) => entry !== 'dingtalk');
         if (nextAllow.length !== allowRaw.length) {
-          console.log('[sanitize] Removing stale value "dingtalk" from "plugins.allow" (plugin not installed)');
+          logger.info('[sanitize] Removing stale value "dingtalk" from "plugins.allow" (plugin not installed)');
           pluginsObj.allow = nextAllow;
           modified = true;
         }
@@ -827,7 +828,7 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
 
   if (modified) {
     await writeOpenClawJson(config);
-    console.log('[sanitize] openclaw.json sanitized successfully');
+    logger.info('[sanitize] openclaw.json sanitized successfully');
   }
 }
 

--- a/tests/unit/dingtalk-plugin.test.ts
+++ b/tests/unit/dingtalk-plugin.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   hasDingTalkConfigReferences,
   resolveDingTalkPluginCandidateSources,
+  runDingTalkStartupCompatibilityPreflight,
 } from '@electron/utils/dingtalk-plugin';
 
 describe('dingtalk plugin compatibility utilities', () => {
@@ -71,6 +72,78 @@ describe('dingtalk plugin compatibility utilities', () => {
         '/workspace/build/openclaw-plugins/dingtalk',
         '/workspace/build/openclaw-plugins/dingtalk',
       ]);
+    });
+  });
+
+  describe('runDingTalkStartupCompatibilityPreflight', () => {
+    it('skips install when config has no dingtalk references', async () => {
+      let installCalls = 0;
+      const result = await runDingTalkStartupCompatibilityPreflight(
+        {
+          channels: { telegram: { enabled: true } },
+          plugins: { allow: ['discord'] },
+        },
+        {
+          isPluginInstalled: async () => false,
+          installPlugin: async () => {
+            installCalls++;
+            return { installed: true };
+          },
+        },
+      );
+
+      expect(result).toEqual({
+        detectedConfigReferences: false,
+        installAttempted: false,
+        installed: false,
+      });
+      expect(installCalls).toBe(0);
+    });
+
+    it('attempts install and returns success when dingtalk is referenced', async () => {
+      let installCalls = 0;
+      const result = await runDingTalkStartupCompatibilityPreflight(
+        {
+          plugins: { allow: ['dingtalk'] },
+        },
+        {
+          isPluginInstalled: async () => false,
+          installPlugin: async () => {
+            installCalls++;
+            return { installed: true };
+          },
+        },
+      );
+
+      expect(result).toEqual({
+        detectedConfigReferences: true,
+        installAttempted: true,
+        installed: true,
+        warning: undefined,
+      });
+      expect(installCalls).toBe(1);
+    });
+
+    it('attempts install and returns warning on install failure', async () => {
+      const result = await runDingTalkStartupCompatibilityPreflight(
+        {
+          channels: { dingtalk: { enabled: true } },
+        },
+        {
+          isPluginInstalled: async () => false,
+          installPlugin: async () => ({
+            installed: false,
+            warning: 'Bundled DingTalk plugin mirror not found.',
+          }),
+        },
+      );
+
+      expect(result).toEqual({
+        detectedConfigReferences: true,
+        installAttempted: true,
+        installed: false,
+        warning: 'Bundled DingTalk plugin mirror not found.',
+      });
     });
   });
 });

--- a/tests/unit/dingtalk-plugin.test.ts
+++ b/tests/unit/dingtalk-plugin.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest';
+import {
+  hasDingTalkConfigReferences,
+  resolveDingTalkPluginCandidateSources,
+} from '@electron/utils/dingtalk-plugin';
+
+describe('dingtalk plugin compatibility utilities', () => {
+  describe('hasDingTalkConfigReferences', () => {
+    it('detects dingtalk channel config', () => {
+      expect(
+        hasDingTalkConfigReferences({
+          channels: {
+            dingtalk: { enabled: true },
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('detects dingtalk plugins.allow entry', () => {
+      expect(
+        hasDingTalkConfigReferences({
+          plugins: {
+            allow: ['discord', 'dingtalk'],
+          },
+        }),
+      ).toBe(true);
+    });
+
+    it('returns false when dingtalk is not referenced', () => {
+      expect(
+        hasDingTalkConfigReferences({
+          channels: {
+            telegram: { enabled: true },
+          },
+          plugins: {
+            allow: ['discord'],
+          },
+        }),
+      ).toBe(false);
+    });
+  });
+
+  describe('resolveDingTalkPluginCandidateSources', () => {
+    it('builds packaged candidate source paths', () => {
+      const candidates = resolveDingTalkPluginCandidateSources({
+        isPackaged: true,
+        resourcesPath: '/Applications/ClawX.app/Contents/Resources',
+        appPath: '/Applications/ClawX.app/Contents/Resources/app.asar',
+        cwd: '/tmp/irrelevant',
+        currentDir: '/tmp/irrelevant',
+      });
+
+      expect(candidates).toEqual([
+        '/Applications/ClawX.app/Contents/Resources/openclaw-plugins/dingtalk',
+        '/Applications/ClawX.app/Contents/Resources/app.asar.unpacked/build/openclaw-plugins/dingtalk',
+        '/Applications/ClawX.app/Contents/Resources/app.asar.unpacked/openclaw-plugins/dingtalk',
+      ]);
+    });
+
+    it('builds development candidate source paths', () => {
+      const candidates = resolveDingTalkPluginCandidateSources({
+        isPackaged: false,
+        resourcesPath: '/tmp/irrelevant',
+        appPath: '/workspace',
+        cwd: '/workspace',
+        currentDir: '/workspace/dist-electron/utils',
+      });
+
+      expect(candidates).toEqual([
+        '/workspace/build/openclaw-plugins/dingtalk',
+        '/workspace/build/openclaw-plugins/dingtalk',
+        '/workspace/build/openclaw-plugins/dingtalk',
+      ]);
+    });
+  });
+});

--- a/tests/unit/gateway-startup-recovery.test.ts
+++ b/tests/unit/gateway-startup-recovery.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import {
+  buildInvalidConfigRepairGuidance,
   hasInvalidConfigFailureSignal,
   isInvalidConfigSignal,
   shouldAttemptConfigAutoRepair,
@@ -47,6 +48,27 @@ describe('gateway startup recovery heuristics', () => {
     expect(isInvalidConfigSignal('skills: Unrecognized key: "enabled"')).toBe(true);
     expect(isInvalidConfigSignal('Run: openclaw doctor --fix')).toBe(true);
     expect(isInvalidConfigSignal('Gateway ready after 3 attempts')).toBe(false);
+  });
+
+  it('builds actionable repair guidance for generic invalid config', () => {
+    const msg = buildInvalidConfigRepairGuidance(
+      new Error('Config invalid. Run: openclaw doctor --fix'),
+      ['Config invalid'],
+    );
+    expect(msg).toContain('Automatic doctor repair failed');
+    expect(msg).toContain('openclaw doctor --fix');
+  });
+
+  it('includes dingtalk-specific guidance when dingtalk appears in logs', () => {
+    const msg = buildInvalidConfigRepairGuidance(
+      new Error('Gateway process exited before becoming ready (code=1)'),
+      [
+        'channels.dingtalk: unknown channel id: dingtalk',
+        'plugins.allow: plugin not found: dingtalk',
+      ],
+    );
+    expect(msg).toContain('channels.dingtalk');
+    expect(msg).toContain('plugins.allow');
   });
 });
 

--- a/tests/unit/sanitize-config.test.ts
+++ b/tests/unit/sanitize-config.test.ts
@@ -29,7 +29,10 @@ async function readConfig(): Promise<Record<string, unknown>> {
  * Standalone mirror of the sanitization logic in openclaw-auth.ts.
  * Uses the same blocklist approach as the production code.
  */
-async function sanitizeConfig(filePath: string): Promise<boolean> {
+async function sanitizeConfig(
+  filePath: string,
+  options?: { dingtalkPluginInstalled?: boolean }
+): Promise<boolean> {
   let raw: string;
   try {
     raw = await readFile(filePath, 'utf-8');
@@ -49,6 +52,33 @@ async function sanitizeConfig(filePath: string): Promise<boolean> {
       if (key in skillsObj) {
         delete skillsObj[key];
         modified = true;
+      }
+    }
+  }
+
+  // Mirror of stale DingTalk cleanup in production code:
+  // remove only when plugin is not installed.
+  const dingtalkPluginInstalled = options?.dingtalkPluginInstalled ?? false;
+  if (!dingtalkPluginInstalled) {
+    const channels = config.channels;
+    if (channels && typeof channels === 'object' && !Array.isArray(channels)) {
+      const channelsObj = channels as Record<string, unknown>;
+      if (channelsObj.dingtalk !== undefined) {
+        delete channelsObj.dingtalk;
+        modified = true;
+      }
+    }
+
+    const plugins = config.plugins;
+    if (plugins && typeof plugins === 'object' && !Array.isArray(plugins)) {
+      const pluginsObj = plugins as Record<string, unknown>;
+      const allowRaw = pluginsObj.allow;
+      if (Array.isArray(allowRaw)) {
+        const nextAllow = allowRaw.filter((entry) => entry !== 'dingtalk');
+        if (nextAllow.length !== allowRaw.length) {
+          pluginsObj.allow = nextAllow;
+          modified = true;
+        }
       }
     }
   }
@@ -199,6 +229,56 @@ describe('sanitizeOpenClawConfig (blocklist approach)', () => {
 
     const modified = await sanitizeConfig(configPath);
     expect(modified).toBe(false);
+  });
+
+  it('removes stale channels.dingtalk when plugin is missing', async () => {
+    await writeConfig({
+      channels: {
+        dingtalk: { enabled: true, clientId: 'x' },
+        telegram: { enabled: true },
+      },
+    });
+
+    const modified = await sanitizeConfig(configPath, { dingtalkPluginInstalled: false });
+    expect(modified).toBe(true);
+
+    const result = await readConfig();
+    const channels = result.channels as Record<string, unknown>;
+    expect(channels).not.toHaveProperty('dingtalk');
+    expect(channels.telegram).toEqual({ enabled: true });
+  });
+
+  it('removes stale plugins.allow dingtalk value when plugin is missing', async () => {
+    await writeConfig({
+      plugins: {
+        allow: ['dingtalk', 'feishu', 'discord'],
+      },
+    });
+
+    const modified = await sanitizeConfig(configPath, { dingtalkPluginInstalled: false });
+    expect(modified).toBe(true);
+
+    const result = await readConfig();
+    const plugins = result.plugins as Record<string, unknown>;
+    expect(plugins.allow).toEqual(['feishu', 'discord']);
+  });
+
+  it('keeps dingtalk config intact when plugin is installed', async () => {
+    const original = {
+      channels: {
+        dingtalk: { enabled: true, clientId: 'x' },
+      },
+      plugins: {
+        allow: ['dingtalk'],
+      },
+    };
+    await writeConfig(original);
+
+    const modified = await sanitizeConfig(configPath, { dingtalkPluginInstalled: true });
+    expect(modified).toBe(false);
+
+    const result = await readConfig();
+    expect(result).toEqual(original);
   });
 
   it('preserves all other top-level config sections', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix Mac first-launch failure caused by stale DingTalk configuration.

Previously, users with stale DingTalk entries in `~/.openclaw/openclaw.json` would experience Gateway crashes on first launch if the DingTalk plugin was not properly installed, as existing repair mechanisms couldn't resolve this specific config mismatch. This PR introduces a startup preflight to ensure the DingTalk plugin is installed or to sanitize the config if it's missing, preventing the crash.

---
<p><a href="https://cursor.com/agents/bc-3c4b4b3d-b5b1-4d46-a8f6-a160d272acbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3c4b4b3d-b5b1-4d46-a8f6-a160d272acbd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->