### PR TITLE
fix(win): Openclaw Terminal CLI Unicode Error

### DIFF
--- a/resources/cli/win32/openclaw.cmd
+++ b/resources/cli/win32/openclaw.cmd
@@ -10,7 +10,16 @@ if /i "%1"=="update" (
     exit /b 0
 )
 
+rem Switch console to UTF-8 so Unicode box-drawing and CJK text render correctly
+rem on non-English Windows (e.g. Chinese CP936). Save the previous codepage to restore later.
+for /f "tokens=2 delims=:." %%a in ('chcp') do set /a "_CP=%%a" 2>nul
+chcp 65001 >nul 2>&1
+
 set ELECTRON_RUN_AS_NODE=1
 set OPENCLAW_EMBEDDED_IN=ClawX
 "%~dp0..\..\ClawX.exe" "%~dp0..\openclaw\openclaw.mjs" %*
-endlocal
+set _EXIT=%ERRORLEVEL%
+
+if defined _CP chcp %_CP% >nul 2>&1
+
+endlocal & exit /b %_EXIT%


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fix garbled output on Chinese Windows systems by switching the console codepage to UTF-8 in `openclaw.cmd`.

`ClawX.exe` is a Windows GUI subsystem (Electron) executable. When invoked from cmd.exe/PowerShell with `ELECTRON_RUN_AS_NODE=1`, its stdout uses byte-mode writes instead of the Unicode-aware `WriteConsoleW` API. On Chinese Windows where the default codepage is 936 (GBK), the UTF-8 bytes for Unicode box-drawing characters (`┌ ┐ └ ┘ ─ │` etc.) are decoded using GBK, producing garbled output.

---
<p><a href="https://cursor.com/agents/bc-3ad4c358-7dec-4285-a826-1b103d7bbba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3ad4c358-7dec-4285-a826-1b103d7bbba3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->