### PR TITLE
feat(settings): add QMD memory preset controls

### DIFF
--- a/src/i18n/locales/en/settings.json
+++ b/src/i18n/locales/en/settings.json
@@ -119,6 +119,46 @@
     "proxySaved": "Proxy settings saved",
     "proxySaveFailed": "Failed to save proxy settings"
   },
+  "memory": {
+    "title": "QMD Memory",
+    "description": "Enable QMD memory retrieval with a low-token preset to reduce long-session context cost.",
+    "currentBackend": "Current Memory Backend",
+    "backendQmd": "QMD",
+    "backendBuiltin": "Builtin",
+    "backendUnknown": "Unknown",
+    "hashReady": "Config snapshot loaded. Safe to patch.",
+    "hashMissing": "No config snapshot loaded yet. Refresh first.",
+    "presetDescription": "Applying the preset updates memory.qmd and agents.defaults compaction/contextPruning values, then triggers a Gateway hot reload.",
+    "gatewayRequired": "Gateway must be running to read or patch memory config.",
+    "actions": {
+      "reload": "Reload Config",
+      "loading": "Loading...",
+      "probe": "Probe Status",
+      "probing": "Probing...",
+      "enablePreset": "Enable QMD Low-Token Preset",
+      "useBuiltin": "Switch to Builtin",
+      "saving": "Saving..."
+    },
+    "status": {
+      "title": "Memory Probe Result",
+      "agent": "Agent: {{id}}",
+      "provider": "Provider: {{provider}}",
+      "embeddingOk": "Embedding: OK",
+      "embeddingFail": "Embedding: Failed ({{reason}})",
+      "unavailable": "Unavailable"
+    },
+    "toast": {
+      "loadFailed": "Failed to load memory config",
+      "hashMissing": "Missing config hash. Reload and retry.",
+      "enabled": "QMD low-token preset enabled",
+      "enableFailed": "Failed to enable QMD preset",
+      "disabled": "Switched back to Builtin memory backend",
+      "disableFailed": "Failed to switch to Builtin backend",
+      "probeOk": "Memory probe succeeded",
+      "probeFailed": "Memory probe reported an issue: {{reason}}",
+      "probeFailedGeneric": "Memory probe failed"
+    }
+  },
   "updates": {
     "title": "Updates",
     "description": "Keep ClawX up to date",

--- a/src/i18n/locales/ja/settings.json
+++ b/src/i18n/locales/ja/settings.json
@@ -118,6 +118,46 @@
     "proxySaved": "プロキシ設定を保存しました",
     "proxySaveFailed": "プロキシ設定の保存に失敗しました"
   },
+  "memory": {
+    "title": "QMD メモリ",
+    "description": "QMD メモリ検索と低トークンプリセットを有効化し、長時間セッションのコンテキストコストを抑えます。",
+    "currentBackend": "現在のメモリバックエンド",
+    "backendQmd": "QMD",
+    "backendBuiltin": "Builtin",
+    "backendUnknown": "不明",
+    "hashReady": "設定スナップショットを読み込み済みです。安全に反映できます。",
+    "hashMissing": "設定スナップショットが未読み込みです。先に更新してください。",
+    "presetDescription": "プリセットを有効化すると、memory.qmd と agents.defaults の compaction/contextPruning を更新し、Gateway をホットリロードします。",
+    "gatewayRequired": "メモリ設定の読み書きには Gateway の起動が必要です。",
+    "actions": {
+      "reload": "設定を更新",
+      "loading": "読み込み中...",
+      "probe": "状態を検査",
+      "probing": "検査中...",
+      "enablePreset": "QMD 低トークンプリセットを有効化",
+      "useBuiltin": "Builtin に戻す",
+      "saving": "保存中..."
+    },
+    "status": {
+      "title": "メモリ検査結果",
+      "agent": "Agent: {{id}}",
+      "provider": "Provider: {{provider}}",
+      "embeddingOk": "Embedding: 正常",
+      "embeddingFail": "Embedding: 異常（{{reason}}）",
+      "unavailable": "利用不可"
+    },
+    "toast": {
+      "loadFailed": "メモリ設定の読み込みに失敗しました",
+      "hashMissing": "設定ハッシュがありません。更新して再試行してください",
+      "enabled": "QMD 低トークンプリセットを有効化しました",
+      "enableFailed": "QMD プリセットの有効化に失敗しました",
+      "disabled": "Builtin メモリバックエンドに戻しました",
+      "disableFailed": "Builtin バックエンドへの切り替えに失敗しました",
+      "probeOk": "メモリ検査に成功しました",
+      "probeFailed": "メモリ検査で問題が見つかりました: {{reason}}",
+      "probeFailedGeneric": "メモリ検査に失敗しました"
+    }
+  },
   "updates": {
     "title": "アップデート",
     "description": "ClawX を最新に保つ",

--- a/src/i18n/locales/zh/settings.json
+++ b/src/i18n/locales/zh/settings.json
@@ -119,6 +119,46 @@
     "proxySaved": "代理设置已保存",
     "proxySaveFailed": "保存代理设置失败"
   },
+  "memory": {
+    "title": "QMD 记忆系统",
+    "description": "一键启用 QMD 记忆检索和低 token 预设，减少长会话上下文成本。",
+    "currentBackend": "当前记忆后端",
+    "backendQmd": "QMD",
+    "backendBuiltin": "Builtin",
+    "backendUnknown": "未知",
+    "hashReady": "配置快照已加载，可安全写入。",
+    "hashMissing": "尚未加载配置快照，请先刷新。",
+    "presetDescription": "启用预设会写入 memory.qmd 与 agents.defaults 的 compaction/contextPruning 参数，并触发 Gateway 热重载。",
+    "gatewayRequired": "网关未运行，无法读取或写入记忆配置。",
+    "actions": {
+      "reload": "刷新配置",
+      "loading": "加载中...",
+      "probe": "探测状态",
+      "probing": "探测中...",
+      "enablePreset": "启用 QMD 低耗预设",
+      "useBuiltin": "切回 Builtin",
+      "saving": "保存中..."
+    },
+    "status": {
+      "title": "记忆探测结果",
+      "agent": "Agent: {{id}}",
+      "provider": "Provider: {{provider}}",
+      "embeddingOk": "Embedding: 正常",
+      "embeddingFail": "Embedding: 异常（{{reason}}）",
+      "unavailable": "不可用"
+    },
+    "toast": {
+      "loadFailed": "读取记忆配置失败",
+      "hashMissing": "缺少配置 hash，请先刷新后重试",
+      "enabled": "已启用 QMD 低耗预设",
+      "enableFailed": "启用 QMD 预设失败",
+      "disabled": "已切回 Builtin 记忆后端",
+      "disableFailed": "切回 Builtin 失败",
+      "probeOk": "记忆探测通过",
+      "probeFailed": "记忆探测异常：{{reason}}",
+      "probeFailedGeneric": "记忆探测失败"
+    }
+  },
   "updates": {
     "title": "更新",
     "description": "保持 ClawX 最新",

--- a/src/pages/Settings/index.tsx
+++ b/src/pages/Settings/index.tsx
@@ -2,8 +2,9 @@
  * Settings Page
  * Application configuration
  */
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import {
+  Brain,
   Sun,
   Moon,
   Monitor,
@@ -36,6 +37,26 @@ type ControlUiInfo = {
   port: number;
 };
 
+type OpenClawConfigLite = {
+  memory?: {
+    backend?: 'builtin' | 'qmd' | string;
+  };
+};
+
+type GatewayConfigSnapshot = {
+  hash?: string;
+  config?: OpenClawConfigLite;
+};
+
+type MemoryProbeStatus = {
+  agentId?: string;
+  provider?: string;
+  embedding?: {
+    ok?: boolean;
+    error?: string;
+  };
+};
+
 export function Settings() {
   const { t } = useTranslation('settings');
   const {
@@ -65,7 +86,11 @@ export function Settings() {
     setDevModeUnlocked,
   } = useSettingsStore();
 
-  const { status: gatewayStatus, restart: restartGateway } = useGatewayStore();
+  const {
+    status: gatewayStatus,
+    restart: restartGateway,
+    rpc: gatewayRpc,
+  } = useGatewayStore();
   const currentVersion = useUpdateStore((state) => state.currentVersion);
   const updateSetAutoDownload = useUpdateStore((state) => state.setAutoDownload);
   const [controlUiInfo, setControlUiInfo] = useState<ControlUiInfo | null>(null);
@@ -78,8 +103,15 @@ export function Settings() {
   const [proxyBypassRulesDraft, setProxyBypassRulesDraft] = useState('');
   const [proxyEnabledDraft, setProxyEnabledDraft] = useState(false);
   const [savingProxy, setSavingProxy] = useState(false);
+  const [memoryLoading, setMemoryLoading] = useState(false);
+  const [memorySaving, setMemorySaving] = useState(false);
+  const [memoryProbing, setMemoryProbing] = useState(false);
+  const [memorySnapshotHash, setMemorySnapshotHash] = useState<string | null>(null);
+  const [memoryBackend, setMemoryBackend] = useState<'builtin' | 'qmd' | 'unknown'>('unknown');
+  const [memoryProbeStatus, setMemoryProbeStatus] = useState<MemoryProbeStatus | null>(null);
 
   const isWindows = window.electron.platform === 'win32';
+  const isGatewayRunning = gatewayStatus.state === 'running';
   const showCliTools = true;
   const [showLogs, setShowLogs] = useState(false);
   const [logContent, setLogContent] = useState('');
@@ -258,6 +290,169 @@ export function Settings() {
       setSavingProxy(false);
     }
   };
+
+  const loadMemoryConfig = useCallback(async () => {
+    if (gatewayStatus.state !== 'running') {
+      setMemorySnapshotHash(null);
+      setMemoryBackend('unknown');
+      setMemoryProbeStatus(null);
+      return;
+    }
+
+    setMemoryLoading(true);
+    try {
+      const snapshot = await gatewayRpc<GatewayConfigSnapshot>('config.get', {});
+      setMemorySnapshotHash(typeof snapshot.hash === 'string' ? snapshot.hash : null);
+
+      const backend = snapshot.config?.memory?.backend;
+      if (backend === 'qmd' || backend === 'builtin') {
+        setMemoryBackend(backend);
+      } else {
+        setMemoryBackend('unknown');
+      }
+    } catch (error) {
+      toast.error(`${t('memory.toast.loadFailed')}: ${String(error)}`);
+    } finally {
+      setMemoryLoading(false);
+    }
+  }, [gatewayStatus.state, gatewayRpc, t]);
+
+  useEffect(() => {
+    void loadMemoryConfig();
+  }, [loadMemoryConfig]);
+
+  const probeMemoryStatus = useCallback(async (showToast = true) => {
+    if (gatewayStatus.state !== 'running') return;
+
+    setMemoryProbing(true);
+    try {
+      const status = await gatewayRpc<MemoryProbeStatus>('doctor.memory.status', {});
+      setMemoryProbeStatus(status);
+
+      if (!showToast) return;
+      if (status.embedding?.ok) {
+        toast.success(t('memory.toast.probeOk'));
+      } else {
+        toast.warning(
+          t('memory.toast.probeFailed', {
+            reason: status.embedding?.error || t('memory.status.unavailable'),
+          })
+        );
+      }
+    } catch (error) {
+      if (showToast) {
+        toast.error(`${t('memory.toast.probeFailedGeneric')}: ${String(error)}`);
+      }
+    } finally {
+      setMemoryProbing(false);
+    }
+  }, [gatewayStatus.state, gatewayRpc, t]);
+
+  const applyQmdPreset = useCallback(async () => {
+    if (gatewayStatus.state !== 'running') return;
+
+    setMemorySaving(true);
+    try {
+      const snapshot = await gatewayRpc<GatewayConfigSnapshot>('config.get', {});
+      const baseHash = typeof snapshot.hash === 'string' ? snapshot.hash : '';
+      if (!baseHash) {
+        throw new Error(t('memory.toast.hashMissing'));
+      }
+
+      const patch = {
+        memory: {
+          backend: 'qmd',
+          qmd: {
+            includeDefaultMemory: true,
+            searchMode: 'query',
+            sessions: {
+              enabled: true,
+              retentionDays: 14,
+            },
+            update: {
+              onBoot: true,
+              waitForBootSync: false,
+              interval: '30m',
+              debounceMs: 5000,
+              embedInterval: '8h',
+            },
+            limits: {
+              maxResults: 6,
+              maxSnippetChars: 240,
+              maxInjectedChars: 1800,
+              timeoutMs: 10000,
+            },
+          },
+        },
+        agents: {
+          defaults: {
+            contextPruning: {
+              mode: 'cache-ttl',
+              ttl: '1h',
+              keepLastAssistants: 2,
+              softTrimRatio: 0.35,
+              hardClearRatio: 0.7,
+            },
+            compaction: {
+              mode: 'safeguard',
+              reserveTokensFloor: 1024,
+              memoryFlush: {
+                enabled: true,
+                softThresholdTokens: 24000,
+              },
+            },
+          },
+        },
+      };
+
+      await gatewayRpc('config.patch', {
+        baseHash,
+        raw: JSON.stringify(patch),
+        note: 'clawx: enable qmd memory preset',
+        restartDelayMs: 800,
+      });
+
+      toast.success(t('memory.toast.enabled'));
+      await loadMemoryConfig();
+      await probeMemoryStatus(false);
+    } catch (error) {
+      toast.error(`${t('memory.toast.enableFailed')}: ${String(error)}`);
+    } finally {
+      setMemorySaving(false);
+    }
+  }, [gatewayStatus.state, gatewayRpc, loadMemoryConfig, probeMemoryStatus, t]);
+
+  const disableQmdPreset = useCallback(async () => {
+    if (gatewayStatus.state !== 'running') return;
+
+    setMemorySaving(true);
+    try {
+      const snapshot = await gatewayRpc<GatewayConfigSnapshot>('config.get', {});
+      const baseHash = typeof snapshot.hash === 'string' ? snapshot.hash : '';
+      if (!baseHash) {
+        throw new Error(t('memory.toast.hashMissing'));
+      }
+
+      await gatewayRpc('config.patch', {
+        baseHash,
+        raw: JSON.stringify({
+          memory: {
+            backend: 'builtin',
+          },
+        }),
+        note: 'clawx: disable qmd memory preset',
+        restartDelayMs: 800,
+      });
+
+      toast.success(t('memory.toast.disabled'));
+      await loadMemoryConfig();
+      await probeMemoryStatus(false);
+    } catch (error) {
+      toast.error(`${t('memory.toast.disableFailed')}: ${String(error)}`);
+    } finally {
+      setMemorySaving(false);
+    }
+  }, [gatewayStatus.state, gatewayRpc, loadMemoryConfig, probeMemoryStatus, t]);
 
   return (
     <div className="space-y-6 p-6">
@@ -507,6 +702,103 @@ export function Settings() {
               </Button>
             </div>
           </div>
+        </CardContent>
+      </Card>
+
+      {/* Memory */}
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Brain className="h-5 w-5" />
+            {t('memory.title')}
+          </CardTitle>
+          <CardDescription>{t('memory.description')}</CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex items-center justify-between">
+            <div>
+              <Label>{t('memory.currentBackend')}</Label>
+              <p className="text-sm text-muted-foreground">
+                {memorySnapshotHash
+                  ? t('memory.hashReady')
+                  : t('memory.hashMissing')}
+              </p>
+            </div>
+            <Badge variant={memoryBackend === 'qmd' ? 'success' : 'secondary'}>
+              {memoryBackend === 'qmd'
+                ? t('memory.backendQmd')
+                : memoryBackend === 'builtin'
+                  ? t('memory.backendBuiltin')
+                  : t('memory.backendUnknown')}
+            </Badge>
+          </div>
+
+          <div className="rounded-lg border border-border/60 bg-background/40 p-3">
+            <p className="text-sm text-muted-foreground">
+              {t('memory.presetDescription')}
+            </p>
+          </div>
+
+          <div className="flex flex-wrap items-center gap-2">
+            <Button
+              variant="outline"
+              onClick={() => void loadMemoryConfig()}
+              disabled={!isGatewayRunning || memoryLoading}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2${memoryLoading ? ' animate-spin' : ''}`} />
+              {memoryLoading ? t('memory.actions.loading') : t('memory.actions.reload')}
+            </Button>
+
+            <Button
+              variant="outline"
+              onClick={() => void probeMemoryStatus()}
+              disabled={!isGatewayRunning || memoryProbing}
+            >
+              <RefreshCw className={`h-4 w-4 mr-2${memoryProbing ? ' animate-spin' : ''}`} />
+              {memoryProbing ? t('memory.actions.probing') : t('memory.actions.probe')}
+            </Button>
+
+            <Button
+              onClick={() => void applyQmdPreset()}
+              disabled={!isGatewayRunning || memorySaving}
+            >
+              <Brain className="h-4 w-4 mr-2" />
+              {memorySaving ? t('memory.actions.saving') : t('memory.actions.enablePreset')}
+            </Button>
+
+            <Button
+              variant="outline"
+              onClick={() => void disableQmdPreset()}
+              disabled={!isGatewayRunning || memorySaving}
+            >
+              {t('memory.actions.useBuiltin')}
+            </Button>
+          </div>
+
+          {memoryProbeStatus && (
+            <div className="rounded-lg border border-border/60 bg-background/40 p-3 space-y-1">
+              <p className="text-sm font-medium">{t('memory.status.title')}</p>
+              <p className="text-xs text-muted-foreground">
+                {t('memory.status.agent', { id: memoryProbeStatus.agentId || '-' })}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {t('memory.status.provider', { provider: memoryProbeStatus.provider || '-' })}
+              </p>
+              <p className="text-xs text-muted-foreground">
+                {memoryProbeStatus.embedding?.ok
+                  ? t('memory.status.embeddingOk')
+                  : t('memory.status.embeddingFail', {
+                    reason: memoryProbeStatus.embedding?.error || t('memory.status.unavailable'),
+                  })}
+              </p>
+            </div>
+          )}
+
+          {!isGatewayRunning && (
+            <p className="text-xs text-amber-600 dark:text-amber-400">
+              {t('memory.gatewayRequired')}
+            </p>
+          )}
         </CardContent>
       </Card>
 


### PR DESCRIPTION
## Linked Issues
- Closes #249

## Summary
- Add a dedicated **QMD Memory** card in `Settings`.
- Add one-click **QMD low-token preset** action via `config.get` + `config.patch`.
- Add one-click fallback action to switch memory backend back to `builtin`.
- Add runtime memory probe action via `doctor.memory.status`.
- Add full i18n coverage for zh/en/ja.

## Why
Issue #249 asks whether ClawX supports QMD memory and highlights high token usage. This PR delivers a practical first-step UX for enabling QMD and applying conservative context controls directly from GUI.

## What this preset writes
- `memory.backend = "qmd"`
- `memory.qmd.*` basic update/session/limits defaults
- `agents.defaults.contextPruning.*`
- `agents.defaults.compaction.*` (including `memoryFlush`)

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`

## Notes
- This PR focuses on a safe, operator-friendly first version.
- Per-agent granularity and richer QMD knobs can be added in a follow-up PR.
