### PR TITLE
打包权限问题

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -1172,7 +1172,13 @@ export class GatewayManager extends EventEmitter {
         logger.info(`Gateway process started (pid=${child.pid})`);
         this.setStatus({ pid: child.pid });
       } else {
-        logger.warn('Gateway process spawned but PID is undefined');
+        logger.debug('Gateway process spawned with undefined PID; waiting for spawn/exit signal');
+        setTimeout(() => {
+          if (this.process !== child) return;
+          if (this.status.pid) return;
+          if (child.exitCode !== null || child.signalCode !== null) return;
+          logger.warn('Gateway process still has undefined PID after startup grace period');
+        }, 1000);
       }
 
       resolve();

--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -40,6 +40,7 @@ import {
   isLifecycleSuperseded,
   nextLifecycleEpoch,
 } from './process-policy';
+import { buildGatewayNodeRuntimeArgs } from './runtime-args';
 
 /**
  * Gateway connection status
@@ -840,7 +841,8 @@ export class GatewayManager extends EventEmitter {
 
     const uvEnv = await getUvMirrorEnv();
     const command = app.isPackaged ? getNodeExecutablePath() : 'node';
-    const args = [entryScript, 'doctor', '--fix', '--yes', '--non-interactive'];
+    const runtimeArgs = app.isPackaged ? buildGatewayNodeRuntimeArgs() : [];
+    const args = [...runtimeArgs, entryScript, 'doctor', '--fix', '--yes', '--non-interactive'];
     logger.info(
       `Running OpenClaw doctor repair (command="${command}", args="${args.join(' ')}", cwd="${openclawDir}", bundledBin=${binPathExists ? 'yes' : 'no'})`
     );
@@ -855,11 +857,6 @@ export class GatewayManager extends EventEmitter {
       if (app.isPackaged) {
         spawnEnv['ELECTRON_RUN_AS_NODE'] = '1';
         spawnEnv['OPENCLAW_NO_RESPAWN'] = '1';
-        const existingNodeOpts = spawnEnv['NODE_OPTIONS'] ?? '';
-        if (!existingNodeOpts.includes('--disable-warning=ExperimentalWarning') &&
-          !existingNodeOpts.includes('--no-warnings')) {
-          spawnEnv['NODE_OPTIONS'] = `${existingNodeOpts} --disable-warning=ExperimentalWarning`.trim();
-        }
       }
 
       const child = spawn(command, args, {
@@ -986,12 +983,25 @@ export class GatewayManager extends EventEmitter {
     // In development, use system 'node'.
     const gatewayArgs = ['gateway', '--port', String(this.status.port), '--token', gatewayToken, '--allow-unconfigured'];
 
+    let gatewayPreloadPath: string | undefined;
+    try {
+      const preloadPath = ensureGatewayFetchPreload();
+      if (existsSync(preloadPath)) {
+        gatewayPreloadPath = preloadPath;
+      }
+    } catch (err) {
+      logger.warn('Failed to set up OpenRouter headers preload:', err);
+    }
+
     if (app.isPackaged) {
       // Production: use Electron binary as Node.js via ELECTRON_RUN_AS_NODE
       // On macOS, use the Electron Helper binary to avoid extra dock icons
       if (existsSync(entryScript)) {
+        const runtimeArgs = buildGatewayNodeRuntimeArgs({
+          requireModules: gatewayPreloadPath ? [gatewayPreloadPath] : [],
+        });
         command = getNodeExecutablePath();
-        args = [entryScript, ...gatewayArgs];
+        args = [...runtimeArgs, entryScript, ...gatewayArgs];
         mode = 'packaged';
       } else {
         const errMsg = `OpenClaw entry script not found at: ${entryScript}`;
@@ -1090,26 +1100,15 @@ export class GatewayManager extends EventEmitter {
         // Prevent OpenClaw entry.ts from respawning itself (which would create
         // another child process and a second "exec" dock icon on macOS)
         spawnEnv['OPENCLAW_NO_RESPAWN'] = '1';
-        // Pre-set the NODE_OPTIONS that entry.ts would have added via respawn
-        const existingNodeOpts = spawnEnv['NODE_OPTIONS'] ?? '';
-        if (!existingNodeOpts.includes('--disable-warning=ExperimentalWarning') &&
-          !existingNodeOpts.includes('--no-warnings')) {
-          spawnEnv['NODE_OPTIONS'] = `${existingNodeOpts} --disable-warning=ExperimentalWarning`.trim();
-        }
       }
 
       // Inject fetch preload so OpenRouter requests carry ClawX headers.
       // The preload patches globalThis.fetch before any module loads.
-      try {
-        const preloadPath = ensureGatewayFetchPreload();
-        if (existsSync(preloadPath)) {
-          spawnEnv['NODE_OPTIONS'] = appendNodeRequireToNodeOptions(
-            spawnEnv['NODE_OPTIONS'],
-            preloadPath,
-          );
-        }
-      } catch (err) {
-        logger.warn('Failed to set up OpenRouter headers preload:', err);
+      if (!app.isPackaged && gatewayPreloadPath) {
+        spawnEnv['NODE_OPTIONS'] = appendNodeRequireToNodeOptions(
+          spawnEnv['NODE_OPTIONS'],
+          gatewayPreloadPath,
+        );
       }
 
       const useShell = !app.isPackaged && process.platform === 'win32';

--- a/electron/gateway/runtime-args.ts
+++ b/electron/gateway/runtime-args.ts
@@ -1,0 +1,28 @@
+/**
+ * Helper utilities for building Node runtime args for Gateway child processes.
+ *
+ * Packaged Electron apps should prefer explicit runtime CLI args over
+ * NODE_OPTIONS to avoid Electron's "Most NODE_OPTIONs are not supported in
+ * packaged apps" warning noise.
+ */
+
+export interface GatewayRuntimeArgsOptions {
+  disableExperimentalWarning?: boolean;
+  requireModules?: string[];
+}
+
+export function buildGatewayNodeRuntimeArgs(options: GatewayRuntimeArgsOptions = {}): string[] {
+  const args: string[] = [];
+  const shouldDisableExperimentalWarning = options.disableExperimentalWarning ?? true;
+
+  if (shouldDisableExperimentalWarning) {
+    args.push('--disable-warning=ExperimentalWarning');
+  }
+
+  for (const modulePath of options.requireModules ?? []) {
+    if (!modulePath) continue;
+    args.push('--require', modulePath);
+  }
+
+  return args;
+}

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -41,6 +41,7 @@ app.disableHardwareAcceleration();
 let mainWindow: BrowserWindow | null = null;
 const gatewayManager = new GatewayManager();
 const clawHubService = new ClawHubService();
+const hasSingleInstanceLock = app.requestSingleInstanceLock();
 
 /**
  * Resolve the icons directory path (works in both dev and packaged mode)
@@ -243,29 +244,49 @@ async function initialize(): Promise<void> {
 }
 
 // Application lifecycle
-app.whenReady().then(() => {
-  initialize();
-
-  // Register activate handler AFTER app is ready to prevent
-  // "Cannot create BrowserWindow before app is ready" on macOS.
-  app.on('activate', () => {
-    if (BrowserWindow.getAllWindows().length === 0) {
-      mainWindow = createWindow();
-    } else if (mainWindow && !mainWindow.isDestroyed()) {
-      // On macOS, clicking the dock icon should show the window if it's hidden
+if (!hasSingleInstanceLock) {
+  app.quit();
+} else {
+  app.on('second-instance', () => {
+    if (mainWindow && !mainWindow.isDestroyed()) {
+      if (mainWindow.isMinimized()) {
+        mainWindow.restore();
+      }
       mainWindow.show();
       mainWindow.focus();
+      return;
+    }
+
+    if (app.isReady()) {
+      mainWindow = createWindow();
     }
   });
-});
+
+  app.whenReady().then(() => {
+    initialize();
+
+    // Register activate handler AFTER app is ready to prevent
+    // "Cannot create BrowserWindow before app is ready" on macOS.
+    app.on('activate', () => {
+      if (BrowserWindow.getAllWindows().length === 0) {
+        mainWindow = createWindow();
+      } else if (mainWindow && !mainWindow.isDestroyed()) {
+        // On macOS, clicking the dock icon should show the window if it's hidden
+        mainWindow.show();
+        mainWindow.focus();
+      }
+    });
+  });
+}
 
 app.on('window-all-closed', () => {
-  if (process.platform !== 'darwin') {
+  if (process.platform !== 'darwin' && hasSingleInstanceLock) {
     app.quit();
   }
 });
 
 app.on('before-quit', () => {
+  if (!hasSingleInstanceLock) return;
   setQuitting();
   // Fire-and-forget: do not await gatewayManager.stop() here.
   // Awaiting inside before-quit can stall Electron's quit sequence.

--- a/electron/utils/skill-config.ts
+++ b/electron/utils/skill-config.ts
@@ -12,6 +12,11 @@ import { join } from 'path';
 import { homedir } from 'os';
 import { getOpenClawDir } from './paths';
 import { logger } from './logger';
+import {
+    getBuiltinSkillInstallRetryDelayMs,
+    shouldRetryBuiltinSkillInstallError,
+    shouldTreatBuiltinSkillInstallErrorAsSuccess,
+} from './skill-install';
 
 const OPENCLAW_CONFIG_PATH = join(homedir(), '.openclaw', 'openclaw.json');
 
@@ -156,6 +161,7 @@ const BUILTIN_SKILLS = [
  */
 export async function ensureBuiltinSkillsInstalled(): Promise<void> {
     const skillsRoot = join(homedir(), '.openclaw', 'skills');
+    const maxInstallAttempts = process.platform === 'win32' ? 3 : 1;
 
     for (const { slug, sourceExtension } of BUILTIN_SKILLS) {
         const targetDir = join(skillsRoot, slug);
@@ -173,12 +179,34 @@ export async function ensureBuiltinSkillsInstalled(): Promise<void> {
             continue;
         }
 
-        try {
-            await mkdir(targetDir, { recursive: true });
-            await cp(sourceDir, targetDir, { recursive: true });
-            logger.info(`Installed built-in skill: ${slug} -> ${targetDir}`);
-        } catch (error) {
-            logger.warn(`Failed to install built-in skill ${slug}:`, error);
+        for (let attempt = 1; attempt <= maxInstallAttempts; attempt++) {
+            try {
+                await mkdir(targetDir, { recursive: true });
+                await cp(sourceDir, targetDir, { recursive: true, force: true, errorOnExist: false });
+                logger.info(`Installed built-in skill: ${slug} -> ${targetDir}`);
+                break;
+            } catch (error) {
+                const manifestExistsNow = existsSync(targetManifest);
+
+                if (shouldTreatBuiltinSkillInstallErrorAsSuccess(error, manifestExistsNow)) {
+                    logger.info(`Built-in skill install race resolved for ${slug}; using existing manifest at ${targetManifest}`);
+                    break;
+                }
+
+                const isRetryable = shouldRetryBuiltinSkillInstallError(error) && attempt < maxInstallAttempts;
+                if (isRetryable) {
+                    const delayMs = getBuiltinSkillInstallRetryDelayMs(attempt);
+                    logger.debug(
+                        `Retrying built-in skill install ${slug} after transient error (attempt ${attempt}/${maxInstallAttempts}, delay=${delayMs}ms)`,
+                        error,
+                    );
+                    await new Promise((resolve) => setTimeout(resolve, delayMs));
+                    continue;
+                }
+
+                logger.warn(`Failed to install built-in skill ${slug}:`, error);
+                break;
+            }
         }
     }
 }

--- a/electron/utils/skill-install.ts
+++ b/electron/utils/skill-install.ts
@@ -1,0 +1,71 @@
+/**
+ * Built-in skill installation helpers.
+ *
+ * These helpers are intentionally pure and Electron-free so they can be
+ * unit-tested without mocking app runtime APIs.
+ */
+
+type ErrnoLike = {
+  code?: string;
+  syscall?: string;
+  message?: string;
+};
+
+function toErrnoLike(error: unknown): ErrnoLike {
+  if (!error || typeof error !== 'object') return {};
+  return error as ErrnoLike;
+}
+
+export function getBuiltinSkillInstallErrorCode(error: unknown): string | undefined {
+  const { code } = toErrnoLike(error);
+  return typeof code === 'string' ? code : undefined;
+}
+
+export function isBuiltinSkillWindowsPermissionError(error: unknown): boolean {
+  const code = getBuiltinSkillInstallErrorCode(error);
+  return code === 'EPERM' || code === 'EACCES' || code === 'EBUSY';
+}
+
+export function isBuiltinSkillChmodError(error: unknown): boolean {
+  const { syscall, message } = toErrnoLike(error);
+  if (typeof syscall === 'string' && syscall.toLowerCase() === 'chmod') {
+    return true;
+  }
+  return typeof message === 'string' && message.toLowerCase().includes('chmod');
+}
+
+/**
+ * Whether we should retry this installation error.
+ *
+ * On Windows, file locking / antivirus / concurrent-copy timing can produce
+ * transient EPERM/EACCES/EBUSY failures during fs.cp recursion.
+ */
+export function shouldRetryBuiltinSkillInstallError(
+  error: unknown,
+  platform = process.platform,
+): boolean {
+  return platform === 'win32' && isBuiltinSkillWindowsPermissionError(error);
+}
+
+/**
+ * Whether an installation error can be safely downgraded because the manifest
+ * already exists after the failed copy attempt.
+ *
+ * This handles concurrent startup races where another app instance finishes the
+ * installation first, causing fs.cp/chmod in this process to throw.
+ */
+export function shouldTreatBuiltinSkillInstallErrorAsSuccess(
+  error: unknown,
+  targetManifestExists: boolean,
+  platform = process.platform,
+): boolean {
+  if (!targetManifestExists) return false;
+  if (platform !== 'win32') return false;
+  return isBuiltinSkillWindowsPermissionError(error) || isBuiltinSkillChmodError(error);
+}
+
+export function getBuiltinSkillInstallRetryDelayMs(attempt: number): number {
+  if (attempt <= 1) return 120;
+  const cappedAttempt = Math.min(attempt, 4);
+  return 120 * (2 ** (cappedAttempt - 1));
+}

--- a/tests/unit/gateway-runtime-args.test.ts
+++ b/tests/unit/gateway-runtime-args.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from 'vitest';
+import { buildGatewayNodeRuntimeArgs } from '@electron/gateway/runtime-args';
+
+describe('buildGatewayNodeRuntimeArgs', () => {
+  it('includes experimental warning suppression by default', () => {
+    expect(buildGatewayNodeRuntimeArgs()).toEqual(['--disable-warning=ExperimentalWarning']);
+  });
+
+  it('can disable warning suppression explicitly', () => {
+    expect(
+      buildGatewayNodeRuntimeArgs({ disableExperimentalWarning: false }),
+    ).toEqual([]);
+  });
+
+  it('appends require modules as explicit runtime args', () => {
+    expect(
+      buildGatewayNodeRuntimeArgs({
+        requireModules: ['C:/Users/test/gateway-fetch-preload.cjs'],
+      }),
+    ).toEqual([
+      '--disable-warning=ExperimentalWarning',
+      '--require',
+      'C:/Users/test/gateway-fetch-preload.cjs',
+    ]);
+  });
+
+  it('skips empty require module entries', () => {
+    expect(
+      buildGatewayNodeRuntimeArgs({
+        requireModules: ['', 'D:/app/preload.cjs'],
+      }),
+    ).toEqual([
+      '--disable-warning=ExperimentalWarning',
+      '--require',
+      'D:/app/preload.cjs',
+    ]);
+  });
+});

--- a/tests/unit/skill-install.test.ts
+++ b/tests/unit/skill-install.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getBuiltinSkillInstallErrorCode,
+  getBuiltinSkillInstallRetryDelayMs,
+  isBuiltinSkillChmodError,
+  isBuiltinSkillWindowsPermissionError,
+  shouldRetryBuiltinSkillInstallError,
+  shouldTreatBuiltinSkillInstallErrorAsSuccess,
+} from '@electron/utils/skill-install';
+
+describe('skill-install helpers', () => {
+  it('extracts errno code from error-like objects', () => {
+    expect(getBuiltinSkillInstallErrorCode({ code: 'EPERM' })).toBe('EPERM');
+    expect(getBuiltinSkillInstallErrorCode(new Error('x'))).toBeUndefined();
+    expect(getBuiltinSkillInstallErrorCode(null)).toBeUndefined();
+  });
+
+  it('classifies Windows permission-style copy errors', () => {
+    expect(isBuiltinSkillWindowsPermissionError({ code: 'EPERM' })).toBe(true);
+    expect(isBuiltinSkillWindowsPermissionError({ code: 'EACCES' })).toBe(true);
+    expect(isBuiltinSkillWindowsPermissionError({ code: 'EBUSY' })).toBe(true);
+    expect(isBuiltinSkillWindowsPermissionError({ code: 'ENOENT' })).toBe(false);
+  });
+
+  it('detects chmod-related errors', () => {
+    expect(isBuiltinSkillChmodError({ syscall: 'chmod' })).toBe(true);
+    expect(isBuiltinSkillChmodError({ message: 'operation not permitted, chmod x' })).toBe(true);
+    expect(isBuiltinSkillChmodError({ message: 'copy failed' })).toBe(false);
+  });
+
+  it('retries only transient permission errors on Windows', () => {
+    const err = { code: 'EPERM' };
+    expect(shouldRetryBuiltinSkillInstallError(err, 'win32')).toBe(true);
+    expect(shouldRetryBuiltinSkillInstallError(err, 'linux')).toBe(false);
+    expect(shouldRetryBuiltinSkillInstallError({ code: 'ENOENT' }, 'win32')).toBe(false);
+  });
+
+  it('downgrades to success when manifest exists after Windows chmod/permission race', () => {
+    expect(
+      shouldTreatBuiltinSkillInstallErrorAsSuccess({ code: 'EPERM' }, true, 'win32'),
+    ).toBe(true);
+    expect(
+      shouldTreatBuiltinSkillInstallErrorAsSuccess({ message: 'chmod failed' }, true, 'win32'),
+    ).toBe(true);
+    expect(
+      shouldTreatBuiltinSkillInstallErrorAsSuccess({ code: 'EPERM' }, false, 'win32'),
+    ).toBe(false);
+    expect(
+      shouldTreatBuiltinSkillInstallErrorAsSuccess({ code: 'EPERM' }, true, 'linux'),
+    ).toBe(false);
+  });
+
+  it('uses bounded exponential retry delays', () => {
+    expect(getBuiltinSkillInstallRetryDelayMs(1)).toBe(120);
+    expect(getBuiltinSkillInstallRetryDelayMs(2)).toBe(240);
+    expect(getBuiltinSkillInstallRetryDelayMs(3)).toBe(480);
+    expect(getBuiltinSkillInstallRetryDelayMs(4)).toBe(960);
+    expect(getBuiltinSkillInstallRetryDelayMs(10)).toBe(960);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Harden Windows startup to prevent `EPERM` skill install errors and `NODE_OPTIONS` warnings.

This PR addresses several issues observed during Windows packaged app startup:
1.  **`EPERM` on `chmod` for built-in skills:** Caused by a race condition when multiple app instances tried to install skills concurrently. The fix adds single-instance lock, retries for transient errors, and handles existing files gracefully.
2.  **`Most NODE_OPTIONs are not supported` warning:** Occurred because `NODE_OPTIONS` were used for packaged Electron child processes. The fix now passes these options as explicit arguments.
3.  **Duplicate app startups:** Prevented by implementing `app.requestSingleInstanceLock()`.
4.  **`PID is undefined` warning:** Reduced false positives by adding a grace period before logging.

---
<p><a href="https://cursor.com/agents/bc-e6b133fd-c89c-45a3-ab01-085da1c6e159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e6b133fd-c89c-45a3-ab01-085da1c6e159"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->