### PR TITLE
feat(agents): complete in-app multi-agent management flow

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -14,6 +14,7 @@ import { Chat } from './pages/Chat';
 import { Channels } from './pages/Channels';
 import { Skills } from './pages/Skills';
 import { Cron } from './pages/Cron';
+import { Agents } from './pages/Agents';
 import { Settings } from './pages/Settings';
 import { Setup } from './pages/Setup';
 import { useSettingsStore } from './stores/settings';
@@ -162,6 +163,7 @@ function App() {
             <Route path="/dashboard" element={<Dashboard />} />
             <Route path="/channels" element={<Channels />} />
             <Route path="/skills" element={<Skills />} />
+            <Route path="/agents" element={<Agents />} />
             <Route path="/cron" element={<Cron />} />
             <Route path="/settings/*" element={<Settings />} />
           </Route>

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -11,6 +11,7 @@ import {
   Radio,
   Puzzle,
   Clock,
+  Users,
   Settings,
   ChevronLeft,
   ChevronRight,
@@ -109,6 +110,7 @@ export function Sidebar() {
   const [sessionToDelete, setSessionToDelete] = useState<{ key: string; label: string } | null>(null);
 
   const navItems = [
+    { to: '/agents', icon: <Users className="h-5 w-5" />, label: t('sidebar.agents') },
     { to: '/cron', icon: <Clock className="h-5 w-5" />, label: t('sidebar.cronTasks') },
     { to: '/skills', icon: <Puzzle className="h-5 w-5" />, label: t('sidebar.skills') },
     { to: '/channels', icon: <Radio className="h-5 w-5" />, label: t('sidebar.channels') },

--- a/src/i18n/index.ts
+++ b/src/i18n/index.ts
@@ -10,6 +10,7 @@ import enChannels from './locales/en/channels.json';
 import enSkills from './locales/en/skills.json';
 import enCron from './locales/en/cron.json';
 import enSetup from './locales/en/setup.json';
+import enAgents from './locales/en/agents.json';
 
 // ZH
 import zhCommon from './locales/zh/common.json';
@@ -20,6 +21,7 @@ import zhChannels from './locales/zh/channels.json';
 import zhSkills from './locales/zh/skills.json';
 import zhCron from './locales/zh/cron.json';
 import zhSetup from './locales/zh/setup.json';
+import zhAgents from './locales/zh/agents.json';
 
 // JA
 import jaCommon from './locales/ja/common.json';
@@ -30,6 +32,7 @@ import jaChannels from './locales/ja/channels.json';
 import jaSkills from './locales/ja/skills.json';
 import jaCron from './locales/ja/cron.json';
 import jaSetup from './locales/ja/setup.json';
+import jaAgents from './locales/ja/agents.json';
 
 export const SUPPORTED_LANGUAGES = [
     { code: 'en', label: 'English' },
@@ -49,6 +52,7 @@ const resources = {
         skills: enSkills,
         cron: enCron,
         setup: enSetup,
+        agents: enAgents,
     },
     zh: {
         common: zhCommon,
@@ -59,6 +63,7 @@ const resources = {
         skills: zhSkills,
         cron: zhCron,
         setup: zhSetup,
+        agents: zhAgents,
     },
     ja: {
         common: jaCommon,
@@ -69,6 +74,7 @@ const resources = {
         skills: jaSkills,
         cron: jaCron,
         setup: jaSetup,
+        agents: jaAgents,
     },
 };
 
@@ -79,7 +85,7 @@ i18n
         lng: 'en', // will be overridden by settings store
         fallbackLng: 'en',
         defaultNS: 'common',
-        ns: ['common', 'settings', 'dashboard', 'chat', 'channels', 'skills', 'cron', 'setup'],
+        ns: ['common', 'settings', 'dashboard', 'chat', 'channels', 'skills', 'cron', 'setup', 'agents'],
         interpolation: {
             escapeValue: false, // React already escapes
         },

--- a/src/i18n/locales/en/agents.json
+++ b/src/i18n/locales/en/agents.json
@@ -1,0 +1,27 @@
+{
+  "title": "Agent Management",
+  "subtitle": "Create and view OpenClaw agents without using the CLI.",
+  "refresh": "Refresh",
+  "gatewayWarning": "Gateway is not running. Start Gateway first to manage agents.",
+  "create": {
+    "title": "Create New Agent",
+    "description": "Basic fields only. For advanced settings (bindings, identity, model strategy), continue in OpenClaw config.",
+    "nameLabel": "Agent Name",
+    "namePlaceholder": "e.g. support",
+    "workspaceLabel": "Workspace Directory",
+    "workspacePlaceholder": "e.g. ~/.openclaw/workspace-support",
+    "submit": "Create Agent",
+    "creating": "Creating..."
+  },
+  "list": {
+    "title": "Existing Agents",
+    "description": "{{count}} agents · session scope: {{scope}}",
+    "empty": "No agents found yet.",
+    "defaultBadge": "Default",
+    "mainBadge": "Main Key"
+  },
+  "toast": {
+    "created": "Agent \"{{id}}\" created",
+    "createFailed": "Failed to create agent"
+  }
+}

--- a/src/i18n/locales/en/agents.json
+++ b/src/i18n/locales/en/agents.json
@@ -1,27 +1,77 @@
 {
   "title": "Agent Management",
-  "subtitle": "Create and view OpenClaw agents without using the CLI.",
+  "subtitle": "Create, edit, delete, and configure agents directly in the UI.",
   "refresh": "Refresh",
   "gatewayWarning": "Gateway is not running. Start Gateway first to manage agents.",
-  "create": {
-    "title": "Create New Agent",
-    "description": "Basic fields only. For advanced settings (bindings, identity, model strategy), continue in OpenClaw config.",
+  "form": {
+    "createTitle": "Create Agent",
+    "createDescription": "Fill in name, workspace, model, and identity fields to create a new agent.",
+    "editTitle": "Edit Agent",
+    "editDescription": "Update base info and model settings for the selected agent.",
     "nameLabel": "Agent Name",
     "namePlaceholder": "e.g. support",
     "workspaceLabel": "Workspace Directory",
     "workspacePlaceholder": "e.g. ~/.openclaw/workspace-support",
-    "submit": "Create Agent",
-    "creating": "Creating..."
+    "workspaceLoadError": "Unable to load this agent's workspace path. Retry loading before saving.",
+    "modelLabel": "Model ID (optional)",
+    "modelPlaceholder": "e.g. openai/gpt-4.1",
+    "emojiLabel": "Emoji (optional)",
+    "emojiPlaceholder": "e.g. 🤖",
+    "avatarLabel": "Avatar (optional)",
+    "avatarPlaceholder": "e.g. robot",
+    "submitting": "Submitting...",
+    "createButton": "Create Agent",
+    "saveButton": "Save Changes",
+    "cancelEdit": "Cancel",
+    "editingHint": "Currently editing: {{id}}"
   },
   "list": {
-    "title": "Existing Agents",
+    "title": "Agents",
     "description": "{{count}} agents · session scope: {{scope}}",
     "empty": "No agents found yet.",
     "defaultBadge": "Default",
-    "mainBadge": "Main Key"
+    "mainBadge": "Main Key",
+    "edit": "Edit",
+    "configureFiles": "Configure Files",
+    "delete": "Delete",
+    "deleting": "Deleting..."
+  },
+  "files": {
+    "title": "Agent Files",
+    "description": "View and edit workspace files such as AGENTS.md, SOUL.md, and IDENTITY.md.",
+    "noAgent": "No agent available to configure.",
+    "agentLabel": "Select Agent",
+    "workspaceLabel": "Workspace Path",
+    "openWorkspace": "Open Folder",
+    "reload": "Reload",
+    "loading": "Loading...",
+    "missingBadge": "Missing",
+    "editorLabel": "Editing: {{file}}",
+    "saving": "Saving...",
+    "save": "Save File",
+    "unsavedHint": "You have unsaved changes",
+    "savedHint": "All changes saved"
+  },
+  "confirmDelete": {
+    "title": "Delete Agent",
+    "message": "Delete agent \"{{id}}\" and its workspace files? This action cannot be undone.",
+    "confirm": "Delete",
+    "cancel": "Cancel"
   },
   "toast": {
     "created": "Agent \"{{id}}\" created",
-    "createFailed": "Failed to create agent"
+    "createdWithWarnings": "Agent \"{{id}}\" was created, but some follow-up settings failed to sync",
+    "createFailed": "Failed to create agent",
+    "modelUpdateFailed": "Failed to update model settings",
+    "identitySyncFailed": "Failed to sync identity fields",
+    "updated": "Agent \"{{id}}\" updated",
+    "updateFailed": "Failed to update agent",
+    "deleted": "Agent \"{{id}}\" deleted",
+    "deleteFailed": "Failed to delete agent",
+    "fileSaved": "Saved \"{{file}}\"",
+    "fileSaveFailed": "Failed to save file",
+    "fileLoadFailed": "Failed to load file",
+    "workspaceLoadFailed": "Failed to load workspace path",
+    "workspaceOpenFailed": "Failed to open workspace"
   }
 }

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "Chat",
         "newChat": "New Chat",
+        "agents": "Agents",
         "cronTasks": "Cron Tasks",
         "skills": "Skills",
         "channels": "Channels",

--- a/src/i18n/locales/ja/agents.json
+++ b/src/i18n/locales/ja/agents.json
@@ -1,0 +1,27 @@
+{
+  "title": "エージェント管理",
+  "subtitle": "CLI を使わずに OpenClaw エージェントを作成・確認できます。",
+  "refresh": "更新",
+  "gatewayWarning": "ゲートウェイが停止中です。先にゲートウェイを起動してください。",
+  "create": {
+    "title": "新しいエージェントを作成",
+    "description": "ここでは基本項目のみ設定します。バインディングや詳細なモデル設定は OpenClaw 設定で続けてください。",
+    "nameLabel": "エージェント名",
+    "namePlaceholder": "例: support",
+    "workspaceLabel": "ワークスペースディレクトリ",
+    "workspacePlaceholder": "例: ~/.openclaw/workspace-support",
+    "submit": "エージェントを作成",
+    "creating": "作成中..."
+  },
+  "list": {
+    "title": "既存エージェント",
+    "description": "{{count}} 件 · セッションスコープ: {{scope}}",
+    "empty": "エージェントはまだありません。",
+    "defaultBadge": "デフォルト",
+    "mainBadge": "メインキー"
+  },
+  "toast": {
+    "created": "エージェント「{{id}}」を作成しました",
+    "createFailed": "エージェントの作成に失敗しました"
+  }
+}

--- a/src/i18n/locales/ja/agents.json
+++ b/src/i18n/locales/ja/agents.json
@@ -1,27 +1,77 @@
 {
   "title": "エージェント管理",
-  "subtitle": "CLI を使わずに OpenClaw エージェントを作成・確認できます。",
+  "subtitle": "UI 上でエージェントの作成・編集・削除とファイル設定を完結できます。",
   "refresh": "更新",
   "gatewayWarning": "ゲートウェイが停止中です。先にゲートウェイを起動してください。",
-  "create": {
-    "title": "新しいエージェントを作成",
-    "description": "ここでは基本項目のみ設定します。バインディングや詳細なモデル設定は OpenClaw 設定で続けてください。",
+  "form": {
+    "createTitle": "エージェントを作成",
+    "createDescription": "名前、ワークスペース、モデル、ID 情報を入力して新規作成します。",
+    "editTitle": "エージェントを編集",
+    "editDescription": "選択したエージェントの基本情報とモデル設定を更新します。",
     "nameLabel": "エージェント名",
     "namePlaceholder": "例: support",
     "workspaceLabel": "ワークスペースディレクトリ",
     "workspacePlaceholder": "例: ~/.openclaw/workspace-support",
-    "submit": "エージェントを作成",
-    "creating": "作成中..."
+    "workspaceLoadError": "このエージェントのワークスペースパスを読み込めません。再読み込み後に保存してください。",
+    "modelLabel": "モデル ID（任意）",
+    "modelPlaceholder": "例: openai/gpt-4.1",
+    "emojiLabel": "絵文字（任意）",
+    "emojiPlaceholder": "例: 🤖",
+    "avatarLabel": "アバター（任意）",
+    "avatarPlaceholder": "例: robot",
+    "submitting": "送信中...",
+    "createButton": "エージェントを作成",
+    "saveButton": "変更を保存",
+    "cancelEdit": "キャンセル",
+    "editingHint": "編集中: {{id}}"
   },
   "list": {
-    "title": "既存エージェント",
+    "title": "エージェント一覧",
     "description": "{{count}} 件 · セッションスコープ: {{scope}}",
     "empty": "エージェントはまだありません。",
     "defaultBadge": "デフォルト",
-    "mainBadge": "メインキー"
+    "mainBadge": "メインキー",
+    "edit": "編集",
+    "configureFiles": "ファイル設定",
+    "delete": "削除",
+    "deleting": "削除中..."
+  },
+  "files": {
+    "title": "エージェントファイル",
+    "description": "AGENTS.md、SOUL.md、IDENTITY.md などのワークスペースファイルを直接編集できます。",
+    "noAgent": "設定可能なエージェントがありません。",
+    "agentLabel": "エージェント選択",
+    "workspaceLabel": "ワークスペースパス",
+    "openWorkspace": "フォルダを開く",
+    "reload": "再読み込み",
+    "loading": "読み込み中...",
+    "missingBadge": "未作成",
+    "editorLabel": "編集中: {{file}}",
+    "saving": "保存中...",
+    "save": "ファイルを保存",
+    "unsavedHint": "未保存の変更があります",
+    "savedHint": "保存済み"
+  },
+  "confirmDelete": {
+    "title": "エージェント削除",
+    "message": "エージェント「{{id}}」とワークスペースファイルを削除しますか？この操作は取り消せません。",
+    "confirm": "削除する",
+    "cancel": "キャンセル"
   },
   "toast": {
     "created": "エージェント「{{id}}」を作成しました",
-    "createFailed": "エージェントの作成に失敗しました"
+    "createdWithWarnings": "エージェント「{{id}}」は作成されましたが、一部の後続設定の同期に失敗しました",
+    "createFailed": "エージェントの作成に失敗しました",
+    "modelUpdateFailed": "モデル設定の更新に失敗しました",
+    "identitySyncFailed": "ID 情報の同期に失敗しました",
+    "updated": "エージェント「{{id}}」を更新しました",
+    "updateFailed": "エージェントの更新に失敗しました",
+    "deleted": "エージェント「{{id}}」を削除しました",
+    "deleteFailed": "エージェントの削除に失敗しました",
+    "fileSaved": "「{{file}}」を保存しました",
+    "fileSaveFailed": "ファイルの保存に失敗しました",
+    "fileLoadFailed": "ファイルの読み込みに失敗しました",
+    "workspaceLoadFailed": "ワークスペースパスの読み込みに失敗しました",
+    "workspaceOpenFailed": "ワークスペースを開けませんでした"
   }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "チャット",
         "newChat": "新しいチャット",
+        "agents": "エージェント",
         "cronTasks": "定期タスク",
         "skills": "スキル",
         "channels": "チャンネル",

--- a/src/i18n/locales/zh/agents.json
+++ b/src/i18n/locales/zh/agents.json
@@ -1,27 +1,77 @@
 {
   "title": "智能体管理",
-  "subtitle": "无需命令行，直接创建并查看 OpenClaw 智能体。",
+  "subtitle": "在图形界面中完成智能体创建、编辑、删除和文件配置。",
   "refresh": "刷新",
   "gatewayWarning": "网关未运行。请先启动网关后再管理智能体。",
-  "create": {
-    "title": "创建新智能体",
-    "description": "当前仅提供基础字段。路由绑定、身份信息、模型策略等高级配置请继续在 OpenClaw 配置中完成。",
+  "form": {
+    "createTitle": "创建智能体",
+    "createDescription": "填写名称、工作区、模型与身份信息后即可创建。",
+    "editTitle": "编辑智能体",
+    "editDescription": "修改智能体的基础信息与模型设置。",
     "nameLabel": "智能体名称",
     "namePlaceholder": "例如：support",
     "workspaceLabel": "工作区目录",
     "workspacePlaceholder": "例如：~/.openclaw/workspace-support",
-    "submit": "创建智能体",
-    "creating": "创建中..."
+    "workspaceLoadError": "无法读取该智能体的工作区路径，请先重试读取后再保存。",
+    "modelLabel": "模型 ID（可选）",
+    "modelPlaceholder": "例如：openai/gpt-4.1",
+    "emojiLabel": "Emoji（可选）",
+    "emojiPlaceholder": "例如：🤖",
+    "avatarLabel": "头像（可选）",
+    "avatarPlaceholder": "例如：robot",
+    "submitting": "提交中...",
+    "createButton": "创建智能体",
+    "saveButton": "保存修改",
+    "cancelEdit": "取消编辑",
+    "editingHint": "当前正在编辑：{{id}}"
   },
   "list": {
-    "title": "已有智能体",
+    "title": "智能体列表",
     "description": "{{count}} 个智能体 · 会话作用域：{{scope}}",
     "empty": "暂未发现智能体。",
     "defaultBadge": "默认",
-    "mainBadge": "主会话键"
+    "mainBadge": "主会话键",
+    "edit": "编辑",
+    "configureFiles": "配置文件",
+    "delete": "删除",
+    "deleting": "删除中..."
+  },
+  "files": {
+    "title": "Agent 文件管理",
+    "description": "直接查看和编辑工作区中的 AGENTS.md、SOUL.md、IDENTITY.md 等文件。",
+    "noAgent": "暂无可配置的智能体。",
+    "agentLabel": "选择智能体",
+    "workspaceLabel": "工作区路径",
+    "openWorkspace": "打开目录",
+    "reload": "重新加载",
+    "loading": "加载中...",
+    "missingBadge": "缺失",
+    "editorLabel": "编辑文件：{{file}}",
+    "saving": "保存中...",
+    "save": "保存文件",
+    "unsavedHint": "有未保存改动",
+    "savedHint": "已保存"
+  },
+  "confirmDelete": {
+    "title": "删除智能体",
+    "message": "确认删除智能体「{{id}}」及其工作区文件吗？该操作不可撤销。",
+    "confirm": "确认删除",
+    "cancel": "取消"
   },
   "toast": {
     "created": "已创建智能体「{{id}}」",
-    "createFailed": "创建智能体失败"
+    "createdWithWarnings": "智能体「{{id}}」已创建，但部分后续配置未同步成功",
+    "createFailed": "创建智能体失败",
+    "modelUpdateFailed": "模型配置更新失败",
+    "identitySyncFailed": "身份信息同步失败",
+    "updated": "已更新智能体「{{id}}」",
+    "updateFailed": "更新智能体失败",
+    "deleted": "已删除智能体「{{id}}」",
+    "deleteFailed": "删除智能体失败",
+    "fileSaved": "已保存文件「{{file}}」",
+    "fileSaveFailed": "文件保存失败",
+    "fileLoadFailed": "文件加载失败",
+    "workspaceLoadFailed": "读取工作区路径失败",
+    "workspaceOpenFailed": "打开工作区失败"
   }
 }

--- a/src/i18n/locales/zh/agents.json
+++ b/src/i18n/locales/zh/agents.json
@@ -1,0 +1,27 @@
+{
+  "title": "智能体管理",
+  "subtitle": "无需命令行，直接创建并查看 OpenClaw 智能体。",
+  "refresh": "刷新",
+  "gatewayWarning": "网关未运行。请先启动网关后再管理智能体。",
+  "create": {
+    "title": "创建新智能体",
+    "description": "当前仅提供基础字段。路由绑定、身份信息、模型策略等高级配置请继续在 OpenClaw 配置中完成。",
+    "nameLabel": "智能体名称",
+    "namePlaceholder": "例如：support",
+    "workspaceLabel": "工作区目录",
+    "workspacePlaceholder": "例如：~/.openclaw/workspace-support",
+    "submit": "创建智能体",
+    "creating": "创建中..."
+  },
+  "list": {
+    "title": "已有智能体",
+    "description": "{{count}} 个智能体 · 会话作用域：{{scope}}",
+    "empty": "暂未发现智能体。",
+    "defaultBadge": "默认",
+    "mainBadge": "主会话键"
+  },
+  "toast": {
+    "created": "已创建智能体「{{id}}」",
+    "createFailed": "创建智能体失败"
+  }
+}

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -2,6 +2,7 @@
     "sidebar": {
         "chat": "聊天",
         "newChat": "新对话",
+        "agents": "多智能体",
         "cronTasks": "定时任务",
         "skills": "技能",
         "channels": "频道",

--- a/src/pages/Agents/index.tsx
+++ b/src/pages/Agents/index.tsx
@@ -1,0 +1,207 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Bot, Plus, RefreshCw, Sparkles } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
+import { useAgentsStore } from '@/stores/agents';
+import { useGatewayStore } from '@/stores/gateway';
+
+function normalizeAgentId(value: string): string {
+  const normalized = value
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+
+  return normalized || 'agent';
+}
+
+export function Agents() {
+  const { t } = useTranslation('agents');
+  const { agents, defaultId, mainKey, scope, loading, creating, error, fetchAgents, createAgent } = useAgentsStore();
+  const gatewayStatus = useGatewayStore((state) => state.status);
+  const isGatewayRunning = gatewayStatus.state === 'running';
+
+  const [agentName, setAgentName] = useState('');
+  const [workspace, setWorkspace] = useState('');
+  const [workspaceTouched, setWorkspaceTouched] = useState(false);
+  const [configDir, setConfigDir] = useState('~/.openclaw');
+
+  useEffect(() => {
+    window.electron.ipcRenderer.invoke('openclaw:getConfigDir')
+      .then((dir) => setConfigDir(String(dir)))
+      .catch(() => setConfigDir('~/.openclaw'));
+  }, []);
+
+  useEffect(() => {
+    if (isGatewayRunning) {
+      fetchAgents();
+    }
+  }, [isGatewayRunning, fetchAgents]);
+
+  const suggestedWorkspace = useMemo(() => {
+    const normalizedId = normalizeAgentId(agentName || 'agent');
+    return `${configDir}/workspace-${normalizedId}`;
+  }, [agentName, configDir]);
+
+  const workspaceValue = workspaceTouched ? workspace : suggestedWorkspace;
+
+  const sortedAgents = useMemo(() => {
+    return [...agents].sort((firstAgent, secondAgent) => {
+      if (firstAgent.id === defaultId && secondAgent.id !== defaultId) return -1;
+      if (firstAgent.id !== defaultId && secondAgent.id === defaultId) return 1;
+      return firstAgent.id.localeCompare(secondAgent.id);
+    });
+  }, [agents, defaultId]);
+
+  const handleCreateAgent = useCallback(async () => {
+    const name = agentName.trim();
+    const workspaceDir = workspaceValue.trim();
+
+    if (!name || !workspaceDir) {
+      return;
+    }
+
+    try {
+      await createAgent({
+        name,
+        workspace: workspaceDir,
+      });
+      toast.success(t('toast.created', { id: normalizeAgentId(name) }));
+      setAgentName('');
+      setWorkspace('');
+      setWorkspaceTouched(false);
+    } catch (createError) {
+      toast.error(`${t('toast.createFailed')}: ${String(createError)}`);
+    }
+  }, [agentName, workspaceValue, createAgent, t]);
+
+  if (loading && agents.length === 0) {
+    return (
+      <div className="flex h-96 items-center justify-center">
+        <LoadingSpinner size="lg" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold">{t('title')}</h1>
+          <p className="text-muted-foreground">{t('subtitle')}</p>
+        </div>
+        <Button variant="outline" onClick={fetchAgents} disabled={!isGatewayRunning || loading}>
+          <RefreshCw className="h-4 w-4 mr-2" />
+          {t('refresh')}
+        </Button>
+      </div>
+
+      {!isGatewayRunning && (
+        <Card className="border-yellow-500 bg-yellow-50 dark:bg-yellow-900/10">
+          <CardContent className="py-4">
+            <p className="text-yellow-700 dark:text-yellow-400">{t('gatewayWarning')}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      {error && (
+        <Card className="border-red-500 bg-red-50 dark:bg-red-900/10">
+          <CardContent className="py-4">
+            <p className="text-red-700 dark:text-red-300">{error}</p>
+          </CardContent>
+        </Card>
+      )}
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Plus className="h-5 w-5" />
+            {t('create.title')}
+          </CardTitle>
+          <CardDescription>{t('create.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t('create.nameLabel')}</label>
+            <Input
+              value={agentName}
+              onChange={(event) => setAgentName(event.target.value)}
+              placeholder={t('create.namePlaceholder')}
+              disabled={!isGatewayRunning || creating}
+            />
+          </div>
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t('create.workspaceLabel')}</label>
+            <Input
+              value={workspaceValue}
+              onChange={(event) => {
+                setWorkspace(event.target.value);
+                setWorkspaceTouched(true);
+              }}
+              placeholder={t('create.workspacePlaceholder')}
+              disabled={!isGatewayRunning || creating}
+            />
+          </div>
+          <Button
+            onClick={handleCreateAgent}
+            disabled={!isGatewayRunning || creating || !agentName.trim() || !workspaceValue.trim()}
+          >
+            <Bot className="h-4 w-4 mr-2" />
+            {creating ? t('create.creating') : t('create.submit')}
+          </Button>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('list.title')}</CardTitle>
+          <CardDescription>{t('list.description', { count: sortedAgents.length, scope })}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          {sortedAgents.length === 0 ? (
+            <p className="text-muted-foreground">{t('list.empty')}</p>
+          ) : (
+            <div className="space-y-3">
+              {sortedAgents.map((agent) => {
+                const displayName = agent.name?.trim() || agent.identity?.name?.trim() || agent.id;
+                const hasIdentity = Boolean(agent.identity?.emoji || agent.identity?.name);
+
+                return (
+                  <div
+                    key={agent.id}
+                    className="rounded-lg border p-4 flex items-start justify-between gap-3"
+                  >
+                    <div className="min-w-0">
+                      <p className="font-medium truncate">{displayName}</p>
+                      <p className="text-sm text-muted-foreground truncate">{agent.id}</p>
+                      {hasIdentity && (
+                        <p className="text-sm text-muted-foreground mt-1 truncate">
+                          <Sparkles className="inline h-3 w-3 mr-1" />
+                          {[agent.identity?.emoji, agent.identity?.name].filter(Boolean).join(' ')}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      {agent.id === defaultId && <Badge>{t('list.defaultBadge')}</Badge>}
+                      {agent.id === mainKey && (
+                        <Badge variant="outline">{t('list.mainBadge')}</Badge>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+}
+
+export default Agents;

--- a/src/pages/Agents/index.tsx
+++ b/src/pages/Agents/index.tsx
@@ -1,14 +1,26 @@
 import { useCallback, useEffect, useMemo, useState } from 'react';
-import { Bot, Plus, RefreshCw, Sparkles } from 'lucide-react';
+import {
+  Bot,
+  FileText,
+  FolderOpen,
+  Pencil,
+  Plus,
+  RefreshCw,
+  Save,
+  Trash2,
+} from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { toast } from 'sonner';
+import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { Input } from '@/components/ui/input';
+import { Textarea } from '@/components/ui/textarea';
 import { Badge } from '@/components/ui/badge';
-import { LoadingSpinner } from '@/components/common/LoadingSpinner';
 import { useAgentsStore } from '@/stores/agents';
 import { useGatewayStore } from '@/stores/gateway';
+import type { AgentRow } from '@/types/agent';
 
 function normalizeAgentId(value: string): string {
   const normalized = value
@@ -21,16 +33,89 @@ function normalizeAgentId(value: string): string {
   return normalized || 'agent';
 }
 
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function upsertIdentityField(content: string, field: string, value: string): string {
+  const normalizedValue = value.trim();
+  const pattern = new RegExp(`^\\s*-\\s*${escapeRegExp(field)}\\s*:.*$`, 'i');
+  const existingLines = content.split(/\r?\n/);
+
+  const nextLines = existingLines.filter((line) => !pattern.test(line));
+  if (normalizedValue) {
+    nextLines.push(`- ${field}: ${normalizedValue}`);
+  }
+
+  const normalizedContent = nextLines.join('\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+  return normalizedContent ? `${normalizedContent}\n` : '';
+}
+
+function formatSize(size?: number): string {
+  if (typeof size !== 'number' || Number.isNaN(size)) return '-';
+  if (size < 1024) return `${size} B`;
+  if (size < 1024 * 1024) return `${(size / 1024).toFixed(1)} KB`;
+  return `${(size / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function formatUpdatedAt(timestamp?: number): string {
+  if (!timestamp) return '-';
+  return new Date(timestamp).toLocaleString();
+}
+
 export function Agents() {
   const { t } = useTranslation('agents');
-  const { agents, defaultId, mainKey, scope, loading, creating, error, fetchAgents, createAgent } = useAgentsStore();
   const gatewayStatus = useGatewayStore((state) => state.status);
   const isGatewayRunning = gatewayStatus.state === 'running';
 
-  const [agentName, setAgentName] = useState('');
-  const [workspace, setWorkspace] = useState('');
-  const [workspaceTouched, setWorkspaceTouched] = useState(false);
+  const {
+    agents,
+    defaultId,
+    mainKey,
+    scope,
+    models,
+    loading,
+    submitting,
+    deletingAgentId,
+    error,
+    fetchAgents,
+    fetchModels,
+    createAgent,
+    updateAgent,
+    deleteAgent,
+    listAgentFiles,
+    getAgentFile,
+    setAgentFile,
+  } = useAgentsStore();
+
   const [configDir, setConfigDir] = useState('~/.openclaw');
+
+  const [nameInput, setNameInput] = useState('');
+  const [workspaceInput, setWorkspaceInput] = useState('');
+  const [workspaceTouched, setWorkspaceTouched] = useState(false);
+  const [workspaceLoadFailed, setWorkspaceLoadFailed] = useState(false);
+  const [modelInput, setModelInput] = useState('');
+  const [emojiInput, setEmojiInput] = useState('');
+  const [avatarInput, setAvatarInput] = useState('');
+  const [editingAgentId, setEditingAgentId] = useState<string | null>(null);
+
+  const [deleteCandidate, setDeleteCandidate] = useState<AgentRow | null>(null);
+
+  const [filesAgentId, setFilesAgentId] = useState('');
+  const [filesWorkspace, setFilesWorkspace] = useState('');
+  const [files, setFiles] = useState<Array<{
+    name: string;
+    path: string;
+    missing: boolean;
+    size?: number;
+    updatedAtMs?: number;
+  }>>([]);
+  const [selectedFileName, setSelectedFileName] = useState('');
+  const [fileContent, setFileContent] = useState('');
+  const [fileOriginalContent, setFileOriginalContent] = useState('');
+  const [loadingFiles, setLoadingFiles] = useState(false);
+  const [loadingFileContent, setLoadingFileContent] = useState(false);
+  const [savingFile, setSavingFile] = useState(false);
 
   useEffect(() => {
     window.electron.ipcRenderer.invoke('openclaw:getConfigDir')
@@ -39,17 +124,10 @@ export function Agents() {
   }, []);
 
   useEffect(() => {
-    if (isGatewayRunning) {
-      fetchAgents();
-    }
-  }, [isGatewayRunning, fetchAgents]);
-
-  const suggestedWorkspace = useMemo(() => {
-    const normalizedId = normalizeAgentId(agentName || 'agent');
-    return `${configDir}/workspace-${normalizedId}`;
-  }, [agentName, configDir]);
-
-  const workspaceValue = workspaceTouched ? workspace : suggestedWorkspace;
+    if (!isGatewayRunning) return;
+    void fetchAgents();
+    void fetchModels();
+  }, [isGatewayRunning, fetchAgents, fetchModels]);
 
   const sortedAgents = useMemo(() => {
     return [...agents].sort((firstAgent, secondAgent) => {
@@ -59,29 +137,300 @@ export function Agents() {
     });
   }, [agents, defaultId]);
 
-  const handleCreateAgent = useCallback(async () => {
-    const name = agentName.trim();
-    const workspaceDir = workspaceValue.trim();
+  const suggestedWorkspace = useMemo(() => {
+    const normalizedId = normalizeAgentId(nameInput || 'agent');
+    return `${configDir}/workspace-${normalizedId}`;
+  }, [nameInput, configDir]);
 
-    if (!name || !workspaceDir) {
-      return;
+  const workspaceValue = workspaceTouched ? workspaceInput : suggestedWorkspace;
+
+  const currentEditingAgent = useMemo(
+    () => sortedAgents.find((agent) => agent.id === editingAgentId) ?? null,
+    [sortedAgents, editingAgentId]
+  );
+
+  const activeFilesAgentId = filesAgentId || sortedAgents[0]?.id || '';
+
+  const fileDirty = fileContent !== fileOriginalContent;
+
+  const resetForm = useCallback(() => {
+    setNameInput('');
+    setWorkspaceInput('');
+    setWorkspaceTouched(false);
+    setWorkspaceLoadFailed(false);
+    setModelInput('');
+    setEmojiInput('');
+    setAvatarInput('');
+    setEditingAgentId(null);
+  }, []);
+
+  const syncIdentityFields = useCallback(async (
+    agentId: string,
+    fields: { name?: string; emoji?: string; avatar?: string }
+  ) => {
+    const identityResult = await getAgentFile(agentId, 'IDENTITY.md');
+    const currentContent = identityResult.file.content ?? '';
+    let nextContent = currentContent;
+
+    if (typeof fields.name === 'string') {
+      nextContent = upsertIdentityField(nextContent, 'Name', fields.name);
+    }
+
+    if (typeof fields.emoji === 'string') {
+      nextContent = upsertIdentityField(nextContent, 'Emoji', fields.emoji);
+    }
+
+    if (typeof fields.avatar === 'string') {
+      nextContent = upsertIdentityField(nextContent, 'Avatar', fields.avatar);
+    }
+
+    if (nextContent !== currentContent) {
+      await setAgentFile(agentId, 'IDENTITY.md', nextContent);
+    }
+  }, [getAgentFile, setAgentFile]);
+
+  const loadFileContent = useCallback(async (agentId: string, fileName: string) => {
+    if (!agentId || !fileName) return;
+    setLoadingFileContent(true);
+    try {
+      const fileResult = await getAgentFile(agentId, fileName);
+      const nextContent = fileResult.file.content ?? '';
+      setSelectedFileName(fileName);
+      setFileContent(nextContent);
+      setFileOriginalContent(nextContent);
+    } catch (loadError) {
+      toast.error(`${t('toast.fileLoadFailed')}: ${String(loadError)}`);
+    } finally {
+      setLoadingFileContent(false);
+    }
+  }, [getAgentFile, t]);
+
+  const refreshAgentFiles = useCallback(async (agentId: string, preferredFileName?: string) => {
+    if (!agentId) return;
+    setLoadingFiles(true);
+    try {
+      const result = await listAgentFiles(agentId);
+      setFilesWorkspace(result.workspace);
+      setFiles(result.files ?? []);
+
+      const nextFileName = preferredFileName
+        || selectedFileName
+        || result.files?.[0]?.name
+        || '';
+
+      if (nextFileName) {
+        await loadFileContent(agentId, nextFileName);
+      } else {
+        setSelectedFileName('');
+        setFileContent('');
+        setFileOriginalContent('');
+      }
+    } catch (loadError) {
+      toast.error(`${t('toast.fileLoadFailed')}: ${String(loadError)}`);
+    } finally {
+      setLoadingFiles(false);
+    }
+  }, [listAgentFiles, loadFileContent, selectedFileName, t]);
+
+  const handleCreateAgent = useCallback(async () => {
+    const nextName = nameInput.trim();
+    const nextWorkspace = workspaceValue.trim();
+    const nextModel = modelInput.trim();
+    const nextEmoji = emojiInput.trim();
+    const nextAvatar = avatarInput.trim();
+
+    if (!nextName || !nextWorkspace) return;
+
+    const createResult = await createAgent({
+      name: nextName,
+      workspace: nextWorkspace,
+      ...(nextEmoji ? { emoji: nextEmoji } : {}),
+      ...(nextAvatar ? { avatar: nextAvatar } : {}),
+    }).catch((createError) => {
+      toast.error(`${t('toast.createFailed')}: ${String(createError)}`);
+      return null;
+    });
+
+    if (!createResult) return;
+
+    const nextAgentId = createResult.agentId;
+
+    const postCreateErrors: string[] = [];
+
+    if (nextModel) {
+      try {
+        await updateAgent({
+          agentId: nextAgentId,
+          model: nextModel,
+        });
+      } catch (updateModelError) {
+        postCreateErrors.push(`${t('toast.modelUpdateFailed')}: ${String(updateModelError)}`);
+      }
     }
 
     try {
-      await createAgent({
-        name,
-        workspace: workspaceDir,
+      await syncIdentityFields(nextAgentId, {
+        name: nextName,
+        emoji: nextEmoji,
+        avatar: nextAvatar,
       });
-      toast.success(t('toast.created', { id: normalizeAgentId(name) }));
-      setAgentName('');
-      setWorkspace('');
-      setWorkspaceTouched(false);
-    } catch (createError) {
-      toast.error(`${t('toast.createFailed')}: ${String(createError)}`);
+    } catch (syncError) {
+      postCreateErrors.push(`${t('toast.identitySyncFailed')}: ${String(syncError)}`);
     }
-  }, [agentName, workspaceValue, createAgent, t]);
 
-  if (loading && agents.length === 0) {
+    if (postCreateErrors.length > 0) {
+      toast.warning(t('toast.createdWithWarnings', { id: nextAgentId }));
+      postCreateErrors.forEach((message) => {
+        toast.error(message);
+      });
+    } else {
+      toast.success(t('toast.created', { id: nextAgentId }));
+    }
+
+    resetForm();
+    setFilesAgentId(nextAgentId);
+    await refreshAgentFiles(nextAgentId);
+  }, [
+    nameInput,
+    workspaceValue,
+    modelInput,
+    emojiInput,
+    avatarInput,
+    createAgent,
+    updateAgent,
+    syncIdentityFields,
+    resetForm,
+    refreshAgentFiles,
+    t,
+  ]);
+
+  const handleStartEdit = useCallback(async (agent: AgentRow) => {
+    setEditingAgentId(agent.id);
+    setNameInput(agent.name?.trim() || agent.id);
+    setModelInput('');
+    setEmojiInput(agent.identity?.emoji ?? '');
+    setAvatarInput(agent.identity?.avatar ?? '');
+    setWorkspaceLoadFailed(false);
+
+    try {
+      const fileResult = await listAgentFiles(agent.id);
+      setWorkspaceInput(fileResult.workspace);
+      setWorkspaceTouched(true);
+      setWorkspaceLoadFailed(false);
+    } catch {
+      setWorkspaceInput('');
+      setWorkspaceTouched(true);
+      setWorkspaceLoadFailed(true);
+      toast.error(t('toast.workspaceLoadFailed'));
+    }
+  }, [listAgentFiles, t]);
+
+  const handleUpdateAgent = useCallback(async () => {
+    if (!editingAgentId) return;
+    if (workspaceLoadFailed) {
+      toast.error(t('form.workspaceLoadError'));
+      return;
+    }
+
+    const nextName = nameInput.trim();
+    const nextWorkspace = workspaceValue.trim();
+    const nextModel = modelInput.trim();
+    const nextEmoji = emojiInput.trim();
+    const nextAvatar = avatarInput.trim();
+
+    if (!nextName || !nextWorkspace) return;
+
+    try {
+      await updateAgent({
+        agentId: editingAgentId,
+        name: nextName,
+        workspace: nextWorkspace,
+        ...(nextModel ? { model: nextModel } : {}),
+      });
+
+      await syncIdentityFields(editingAgentId, {
+        name: nextName,
+        emoji: nextEmoji,
+        avatar: nextAvatar,
+      });
+
+      toast.success(t('toast.updated', { id: editingAgentId }));
+      resetForm();
+
+      if (activeFilesAgentId === editingAgentId) {
+        await refreshAgentFiles(editingAgentId);
+      }
+    } catch (updateError) {
+      toast.error(`${t('toast.updateFailed')}: ${String(updateError)}`);
+    }
+  }, [
+    editingAgentId,
+    nameInput,
+    workspaceValue,
+    modelInput,
+    emojiInput,
+    avatarInput,
+    workspaceLoadFailed,
+    updateAgent,
+    syncIdentityFields,
+    resetForm,
+    activeFilesAgentId,
+    refreshAgentFiles,
+    t,
+  ]);
+
+  const handleDeleteAgent = useCallback(async () => {
+    if (!deleteCandidate) return;
+    try {
+      await deleteAgent({ agentId: deleteCandidate.id, deleteFiles: true });
+      toast.success(t('toast.deleted', { id: deleteCandidate.id }));
+
+      if (editingAgentId === deleteCandidate.id) {
+        resetForm();
+      }
+
+      if (activeFilesAgentId === deleteCandidate.id) {
+        setFilesAgentId('');
+        setFilesWorkspace('');
+        setFiles([]);
+        setSelectedFileName('');
+        setFileContent('');
+        setFileOriginalContent('');
+      }
+      setDeleteCandidate(null);
+    } catch (deleteError) {
+      toast.error(`${t('toast.deleteFailed')}: ${String(deleteError)}`);
+    }
+  }, [deleteCandidate, deleteAgent, editingAgentId, resetForm, activeFilesAgentId, t]);
+
+  const handleSaveFile = useCallback(async () => {
+    if (!activeFilesAgentId || !selectedFileName) return;
+    setSavingFile(true);
+    try {
+      await setAgentFile(activeFilesAgentId, selectedFileName, fileContent);
+      setFileOriginalContent(fileContent);
+      await refreshAgentFiles(activeFilesAgentId, selectedFileName);
+      toast.success(t('toast.fileSaved', { file: selectedFileName }));
+    } catch (saveError) {
+      toast.error(`${t('toast.fileSaveFailed')}: ${String(saveError)}`);
+    } finally {
+      setSavingFile(false);
+    }
+  }, [activeFilesAgentId, selectedFileName, fileContent, setAgentFile, refreshAgentFiles, t]);
+
+  const handleOpenWorkspace = useCallback(async () => {
+    if (!filesWorkspace) return;
+    try {
+      const result = await window.electron.ipcRenderer.invoke('shell:openPath', filesWorkspace) as string;
+      if (result) {
+        throw new Error(result);
+      }
+    } catch (openError) {
+      toast.error(`${t('toast.workspaceOpenFailed')}: ${String(openError)}`);
+    }
+  }, [filesWorkspace, t]);
+
+  if (loading && sortedAgents.length === 0) {
     return (
       <div className="flex h-96 items-center justify-center">
         <LoadingSpinner size="lg" />
@@ -96,7 +445,14 @@ export function Agents() {
           <h1 className="text-2xl font-bold">{t('title')}</h1>
           <p className="text-muted-foreground">{t('subtitle')}</p>
         </div>
-        <Button variant="outline" onClick={fetchAgents} disabled={!isGatewayRunning || loading}>
+        <Button
+          variant="outline"
+          onClick={async () => {
+            await fetchAgents();
+            await fetchModels();
+          }}
+          disabled={!isGatewayRunning || loading}
+        >
           <RefreshCw className="h-4 w-4 mr-2" />
           {t('refresh')}
         </Button>
@@ -121,47 +477,121 @@ export function Agents() {
       <Card>
         <CardHeader>
           <CardTitle className="flex items-center gap-2">
-            <Plus className="h-5 w-5" />
-            {t('create.title')}
+            {editingAgentId ? <Pencil className="h-5 w-5" /> : <Plus className="h-5 w-5" />}
+            {editingAgentId ? t('form.editTitle') : t('form.createTitle')}
           </CardTitle>
-          <CardDescription>{t('create.description')}</CardDescription>
+          <CardDescription>
+            {editingAgentId ? t('form.editDescription') : t('form.createDescription')}
+          </CardDescription>
         </CardHeader>
         <CardContent className="space-y-3">
           <div className="space-y-2">
-            <label className="text-sm font-medium">{t('create.nameLabel')}</label>
+            <label className="text-sm font-medium">{t('form.nameLabel')}</label>
             <Input
-              value={agentName}
-              onChange={(event) => setAgentName(event.target.value)}
-              placeholder={t('create.namePlaceholder')}
-              disabled={!isGatewayRunning || creating}
+              value={nameInput}
+              onChange={(event) => setNameInput(event.target.value)}
+              placeholder={t('form.namePlaceholder')}
+              disabled={!isGatewayRunning || submitting}
             />
           </div>
+
           <div className="space-y-2">
-            <label className="text-sm font-medium">{t('create.workspaceLabel')}</label>
+            <label className="text-sm font-medium">{t('form.workspaceLabel')}</label>
             <Input
               value={workspaceValue}
               onChange={(event) => {
-                setWorkspace(event.target.value);
+                setWorkspaceInput(event.target.value);
                 setWorkspaceTouched(true);
+                setWorkspaceLoadFailed(false);
               }}
-              placeholder={t('create.workspacePlaceholder')}
-              disabled={!isGatewayRunning || creating}
+              placeholder={t('form.workspacePlaceholder')}
+              disabled={!isGatewayRunning || submitting}
+            />
+            {editingAgentId && workspaceLoadFailed && (
+              <p className="text-xs text-amber-600 dark:text-amber-400">
+                {t('form.workspaceLoadError')}
+              </p>
+            )}
+          </div>
+
+          <div className="grid gap-3 md:grid-cols-2">
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t('form.modelLabel')}</label>
+              <Input
+                list="agent-model-options"
+                value={modelInput}
+                onChange={(event) => setModelInput(event.target.value)}
+                placeholder={t('form.modelPlaceholder')}
+                disabled={!isGatewayRunning || submitting}
+              />
+              <datalist id="agent-model-options">
+                {models.map((model) => (
+                  <option key={model.id} value={model.id}>
+                    {`${model.provider} · ${model.name}`}
+                  </option>
+                ))}
+              </datalist>
+            </div>
+
+            <div className="space-y-2">
+              <label className="text-sm font-medium">{t('form.emojiLabel')}</label>
+              <Input
+                value={emojiInput}
+                onChange={(event) => setEmojiInput(event.target.value)}
+                placeholder={t('form.emojiPlaceholder')}
+                disabled={!isGatewayRunning || submitting}
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <label className="text-sm font-medium">{t('form.avatarLabel')}</label>
+            <Input
+              value={avatarInput}
+              onChange={(event) => setAvatarInput(event.target.value)}
+              placeholder={t('form.avatarPlaceholder')}
+              disabled={!isGatewayRunning || submitting}
             />
           </div>
-          <Button
-            onClick={handleCreateAgent}
-            disabled={!isGatewayRunning || creating || !agentName.trim() || !workspaceValue.trim()}
-          >
-            <Bot className="h-4 w-4 mr-2" />
-            {creating ? t('create.creating') : t('create.submit')}
-          </Button>
+
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={editingAgentId ? handleUpdateAgent : handleCreateAgent}
+              disabled={
+                !isGatewayRunning
+                || submitting
+                || !nameInput.trim()
+                || !workspaceValue.trim()
+                || (Boolean(editingAgentId) && workspaceLoadFailed)
+              }
+            >
+              <Bot className="h-4 w-4 mr-2" />
+              {submitting
+                ? t('form.submitting')
+                : editingAgentId
+                  ? t('form.saveButton')
+                  : t('form.createButton')}
+            </Button>
+
+            {editingAgentId && (
+              <Button
+                variant="outline"
+                onClick={resetForm}
+                disabled={submitting}
+              >
+                {t('form.cancelEdit')}
+              </Button>
+            )}
+          </div>
         </CardContent>
       </Card>
 
       <Card>
         <CardHeader>
           <CardTitle>{t('list.title')}</CardTitle>
-          <CardDescription>{t('list.description', { count: sortedAgents.length, scope })}</CardDescription>
+          <CardDescription>
+            {t('list.description', { count: sortedAgents.length, scope })}
+          </CardDescription>
         </CardHeader>
         <CardContent>
           {sortedAgents.length === 0 ? (
@@ -170,28 +600,50 @@ export function Agents() {
             <div className="space-y-3">
               {sortedAgents.map((agent) => {
                 const displayName = agent.name?.trim() || agent.identity?.name?.trim() || agent.id;
-                const hasIdentity = Boolean(agent.identity?.emoji || agent.identity?.name);
+                const isDeleting = deletingAgentId === agent.id;
 
                 return (
                   <div
                     key={agent.id}
-                    className="rounded-lg border p-4 flex items-start justify-between gap-3"
+                    className="rounded-lg border p-4 flex flex-col gap-3 md:flex-row md:items-center md:justify-between"
                   >
                     <div className="min-w-0">
                       <p className="font-medium truncate">{displayName}</p>
                       <p className="text-sm text-muted-foreground truncate">{agent.id}</p>
-                      {hasIdentity && (
-                        <p className="text-sm text-muted-foreground mt-1 truncate">
-                          <Sparkles className="inline h-3 w-3 mr-1" />
-                          {[agent.identity?.emoji, agent.identity?.name].filter(Boolean).join(' ')}
-                        </p>
-                      )}
+                      <p className="text-sm text-muted-foreground truncate">
+                        {[agent.identity?.emoji, agent.identity?.avatar].filter(Boolean).join(' · ') || '-'}
+                      </p>
                     </div>
-                    <div className="flex items-center gap-2">
+
+                    <div className="flex flex-wrap items-center gap-2">
                       {agent.id === defaultId && <Badge>{t('list.defaultBadge')}</Badge>}
                       {agent.id === mainKey && (
                         <Badge variant="outline">{t('list.mainBadge')}</Badge>
                       )}
+                      <Button size="sm" variant="outline" onClick={() => void handleStartEdit(agent)}>
+                        <Pencil className="h-4 w-4 mr-1" />
+                        {t('list.edit')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="outline"
+                        onClick={async () => {
+                          setFilesAgentId(agent.id);
+                          await refreshAgentFiles(agent.id);
+                        }}
+                      >
+                        <FileText className="h-4 w-4 mr-1" />
+                        {t('list.configureFiles')}
+                      </Button>
+                      <Button
+                        size="sm"
+                        variant="destructive"
+                        onClick={() => setDeleteCandidate(agent)}
+                        disabled={agent.id === defaultId || isDeleting}
+                      >
+                        <Trash2 className="h-4 w-4 mr-1" />
+                        {isDeleting ? t('list.deleting') : t('list.delete')}
+                      </Button>
                     </div>
                   </div>
                 );
@@ -200,6 +652,146 @@ export function Agents() {
           )}
         </CardContent>
       </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle>{t('files.title')}</CardTitle>
+          <CardDescription>{t('files.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-3">
+          {sortedAgents.length === 0 ? (
+            <p className="text-muted-foreground">{t('files.noAgent')}</p>
+          ) : (
+            <>
+              <div className="grid gap-3 md:grid-cols-[220px_1fr]">
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">{t('files.agentLabel')}</label>
+                  <select
+                    className="w-full rounded-md border border-input bg-background px-3 py-2 text-sm"
+                    value={activeFilesAgentId}
+                    onChange={(event) => {
+                      const nextAgentId = event.target.value;
+                      setFilesAgentId(nextAgentId);
+                      void refreshAgentFiles(nextAgentId);
+                    }}
+                  >
+                    {sortedAgents.map((agent) => (
+                      <option key={agent.id} value={agent.id}>
+                        {agent.name?.trim() || agent.id}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+
+                <div className="space-y-2">
+                  <label className="text-sm font-medium">{t('files.workspaceLabel')}</label>
+                  <div className="flex items-center gap-2">
+                    <Input value={filesWorkspace} readOnly />
+                    <Button variant="outline" onClick={handleOpenWorkspace} disabled={!filesWorkspace}>
+                      <FolderOpen className="h-4 w-4 mr-2" />
+                      {t('files.openWorkspace')}
+                    </Button>
+                    <Button
+                      variant="outline"
+                      onClick={() => void refreshAgentFiles(activeFilesAgentId)}
+                      disabled={!activeFilesAgentId || loadingFiles}
+                    >
+                      <RefreshCw className="h-4 w-4 mr-2" />
+                      {t('files.reload')}
+                    </Button>
+                  </div>
+                </div>
+              </div>
+
+              {loadingFiles ? (
+                <div className="flex items-center gap-2 text-muted-foreground">
+                  <LoadingSpinner size="sm" />
+                  <span>{t('files.loading')}</span>
+                </div>
+              ) : (
+                <>
+                  <div className="grid gap-2">
+                    {files.map((file) => (
+                      <button
+                        key={file.name}
+                        onClick={() => void loadFileContent(activeFilesAgentId, file.name)}
+                        className={`text-left rounded-md border px-3 py-2 transition-colors ${
+                          selectedFileName === file.name
+                            ? 'border-primary bg-primary/5'
+                            : 'hover:bg-accent'
+                        }`}
+                      >
+                        <div className="flex items-center justify-between gap-2">
+                          <div className="flex items-center gap-2">
+                            <span className="font-medium">{file.name}</span>
+                            {file.missing && <Badge variant="outline">{t('files.missingBadge')}</Badge>}
+                          </div>
+                          <span className="text-xs text-muted-foreground">
+                            {formatSize(file.size)}
+                          </span>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-1">
+                          {formatUpdatedAt(file.updatedAtMs)}
+                        </p>
+                      </button>
+                    ))}
+                  </div>
+
+                  {selectedFileName && (
+                    <div className="space-y-2">
+                      <label className="text-sm font-medium">
+                        {t('files.editorLabel', { file: selectedFileName })}
+                      </label>
+                      {loadingFileContent ? (
+                        <div className="flex items-center gap-2 text-muted-foreground">
+                          <LoadingSpinner size="sm" />
+                          <span>{t('files.loading')}</span>
+                        </div>
+                      ) : (
+                        <Textarea
+                          value={fileContent}
+                          onChange={(event) => setFileContent(event.target.value)}
+                          rows={16}
+                          className="font-mono text-xs"
+                        />
+                      )}
+                      <div className="flex items-center gap-2">
+                        <Button
+                          onClick={handleSaveFile}
+                          disabled={!selectedFileName || savingFile || !fileDirty}
+                        >
+                          <Save className="h-4 w-4 mr-2" />
+                          {savingFile ? t('files.saving') : t('files.save')}
+                        </Button>
+                        <span className="text-xs text-muted-foreground">
+                          {fileDirty ? t('files.unsavedHint') : t('files.savedHint')}
+                        </span>
+                      </div>
+                    </div>
+                  )}
+                </>
+              )}
+            </>
+          )}
+        </CardContent>
+      </Card>
+
+      <ConfirmDialog
+        open={!!deleteCandidate}
+        title={t('confirmDelete.title')}
+        message={deleteCandidate ? t('confirmDelete.message', { id: deleteCandidate.id }) : ''}
+        confirmLabel={t('confirmDelete.confirm')}
+        cancelLabel={t('confirmDelete.cancel')}
+        variant="destructive"
+        onConfirm={() => void handleDeleteAgent()}
+        onCancel={() => setDeleteCandidate(null)}
+      />
+
+      {currentEditingAgent && (
+        <p className="text-xs text-muted-foreground">
+          {t('form.editingHint', { id: currentEditingAgent.id })}
+        </p>
+      )}
     </div>
   );
 }

--- a/src/stores/agents.ts
+++ b/src/stores/agents.ts
@@ -1,0 +1,76 @@
+import { create } from 'zustand';
+import type { AgentCreateInput, AgentRow, AgentsListResult } from '@/types/agent';
+
+type GatewayRpcResult<T> = {
+  success: boolean;
+  result?: T;
+  error?: string;
+};
+
+async function invokeGatewayRpc<T>(method: string, params?: unknown): Promise<T> {
+  const response = await window.electron.ipcRenderer.invoke(
+    'gateway:rpc',
+    method,
+    params
+  ) as GatewayRpcResult<T>;
+
+  if (!response.success) {
+    throw new Error(response.error || `RPC call failed: ${method}`);
+  }
+
+  return response.result as T;
+}
+
+interface AgentsState {
+  agents: AgentRow[];
+  defaultId: string;
+  mainKey: string;
+  scope: string;
+  loading: boolean;
+  creating: boolean;
+  error: string | null;
+  fetchAgents: () => Promise<void>;
+  createAgent: (input: AgentCreateInput) => Promise<void>;
+}
+
+export const useAgentsStore = create<AgentsState>((set, get) => ({
+  agents: [],
+  defaultId: 'main',
+  mainKey: 'main',
+  scope: 'per-sender',
+  loading: false,
+  creating: false,
+  error: null,
+
+  fetchAgents: async () => {
+    set({ loading: true, error: null });
+    try {
+      const result = await invokeGatewayRpc<AgentsListResult>('agents.list');
+      set({
+        agents: result.agents ?? [],
+        defaultId: result.defaultId ?? 'main',
+        mainKey: result.mainKey ?? 'main',
+        scope: result.scope ?? 'per-sender',
+        loading: false,
+      });
+    } catch (error) {
+      set({ error: String(error), loading: false });
+    }
+  },
+
+  createAgent: async (input) => {
+    set({ creating: true, error: null });
+    try {
+      await invokeGatewayRpc('agents.create', {
+        name: input.name,
+        workspace: input.workspace,
+        ...(input.emoji ? { emoji: input.emoji } : {}),
+      });
+      await get().fetchAgents();
+      set({ creating: false });
+    } catch (error) {
+      set({ creating: false, error: String(error) });
+      throw error;
+    }
+  },
+}));

--- a/src/stores/agents.ts
+++ b/src/stores/agents.ts
@@ -1,5 +1,17 @@
 import { create } from 'zustand';
-import type { AgentCreateInput, AgentRow, AgentsListResult } from '@/types/agent';
+import type {
+  AgentCreateInput,
+  AgentCreateResult,
+  AgentDeleteInput,
+  AgentRow,
+  AgentsFilesGetResult,
+  AgentsFilesListResult,
+  AgentsFilesSetResult,
+  AgentsListResult,
+  AgentUpdateInput,
+  ModelChoice,
+  ModelsListResult,
+} from '@/types/agent';
 
 type GatewayRpcResult<T> = {
   success: boolean;
@@ -26,11 +38,19 @@ interface AgentsState {
   defaultId: string;
   mainKey: string;
   scope: string;
+  models: ModelChoice[];
   loading: boolean;
-  creating: boolean;
+  submitting: boolean;
+  deletingAgentId: string | null;
   error: string | null;
   fetchAgents: () => Promise<void>;
-  createAgent: (input: AgentCreateInput) => Promise<void>;
+  fetchModels: () => Promise<void>;
+  createAgent: (input: AgentCreateInput) => Promise<AgentCreateResult>;
+  updateAgent: (input: AgentUpdateInput) => Promise<void>;
+  deleteAgent: (input: AgentDeleteInput) => Promise<void>;
+  listAgentFiles: (agentId: string) => Promise<AgentsFilesListResult>;
+  getAgentFile: (agentId: string, name: string) => Promise<AgentsFilesGetResult>;
+  setAgentFile: (agentId: string, name: string, content: string) => Promise<AgentsFilesSetResult>;
 }
 
 export const useAgentsStore = create<AgentsState>((set, get) => ({
@@ -38,8 +58,10 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
   defaultId: 'main',
   mainKey: 'main',
   scope: 'per-sender',
+  models: [],
   loading: false,
-  creating: false,
+  submitting: false,
+  deletingAgentId: null,
   error: null,
 
   fetchAgents: async () => {
@@ -58,19 +80,78 @@ export const useAgentsStore = create<AgentsState>((set, get) => ({
     }
   },
 
-  createAgent: async (input) => {
-    set({ creating: true, error: null });
+  fetchModels: async () => {
     try {
-      await invokeGatewayRpc('agents.create', {
+      const result = await invokeGatewayRpc<ModelsListResult>('models.list');
+      set({ models: result.models ?? [] });
+    } catch {
+      set({ models: [] });
+    }
+  },
+
+  createAgent: async (input) => {
+    set({ submitting: true, error: null });
+    try {
+      const result = await invokeGatewayRpc<AgentCreateResult>('agents.create', {
         name: input.name,
         workspace: input.workspace,
         ...(input.emoji ? { emoji: input.emoji } : {}),
+        ...(input.avatar ? { avatar: input.avatar } : {}),
       });
       await get().fetchAgents();
-      set({ creating: false });
+      set({ submitting: false });
+      return result;
     } catch (error) {
-      set({ creating: false, error: String(error) });
+      set({ submitting: false, error: String(error) });
       throw error;
     }
+  },
+
+  updateAgent: async (input) => {
+    set({ submitting: true, error: null });
+    try {
+      await invokeGatewayRpc('agents.update', {
+        agentId: input.agentId,
+        ...(input.name ? { name: input.name } : {}),
+        ...(input.workspace ? { workspace: input.workspace } : {}),
+        ...(input.model ? { model: input.model } : {}),
+      });
+      await get().fetchAgents();
+      set({ submitting: false });
+    } catch (error) {
+      set({ submitting: false, error: String(error) });
+      throw error;
+    }
+  },
+
+  deleteAgent: async (input) => {
+    set({ deletingAgentId: input.agentId, error: null });
+    try {
+      await invokeGatewayRpc('agents.delete', {
+        agentId: input.agentId,
+        deleteFiles: input.deleteFiles ?? true,
+      });
+      await get().fetchAgents();
+      set({ deletingAgentId: null });
+    } catch (error) {
+      set({ deletingAgentId: null, error: String(error) });
+      throw error;
+    }
+  },
+
+  listAgentFiles: async (agentId) => {
+    return await invokeGatewayRpc<AgentsFilesListResult>('agents.files.list', { agentId });
+  },
+
+  getAgentFile: async (agentId, name) => {
+    return await invokeGatewayRpc<AgentsFilesGetResult>('agents.files.get', { agentId, name });
+  },
+
+  setAgentFile: async (agentId, name, content) => {
+    return await invokeGatewayRpc<AgentsFilesSetResult>('agents.files.set', {
+      agentId,
+      name,
+      content,
+    });
   },
 }));

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -1,0 +1,26 @@
+export interface AgentIdentity {
+  name?: string;
+  theme?: string;
+  emoji?: string;
+  avatar?: string;
+  avatarUrl?: string;
+}
+
+export interface AgentRow {
+  id: string;
+  name?: string;
+  identity?: AgentIdentity;
+}
+
+export interface AgentsListResult {
+  defaultId: string;
+  mainKey: string;
+  scope: string;
+  agents: AgentRow[];
+}
+
+export interface AgentCreateInput {
+  name: string;
+  workspace: string;
+  emoji?: string;
+}

--- a/src/types/agent.ts
+++ b/src/types/agent.ts
@@ -15,7 +15,7 @@ export interface AgentRow {
 export interface AgentsListResult {
   defaultId: string;
   mainKey: string;
-  scope: string;
+  scope: 'per-sender' | 'global' | string;
   agents: AgentRow[];
 }
 
@@ -23,4 +23,64 @@ export interface AgentCreateInput {
   name: string;
   workspace: string;
   emoji?: string;
+  avatar?: string;
+}
+
+export interface AgentCreateResult {
+  ok: true;
+  agentId: string;
+  name: string;
+  workspace: string;
+}
+
+export interface AgentUpdateInput {
+  agentId: string;
+  name?: string;
+  workspace?: string;
+  model?: string;
+}
+
+export interface AgentDeleteInput {
+  agentId: string;
+  deleteFiles?: boolean;
+}
+
+export interface AgentFileEntry {
+  name: string;
+  path: string;
+  missing: boolean;
+  size?: number;
+  updatedAtMs?: number;
+  content?: string;
+}
+
+export interface AgentsFilesListResult {
+  agentId: string;
+  workspace: string;
+  files: AgentFileEntry[];
+}
+
+export interface AgentsFilesGetResult {
+  agentId: string;
+  workspace: string;
+  file: AgentFileEntry;
+}
+
+export interface AgentsFilesSetResult {
+  ok: true;
+  agentId: string;
+  workspace: string;
+  file: AgentFileEntry;
+}
+
+export interface ModelChoice {
+  id: string;
+  name: string;
+  provider: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+}
+
+export interface ModelsListResult {
+  models: ModelChoice[];
 }


### PR DESCRIPTION
## Linked Issues
- Closes #255
- Refs #141

## Summary
- 将 Agents 页面从 MVP 升级为**完整管理闭环**（不再要求用户回到 CLI）
- 支持多 Agent 的创建、编辑、删除、列表展示与默认/主键识别
- 支持 Agent 工作区文件管理：列出/读取/编辑/保存（如 `AGENTS.md`、`SOUL.md`、`IDENTITY.md` 等）
- 支持模型列表加载与模型字段更新
- i18n 完整补齐（en/zh/ja）并优化页面文案

## Why
Issue #255 明确提出“多agent创建希望有图形化表单，CLI 太麻烦”。
这版将该诉求扩展为可用的 UI 管理流，不再是“创建后再回 CLI 配置”的割裂体验。

## What Changed
### 1) Agent 管理能力（UI + Store + Types）
- 页面：`src/pages/Agents/index.tsx`
  - 创建 Agent（name/workspace/model/emoji/avatar）
  - 编辑 Agent（基础信息 + model）
  - 删除 Agent（含确认弹窗）
  - Agent 文件浏览与编辑器
  - 打开 Agent workspace 目录
- Store：`src/stores/agents.ts`
  - 新增 RPC 封装：`agents.update` / `agents.delete` / `agents.files.list` / `agents.files.get` / `agents.files.set` / `models.list`
- 类型：`src/types/agent.ts`
  - 补充 create/update/delete/files/models 相关类型定义

### 2) Review 反馈修复
- 修复：编辑初始化失败时可能误改 workspace
  - 当 `listAgentFiles` 失败时，进入显式错误态并阻止保存，不再回退到推导路径
- 修复：创建成功后后置步骤失败被误报“创建失败”
  - 将“创建成功”与“后置同步失败”拆分提示
  - 后置步骤失败时展示 warning + 具体错误（model 更新失败、identity 同步失败）

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`

## Notes
- 本 PR 目标是先完成多 Agent 管理的核心体验闭环。
- 更细粒度的绑定策略（如复杂 bindings/config patch UI）可在后续 PR 继续增强。
