### PR TITLE
Windows installer size bloat

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -111,7 +111,8 @@ jobs:
             release/*.dmg
             release/*.zip
             release/*.blockmap
-            release/*.exe
+            release/*-win-x64.exe
+            release/*-win-arm64.exe
             release/*.AppImage
             release/*.deb
             release/*.rpm
@@ -155,7 +156,8 @@ jobs:
           files: |
             release-artifacts/**/*.dmg
             release-artifacts/**/*.zip
-            release-artifacts/**/*.exe
+            release-artifacts/**/*-win-x64.exe
+            release-artifacts/**/*-win-arm64.exe
             release-artifacts/**/*.AppImage
             release-artifacts/**/*.deb
             release-artifacts/**/*.rpm

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -118,6 +118,9 @@ win:
 nsis:
   oneClick: false
   perMachine: false
+  # Avoid publishing a combined win.exe (x64+arm64) artifact.
+  # Keep per-arch installers only to reduce confusion and release size.
+  buildUniversalInstaller: false
   # Avoid NSIS build failure: warning 6010 (_ci_StrContains "not referenced") is emitted when
   # building the uninstaller, because that function is only used in the install macro.
   warningsAsErrors: false

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -262,20 +262,43 @@ function cleanupNodeLlamaPackages(nodeModulesDir, platform, arch) {
   const mode = process.env.CLAWX_KEEP_LLAMA_GPU === '1' ? 'same-arch-with-gpu' : 'cpu-only';
   const targetCpu = LLAMA_CPU_VARIANTS[`${platform}:${arch}`] || null;
 
+  const variants = [];
+  for (const entry of readdirSync(scopeDir)) {
+    const meta = parseNodeLlamaVariant(entry);
+    if (meta) variants.push({ name: entry, meta });
+  }
+
+  const hasTargetPlatformArchVariant = variants.some(
+    v => v.meta.platform === platform && v.meta.arch === arch,
+  );
+  const hasTargetCpuVariant = targetCpu ? variants.some(v => v.name === targetCpu) : false;
+
+  // Guard rail: if no target platform/arch variant exists, this is likely a
+  // cross-platform build host mismatch (e.g. building --win on Linux with host-only
+  // optional deps installed). In that case, skip pruning to avoid deleting all
+  // node-llama-cpp binaries.
+  if (!hasTargetPlatformArchVariant) {
+    console.log(
+      `[after-pack] ⚠️  node-llama-cpp: no target variant found for ${platform}/${arch}; skipping prune to avoid over-removal.`,
+    );
+    return { removed: 0, kept: variants.length, mode: 'skip-no-target', targetCpu };
+  }
+
   let removed = 0;
   let kept = 0;
   const keptPkgs = [];
   const removedPkgs = [];
 
-  for (const entry of readdirSync(scopeDir)) {
-    const meta = parseNodeLlamaVariant(entry);
-    if (!meta) continue;
+  for (const { name: entry, meta } of variants) {
 
     const isTargetPlatform = meta.platform === platform;
     const isTargetArch = meta.arch === arch;
     let shouldKeep = isTargetPlatform && isTargetArch;
 
-    if (shouldKeep && mode === 'cpu-only' && targetCpu) {
+    // In cpu-only mode, keep only baseline CPU variant when it exists.
+    // If it does not exist for this version naming, gracefully fall back to
+    // same-platform+arch variants instead of deleting everything.
+    if (shouldKeep && mode === 'cpu-only' && targetCpu && hasTargetCpuVariant) {
       shouldKeep = entry === targetCpu;
     }
 
@@ -542,4 +565,10 @@ exports.default = async function afterPack(context) {
   }
 
   summarizeTopLevelNodeModules(dest);
+};
+
+// Test-only exports for unit validation of pruning logic.
+exports.__test__ = {
+  cleanupNodeLlamaPackages,
+  parseNodeLlamaVariant,
 };

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -40,6 +40,74 @@ function resolveArch(archEnum) {
   return ARCH_MAP[archEnum] || 'x64';
 }
 
+function formatSize(bytes) {
+  if (bytes >= 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024 / 1024).toFixed(1)}G`;
+  if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}M`;
+  if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`;
+  return `${bytes}B`;
+}
+
+function getDirSize(dir) {
+  let total = 0;
+  let entries = [];
+  try { entries = readdirSync(dir, { withFileTypes: true }); } catch { return 0; }
+
+  for (const entry of entries) {
+    const full = join(dir, entry.name);
+    try {
+      if (entry.isDirectory()) total += getDirSize(full);
+      else if (entry.isFile()) total += statSync(full).size;
+    } catch { /* ignore */ }
+  }
+  return total;
+}
+
+function summarizeTopLevelNodeModules(nodeModulesDir, { top = 8 } = {}) {
+  if (!existsSync(nodeModulesDir)) return;
+
+  const pkgSizes = [];
+  let entries = [];
+  try { entries = readdirSync(nodeModulesDir, { withFileTypes: true }); } catch { return; }
+
+  for (const entry of entries) {
+    if (!entry.isDirectory() || entry.name === '.bin') continue;
+    const entryPath = join(nodeModulesDir, entry.name);
+
+    if (entry.name.startsWith('@')) {
+      let scopedEntries = [];
+      try { scopedEntries = readdirSync(entryPath, { withFileTypes: true }); } catch { continue; }
+      for (const sub of scopedEntries) {
+        if (!sub.isDirectory()) continue;
+        const pkgPath = join(entryPath, sub.name);
+        pkgSizes.push({
+          name: `${entry.name}/${sub.name}`,
+          size: getDirSize(pkgPath),
+        });
+      }
+    } else {
+      pkgSizes.push({ name: entry.name, size: getDirSize(entryPath) });
+    }
+  }
+
+  pkgSizes.sort((a, b) => b.size - a.size);
+  const topPkgs = pkgSizes.slice(0, top);
+  const total = pkgSizes.reduce((sum, p) => sum + p.size, 0);
+
+  console.log(`[after-pack] 📊 node_modules summary: ${pkgSizes.length} packages, total=${formatSize(total)}`);
+  for (const pkg of topPkgs) {
+    console.log(`[after-pack]   - ${pkg.name}: ${formatSize(pkg.size)}`);
+  }
+
+  const llamaPkgs = pkgSizes.filter(p => p.name.startsWith('@node-llama-cpp/'));
+  if (llamaPkgs.length > 0) {
+    const llamaTotal = llamaPkgs.reduce((sum, p) => sum + p.size, 0);
+    console.log(`[after-pack]   @node-llama-cpp total=${formatSize(llamaTotal)} (${llamaPkgs.length} packages)`);
+    for (const pkg of llamaPkgs.sort((a, b) => b.size - a.size)) {
+      console.log(`[after-pack]     • ${pkg.name}: ${formatSize(pkg.size)}`);
+    }
+  }
+}
+
 // ── General cleanup ──────────────────────────────────────────────────────────
 
 function cleanupUnnecessaryFiles(dir) {
@@ -136,6 +204,100 @@ function cleanupNativePlatformPackages(nodeModulesDir, platform, arch) {
   }
 
   return removed;
+}
+
+const LLAMA_CPU_VARIANTS = {
+  'darwin:x64': 'mac-x64',
+  'darwin:arm64': 'mac-arm64-metal',
+  'linux:x64': 'linux-x64',
+  'linux:arm64': 'linux-arm64',
+  'win32:x64': 'win-x64',
+  'win32:arm64': 'win-arm64',
+};
+
+function parseNodeLlamaVariant(name) {
+  if (name.startsWith('win-')) {
+    const rest = name.slice('win-'.length);
+    if (rest.startsWith('x64')) {
+      return { platform: 'win32', arch: 'x64', kind: rest === 'x64' ? 'cpu' : 'accel' };
+    }
+    if (rest.startsWith('arm64')) {
+      return { platform: 'win32', arch: 'arm64', kind: rest === 'arm64' ? 'cpu' : 'accel' };
+    }
+    return null;
+  }
+
+  if (name.startsWith('linux-')) {
+    const rest = name.slice('linux-'.length);
+    if (rest.startsWith('x64')) {
+      return { platform: 'linux', arch: 'x64', kind: rest === 'x64' ? 'cpu' : 'accel' };
+    }
+    if (rest.startsWith('arm64')) {
+      return { platform: 'linux', arch: 'arm64', kind: rest === 'arm64' ? 'cpu' : 'accel' };
+    }
+    if (rest.startsWith('armv7l')) {
+      return { platform: 'linux', arch: 'armv7l', kind: 'cpu' };
+    }
+    return null;
+  }
+
+  if (name.startsWith('mac-')) {
+    const rest = name.slice('mac-'.length);
+    if (rest.startsWith('x64')) {
+      return { platform: 'darwin', arch: 'x64', kind: rest === 'x64' ? 'cpu' : 'accel' };
+    }
+    if (rest.startsWith('arm64')) {
+      return { platform: 'darwin', arch: 'arm64', kind: 'cpu' };
+    }
+    return null;
+  }
+
+  return null;
+}
+
+function cleanupNodeLlamaPackages(nodeModulesDir, platform, arch) {
+  const scopeDir = join(nodeModulesDir, '@node-llama-cpp');
+  if (!existsSync(scopeDir)) return { removed: 0, kept: 0, mode: 'skip', targetCpu: null };
+
+  const mode = process.env.CLAWX_KEEP_LLAMA_GPU === '1' ? 'same-arch-with-gpu' : 'cpu-only';
+  const targetCpu = LLAMA_CPU_VARIANTS[`${platform}:${arch}`] || null;
+
+  let removed = 0;
+  let kept = 0;
+  const keptPkgs = [];
+  const removedPkgs = [];
+
+  for (const entry of readdirSync(scopeDir)) {
+    const meta = parseNodeLlamaVariant(entry);
+    if (!meta) continue;
+
+    const isTargetPlatform = meta.platform === platform;
+    const isTargetArch = meta.arch === arch;
+    let shouldKeep = isTargetPlatform && isTargetArch;
+
+    if (shouldKeep && mode === 'cpu-only' && targetCpu) {
+      shouldKeep = entry === targetCpu;
+    }
+
+    if (shouldKeep) {
+      kept++;
+      keptPkgs.push(entry);
+      continue;
+    }
+
+    try {
+      rmSync(join(scopeDir, entry), { recursive: true, force: true });
+      removed++;
+      removedPkgs.push(entry);
+    } catch { /* ignore */ }
+  }
+
+  console.log(`[after-pack] 🧠 node-llama-cpp pruning mode=${mode}, target=${platform}/${arch}, targetCpu=${targetCpu || 'n/a'}`);
+  console.log(`[after-pack] ✅ node-llama-cpp: kept ${kept}, removed ${removed}`);
+  if (keptPkgs.length > 0) console.log(`[after-pack]    kept: ${keptPkgs.sort().join(', ')}`);
+  if (removedPkgs.length > 0) console.log(`[after-pack]    removed: ${removedPkgs.sort().join(', ')}`);
+
+  return { removed, kept, mode, targetCpu };
 }
 
 // ── Broken module patcher ─────────────────────────────────────────────────────
@@ -326,6 +488,7 @@ exports.default = async function afterPack(context) {
   console.log(`[after-pack] Copying ${depCount} openclaw dependencies to ${dest} ...`);
   cpSync(src, dest, { recursive: true });
   console.log('[after-pack] ✅ openclaw node_modules copied.');
+  summarizeTopLevelNodeModules(src);
 
   // Patch broken modules whose CJS transpiled output sets module.exports = undefined,
   // causing TypeError in Node.js 22+ ESM interop.
@@ -351,6 +514,7 @@ exports.default = async function afterPack(context) {
       if (existsSync(pluginNM)) {
         cleanupKoffi(pluginNM, platform, arch);
         cleanupNativePlatformPackages(pluginNM, platform, arch);
+        cleanupNodeLlamaPackages(pluginNM, platform, arch);
       }
     }
   }
@@ -371,4 +535,11 @@ exports.default = async function afterPack(context) {
   if (nativeRemoved > 0) {
     console.log(`[after-pack] ✅ Removed ${nativeRemoved} non-target native platform packages.`);
   }
+
+  const llamaRemoved = cleanupNodeLlamaPackages(dest, platform, arch);
+  if (llamaRemoved.removed > 0) {
+    console.log(`[after-pack] ✅ Removed ${llamaRemoved.removed} node-llama-cpp package variants.`);
+  }
+
+  summarizeTopLevelNodeModules(dest);
 };

--- a/scripts/bundle-openclaw.mjs
+++ b/scripts/bundle-openclaw.mjs
@@ -231,6 +231,45 @@ function formatSize(bytes) {
   return `${bytes}B`;
 }
 
+function summarizeTopLevelNodeModules(nodeModulesDir, { top = 8 } = {}) {
+  if (!fs.existsSync(nodeModulesDir)) return;
+
+  const pkgSizes = [];
+  for (const entry of fs.readdirSync(nodeModulesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === '.bin') continue;
+    const entryPath = path.join(nodeModulesDir, entry.name);
+
+    if (entry.name.startsWith('@')) {
+      let scoped = [];
+      try { scoped = fs.readdirSync(entryPath, { withFileTypes: true }); } catch { continue; }
+      for (const sub of scoped) {
+        if (!sub.isDirectory()) continue;
+        const pkgPath = path.join(entryPath, sub.name);
+        pkgSizes.push({ name: `${entry.name}/${sub.name}`, size: getDirSize(pkgPath) });
+      }
+    } else {
+      pkgSizes.push({ name: entry.name, size: getDirSize(entryPath) });
+    }
+  }
+
+  pkgSizes.sort((a, b) => b.size - a.size);
+  const total = pkgSizes.reduce((sum, p) => sum + p.size, 0);
+
+  echo`   📊 node_modules summary: ${pkgSizes.length} packages, total=${formatSize(total)}`;
+  for (const pkg of pkgSizes.slice(0, top)) {
+    echo`     - ${pkg.name}: ${formatSize(pkg.size)}`;
+  }
+
+  const llamaPkgs = pkgSizes.filter((p) => p.name.startsWith('@node-llama-cpp/'));
+  if (llamaPkgs.length > 0) {
+    const llamaTotal = llamaPkgs.reduce((sum, p) => sum + p.size, 0);
+    echo`     @node-llama-cpp total=${formatSize(llamaTotal)} (${llamaPkgs.length} packages)`;
+    for (const pkg of llamaPkgs.sort((a, b) => b.size - a.size)) {
+      echo`       • ${pkg.name}: ${formatSize(pkg.size)}`;
+    }
+  }
+}
+
 function rmSafe(target) {
   try {
     const stat = fs.lstatSync(target);
@@ -361,10 +400,12 @@ function cleanupBundle(outputDir) {
 echo``;
 echo`🧹 Cleaning up bundle (removing dev artifacts, docs, source maps, type defs)...`;
 const sizeBefore = getDirSize(OUTPUT);
+summarizeTopLevelNodeModules(outputNodeModules);
 const cleanedCount = cleanupBundle(OUTPUT);
 const sizeAfter = getDirSize(OUTPUT);
 echo`   Removed ${cleanedCount} files/directories`;
 echo`   Size: ${formatSize(sizeBefore)} → ${formatSize(sizeAfter)} (saved ${formatSize(sizeBefore - sizeAfter)})`;
+summarizeTopLevelNodeModules(outputNodeModules);
 
 // 7. Patch known broken packages
 //

--- a/tests/unit/after-pack-node-llama.test.ts
+++ b/tests/unit/after-pack-node-llama.test.ts
@@ -1,0 +1,112 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { createRequire } from 'node:module';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { __test__ } = require('../../scripts/after-pack.cjs');
+
+const cleanupNodeLlamaPackages: (
+  nodeModulesDir: string,
+  platform: string,
+  arch: string,
+) => { removed: number; kept: number; mode: string; targetCpu: string | null } =
+  __test__.cleanupNodeLlamaPackages;
+
+function writeLlamaPackages(nodeModulesDir: string, names: string[]) {
+  const scopeDir = path.join(nodeModulesDir, '@node-llama-cpp');
+  fs.mkdirSync(scopeDir, { recursive: true });
+  for (const name of names) {
+    const pkgDir = path.join(scopeDir, name);
+    fs.mkdirSync(pkgDir, { recursive: true });
+    fs.writeFileSync(path.join(pkgDir, 'index.js'), '// stub\n', 'utf8');
+  }
+}
+
+function readLlamaPackages(nodeModulesDir: string) {
+  const scopeDir = path.join(nodeModulesDir, '@node-llama-cpp');
+  if (!fs.existsSync(scopeDir)) return [];
+  return fs.readdirSync(scopeDir).sort();
+}
+
+describe('after-pack node-llama pruning', () => {
+  let tmpRoot = '';
+  let nodeModulesDir = '';
+  const originalGpuEnv = process.env.CLAWX_KEEP_LLAMA_GPU;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'after-pack-'));
+    nodeModulesDir = path.join(tmpRoot, 'node_modules');
+    fs.mkdirSync(nodeModulesDir, { recursive: true });
+    delete process.env.CLAWX_KEEP_LLAMA_GPU;
+  });
+
+  afterEach(() => {
+    if (fs.existsSync(tmpRoot)) {
+      fs.rmSync(tmpRoot, { recursive: true, force: true });
+    }
+    if (originalGpuEnv === undefined) {
+      delete process.env.CLAWX_KEEP_LLAMA_GPU;
+    } else {
+      process.env.CLAWX_KEEP_LLAMA_GPU = originalGpuEnv;
+    }
+  });
+
+  it('keeps only baseline CPU variant in default mode', () => {
+    writeLlamaPackages(nodeModulesDir, [
+      'win-x64',
+      'win-x64-cuda',
+      'win-x64-cuda-ext',
+      'win-x64-vulkan',
+      'win-arm64',
+      'linux-x64',
+    ]);
+
+    const result = cleanupNodeLlamaPackages(nodeModulesDir, 'win32', 'x64');
+
+    expect(result.mode).toBe('cpu-only');
+    expect(result.removed).toBe(5);
+    expect(readLlamaPackages(nodeModulesDir)).toEqual(['win-x64']);
+  });
+
+  it('keeps same-platform GPU variants when CLAWX_KEEP_LLAMA_GPU=1', () => {
+    process.env.CLAWX_KEEP_LLAMA_GPU = '1';
+    writeLlamaPackages(nodeModulesDir, [
+      'win-x64',
+      'win-x64-cuda',
+      'win-x64-cuda-ext',
+      'win-x64-vulkan',
+      'win-arm64',
+      'linux-x64',
+    ]);
+
+    const result = cleanupNodeLlamaPackages(nodeModulesDir, 'win32', 'x64');
+
+    expect(result.mode).toBe('same-arch-with-gpu');
+    expect(readLlamaPackages(nodeModulesDir)).toEqual([
+      'win-x64',
+      'win-x64-cuda',
+      'win-x64-cuda-ext',
+      'win-x64-vulkan',
+    ]);
+  });
+
+  it('skips pruning when target platform variants are absent', () => {
+    writeLlamaPackages(nodeModulesDir, [
+      'linux-x64',
+      'linux-x64-cuda',
+      'linux-arm64',
+    ]);
+
+    const result = cleanupNodeLlamaPackages(nodeModulesDir, 'win32', 'arm64');
+
+    expect(result.mode).toBe('skip-no-target');
+    expect(result.removed).toBe(0);
+    expect(readLlamaPackages(nodeModulesDir)).toEqual([
+      'linux-arm64',
+      'linux-x64',
+      'linux-x64-cuda',
+    ]);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Reduce Windows installer size by pruning unused `@node-llama-cpp` variants and disabling the universal installer.

The Windows installer size significantly increased in `v0.1.21` due to the `OpenClaw` dependency pulling large `@node-llama-cpp` GPU binaries for all architectures, which were not being pruned during packaging. Additionally, a universal Windows installer (`*-win.exe`) was being generated, combining multiple architectures. This PR addresses these issues to optimize artifact size.

---
<p><a href="https://cursor.com/agents/bc-55428556-64ba-44fb-8f7d-3f1d082dd2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-55428556-64ba-44fb-8f7d-3f1d082dd2f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>


<!-- CURSOR_AGENT_PR_BODY_END -->