### PR TITLE
docs: align README command list with package scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,22 +287,19 @@ ClawX/
 
 ```bash
 # Development
+pnpm run init             # Install dependencies + download uv
 pnpm dev                  # Start with hot reload
-pnpm dev:electron         # Launch Electron directly
 
 # Quality
 pnpm lint                 # Run ESLint
-pnpm lint:fix             # Auto-fix issues
 pnpm typecheck            # TypeScript validation
 
 # Testing
 pnpm test                 # Run unit tests
-pnpm test:watch           # Watch mode
-pnpm test:coverage        # Generate coverage report
-pnpm test:e2e             # Run Playwright E2E tests
 
 # Build & Package
-pnpm build                # Full production build
+pnpm run build:vite       # Build frontend only
+pnpm build                # Full production build (with packaging assets)
 pnpm package              # Package for current platform
 pnpm package:mac          # Package for macOS
 pnpm package:win          # Package for Windows

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -288,22 +288,19 @@ ClawX/
 
 ```bash
 # 开发
+pnpm run init             # 安装依赖并下载 uv
 pnpm dev                  # 以热重载模式启动
-pnpm dev:electron         # 直接启动 Electron
 
 # 代码质量
 pnpm lint                 # 运行 ESLint 检查
-pnpm lint:fix             # 自动修复问题
 pnpm typecheck            # TypeScript 类型检查
 
 # 测试
 pnpm test                 # 运行单元测试
-pnpm test:watch           # 监听模式
-pnpm test:coverage        # 生成覆盖率报告
-pnpm test:e2e             # 运行 Playwright E2E 测试
 
 # 构建与打包
-pnpm build                # 完整生产构建
+pnpm run build:vite       # 仅构建前端
+pnpm build                # 完整生产构建（含打包资源）
 pnpm package              # 为当前平台打包
 pnpm package:mac          # 为 macOS 打包
 pnpm package:win          # 为 Windows 打包


### PR DESCRIPTION
## Summary
- align available command snippets in README.md and README.zh-CN.md with actual scripts in package.json
- remove non-existent commands (`dev:electron`, `lint:fix`, `test:watch`, `test:coverage`, `test:e2e`)
- add documented commands that exist (`pnpm run init`, `pnpm run build:vite`)

## Why
The current command section includes several scripts that are not defined in `package.json`, which can confuse new contributors when they bootstrap and validate the project locally.

## Validation
- docs-only change
- verified commands against `package.json` scripts
