### PR TITLE
PR review

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -33,6 +33,7 @@ import { buildProxyEnv, resolveProxySettings } from '../utils/proxy';
 import { syncProxyConfigToOpenClaw } from '../utils/openclaw-proxy';
 import { shouldAttemptConfigAutoRepair } from './startup-recovery';
 import {
+  type GatewayLifecycleState,
   getDeferredRestartAction,
   getReconnectSkipReason,
   isLifecycleSuperseded,
@@ -44,7 +45,7 @@ import {
  * Gateway connection status
  */
 export interface GatewayStatus {
-  state: 'stopped' | 'starting' | 'running' | 'error' | 'reconnecting';
+  state: GatewayLifecycleState;
   port: number;
   pid?: number;
   uptime?: number;
@@ -555,6 +556,7 @@ export class GatewayManager extends EventEmitter {
     }
     this.pendingRequests.clear();
 
+    this.deferredRestartPending = false;
     this.setStatus({ state: 'stopped', error: undefined, pid: undefined, connectedAt: undefined, uptime: undefined });
   }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Synchronize `GatewayLifecycleState` type definition and explicitly clear `deferredRestartPending` on stop.

The `GatewayStatus.state` type now references the `GatewayLifecycleState` type from `process-policy.ts` to ensure consistency. `deferredRestartPending` is explicitly reset to `false` in `stop()` for defense-in-depth, preventing a stale flag from potentially causing an unwanted deferred restart.

---
<p><a href="https://cursor.com/agents/bc-6b3f1e2a-483f-415a-ab44-9e3f4832e31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b3f1e2a-483f-415a-ab44-9e3f4832e31d"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->