### PR TITLE
feat(chat): support manual session rename in sidebar

### DIFF
--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -16,6 +16,9 @@ import {
   ChevronRight,
   Terminal,
   ExternalLink,
+  Pencil,
+  Check,
+  X,
   Trash2,
 } from 'lucide-react';
 import { cn } from '@/lib/utils';
@@ -23,9 +26,11 @@ import { useSettingsStore } from '@/stores/settings';
 import { useChatStore } from '@/stores/chat';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { hostApiFetch } from '@/lib/host-api';
 import { useTranslation } from 'react-i18next';
+import { toast } from 'sonner';
 
 type SessionBucketKey =
   | 'today'
@@ -105,13 +110,14 @@ export function Sidebar() {
   const sessionLastActivity = useChatStore((s) => s.sessionLastActivity);
   const switchSession = useChatStore((s) => s.switchSession);
   const newSession = useChatStore((s) => s.newSession);
+  const renameSession = useChatStore((s) => s.renameSession);
   const deleteSession = useChatStore((s) => s.deleteSession);
 
   const navigate = useNavigate();
   const isOnChat = useLocation().pathname === '/';
 
   const getSessionLabel = (key: string, displayName?: string, label?: string) =>
-    sessionLabels[key] ?? label ?? displayName ?? key;
+    label ?? sessionLabels[key] ?? displayName ?? key;
 
   const openDevConsole = async () => {
     try {
@@ -132,6 +138,8 @@ export function Sidebar() {
 
   const { t } = useTranslation(['common', 'chat']);
   const [sessionToDelete, setSessionToDelete] = useState<{ key: string; label: string } | null>(null);
+  const [sessionToRename, setSessionToRename] = useState<{ key: string; value: string } | null>(null);
+  const [renamingSessionKey, setRenamingSessionKey] = useState<string | null>(null);
   const [nowMs, setNowMs] = useState(INITIAL_NOW_MS);
 
   useEffect(() => {
@@ -140,6 +148,32 @@ export function Sidebar() {
     }, 60 * 1000);
     return () => window.clearInterval(timer);
   }, []);
+
+  const handleStartRename = (key: string, label: string) => {
+    setSessionToRename({ key, value: label });
+  };
+
+  const handleRenameSubmit = async () => {
+    if (!sessionToRename) return;
+
+    const nextLabel = sessionToRename.value.trim();
+    if (!nextLabel) {
+      toast.error(t('sidebar.renameSessionEmpty', { ns: 'common', defaultValue: 'Session title cannot be empty' }));
+      return;
+    }
+
+    setRenamingSessionKey(sessionToRename.key);
+    try {
+      await renameSession(sessionToRename.key, nextLabel);
+      toast.success(t('sidebar.renameSessionSuccess', { ns: 'common', defaultValue: 'Session title updated' }));
+      setSessionToRename(null);
+    } catch (error) {
+      toast.error(`${t('sidebar.renameSessionFailed', { ns: 'common', defaultValue: 'Failed to rename session' })}: ${String(error)}`);
+    } finally {
+      setRenamingSessionKey(null);
+    }
+  };
+
   const sessionBuckets: Array<{ key: SessionBucketKey; label: string; sessions: typeof sessions }> = [
     { key: 'today', label: t('chat:historyBuckets.today'), sessions: [] },
     { key: 'yesterday', label: t('chat:historyBuckets.yesterday'), sessions: [] },
@@ -176,7 +210,7 @@ export function Sidebar() {
       )}
     >
       {/* Navigation */}
-      <nav className="flex-1 overflow-hidden flex flex-col p-2 gap-1">
+      <nav className="flex flex-1 flex-col gap-1 overflow-hidden p-2">
         {/* Chat nav item: acts as "New Chat" button, never highlighted as active */}
         <button
           onClick={() => {
@@ -186,7 +220,7 @@ export function Sidebar() {
           }}
           className={cn(
             'flex items-center gap-3 rounded-lg px-3 py-2 text-sm font-medium transition-colors',
-            'hover:bg-accent hover:text-accent-foreground text-muted-foreground',
+            'text-muted-foreground hover:bg-accent hover:text-accent-foreground',
             sidebarCollapsed && 'justify-center px-2',
           )}
         >
@@ -204,46 +238,119 @@ export function Sidebar() {
 
         {/* Session list — below Settings, only when expanded */}
         {!sidebarCollapsed && sessions.length > 0 && (
-          <div className="mt-1 overflow-y-auto max-h-72 space-y-0.5">
+          <div className="mt-1 max-h-72 space-y-0.5 overflow-y-auto">
             {sessionBuckets.map((bucket) => (
               bucket.sessions.length > 0 ? (
                 <div key={bucket.key} className="pt-1">
                   <div className="px-3 py-1 text-[11px] font-medium text-muted-foreground/80">
                     {bucket.label}
                   </div>
-                  {bucket.sessions.map((s) => (
-                    <div key={s.key} className="group relative flex items-center">
-                      <button
-                        onClick={() => { switchSession(s.key); navigate('/'); }}
-                        className={cn(
-                          'w-full text-left rounded-md px-3 py-1.5 text-sm truncate transition-colors pr-7',
-                          'hover:bg-accent hover:text-accent-foreground',
-                          isOnChat && currentSessionKey === s.key
-                            ? 'bg-accent/60 text-accent-foreground font-medium'
-                            : 'text-muted-foreground',
+                  {bucket.sessions.map((session) => {
+                    const isMainSession = session.key.endsWith(':main');
+                    const isEditing = sessionToRename?.key === session.key;
+                    const isSavingRename = renamingSessionKey === session.key;
+
+                    return (
+                      <div key={session.key} className="group relative flex items-center">
+                        {isEditing ? (
+                          <div className="flex w-full items-center gap-1 px-2 py-1">
+                            <Input
+                              value={sessionToRename.value}
+                              onChange={(event) => setSessionToRename((prev) => (
+                                prev ? { ...prev, value: event.target.value } : prev
+                              ))}
+                              placeholder={t('sidebar.renameSessionPlaceholder', { ns: 'common', defaultValue: 'Session title' })}
+                              className="h-8 text-sm"
+                              disabled={isSavingRename}
+                              autoFocus
+                              onKeyDown={(event) => {
+                                if (event.key === 'Enter') {
+                                  event.preventDefault();
+                                  void handleRenameSubmit();
+                                }
+                                if (event.key === 'Escape') {
+                                  event.preventDefault();
+                                  setSessionToRename(null);
+                                }
+                              }}
+                            />
+                            <button
+                              aria-label={t('sidebar.saveSessionRename', { ns: 'common', defaultValue: 'Save session title' })}
+                              onClick={() => void handleRenameSubmit()}
+                              className={cn(
+                                'flex h-7 w-7 items-center justify-center rounded transition-colors',
+                                'text-muted-foreground hover:bg-accent hover:text-primary',
+                                isSavingRename && 'opacity-60'
+                              )}
+                              disabled={isSavingRename}
+                            >
+                              <Check className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              aria-label={t('sidebar.cancelSessionRename', { ns: 'common', defaultValue: 'Cancel renaming' })}
+                              onClick={() => setSessionToRename(null)}
+                              className="flex h-7 w-7 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+                              disabled={isSavingRename}
+                            >
+                              <X className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        ) : (
+                          <>
+                            <button
+                              onClick={() => { switchSession(session.key); navigate('/'); }}
+                              className={cn(
+                                'w-full truncate rounded-md px-3 py-1.5 text-left text-sm transition-colors',
+                                isMainSession ? 'pr-7' : 'pr-12',
+                                'hover:bg-accent hover:text-accent-foreground',
+                                isOnChat && currentSessionKey === session.key
+                                  ? 'bg-accent/60 font-medium text-accent-foreground'
+                                  : 'text-muted-foreground',
+                              )}
+                            >
+                              {getSessionLabel(session.key, session.displayName, session.label)}
+                            </button>
+                            {!isMainSession && (
+                              <button
+                                aria-label={t('sidebar.renameSession', { ns: 'common', defaultValue: 'Rename session' })}
+                                onClick={(event) => {
+                                  event.stopPropagation();
+                                  handleStartRename(
+                                    session.key,
+                                    getSessionLabel(session.key, session.displayName, session.label),
+                                  );
+                                }}
+                                className={cn(
+                                  'absolute right-6 flex items-center justify-center rounded p-0.5 transition-opacity',
+                                  'opacity-0 group-hover:opacity-100',
+                                  'text-muted-foreground hover:bg-accent hover:text-primary',
+                                )}
+                              >
+                                <Pencil className="h-3.5 w-3.5" />
+                              </button>
+                            )}
+                            <button
+                              aria-label={t('sidebar.deleteSession', { ns: 'common', defaultValue: 'Delete session' })}
+                              onClick={(event) => {
+                                event.stopPropagation();
+                                setSessionToDelete({
+                                  key: session.key,
+                                  label: getSessionLabel(session.key, session.displayName, session.label),
+                                });
+                              }}
+                              className={cn(
+                                'absolute right-1 flex items-center justify-center rounded p-0.5 transition-opacity',
+                                'opacity-0 group-hover:opacity-100',
+                                'text-muted-foreground hover:bg-destructive/10 hover:text-destructive',
+                              )}
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </>
                         )}
-                      >
-                        {getSessionLabel(s.key, s.displayName, s.label)}
-                      </button>
-                      <button
-                        aria-label="Delete session"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSessionToDelete({
-                            key: s.key,
-                            label: getSessionLabel(s.key, s.displayName, s.label),
-                          });
-                        }}
-                        className={cn(
-                          'absolute right-1 flex items-center justify-center rounded p-0.5 transition-opacity',
-                          'opacity-0 group-hover:opacity-100',
-                          'text-muted-foreground hover:text-destructive hover:bg-destructive/10',
-                        )}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
-                    </div>
-                  ))}
+                      </div>
+                    );
+                  })}
                 </div>
               ) : null
             ))}
@@ -252,7 +359,7 @@ export function Sidebar() {
       </nav>
 
       {/* Footer */}
-      <div className="p-2 space-y-2">
+      <div className="space-y-2 p-2">
         {devModeUnlocked && !sidebarCollapsed && (
           <Button
             variant="ghost"
@@ -260,9 +367,9 @@ export function Sidebar() {
             className="w-full justify-start"
             onClick={openDevConsole}
           >
-            <Terminal className="h-4 w-4 mr-2" />
+            <Terminal className="mr-2 h-4 w-4" />
             {t('sidebar.devConsole')}
-            <ExternalLink className="h-3 w-3 ml-auto" />
+            <ExternalLink className="ml-auto h-3 w-3" />
           </Button>
         )}
 
@@ -283,7 +390,7 @@ export function Sidebar() {
       <ConfirmDialog
         open={!!sessionToDelete}
         title={t('common.confirm', 'Confirm')}
-        message={sessionToDelete ? t('sidebar.deleteSessionConfirm', `Delete "${sessionToDelete.label}"?`) : ''}
+        message={sessionToDelete ? t('sidebar.deleteSessionConfirm', { label: sessionToDelete.label }) : ''}
         confirmLabel={t('common.delete', 'Delete')}
         cancelLabel={t('common.cancel', 'Cancel')}
         variant="destructive"

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -7,7 +7,16 @@
         "channels": "Channels",
         "dashboard": "Dashboard",
         "settings": "Settings",
-        "devConsole": "Developer Console"
+        "devConsole": "Developer Console",
+        "renameSession": "Rename Session",
+        "deleteSession": "Delete Session",
+        "deleteSessionConfirm": "Delete \"{{label}}\"?",
+        "renameSessionPlaceholder": "Session title",
+        "saveSessionRename": "Save session title",
+        "cancelSessionRename": "Cancel renaming",
+        "renameSessionSuccess": "Session title updated",
+        "renameSessionFailed": "Failed to rename session",
+        "renameSessionEmpty": "Session title cannot be empty"
     },
     "actions": {
         "save": "Save",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -7,7 +7,16 @@
         "channels": "チャンネル",
         "dashboard": "ダッシュボード",
         "settings": "設定",
-        "devConsole": "開発者コンソール"
+        "devConsole": "開発者コンソール",
+        "renameSession": "セッション名を変更",
+        "deleteSession": "セッションを削除",
+        "deleteSessionConfirm": "「{{label}}」を削除しますか？",
+        "renameSessionPlaceholder": "セッションタイトル",
+        "saveSessionRename": "セッションタイトルを保存",
+        "cancelSessionRename": "名前変更をキャンセル",
+        "renameSessionSuccess": "セッションタイトルを更新しました",
+        "renameSessionFailed": "セッション名の変更に失敗しました",
+        "renameSessionEmpty": "セッションタイトルは空にできません"
     },
     "actions": {
         "save": "保存",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -7,7 +7,16 @@
         "channels": "频道",
         "dashboard": "仪表盘",
         "settings": "设置",
-        "devConsole": "开发者控制台"
+        "devConsole": "开发者控制台",
+        "renameSession": "重命名会话",
+        "deleteSession": "删除会话",
+        "deleteSessionConfirm": "删除“{{label}}”？",
+        "renameSessionPlaceholder": "会话标题",
+        "saveSessionRename": "保存会话标题",
+        "cancelSessionRename": "取消重命名",
+        "renameSessionSuccess": "会话标题已更新",
+        "renameSessionFailed": "重命名会话失败",
+        "renameSessionEmpty": "会话标题不能为空"
     },
     "actions": {
         "save": "保存",

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -100,6 +100,7 @@ interface ChatState {
   loadSessions: () => Promise<void>;
   switchSession: (key: string) => void;
   newSession: () => void;
+  renameSession: (key: string, label: string) => Promise<void>;
   deleteSession: (key: string) => Promise<void>;
   cleanupEmptySession: () => void;
   loadHistory: (quiet?: boolean) => Promise<void>;
@@ -993,9 +994,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
           get().loadHistory();
         }
 
-        // Background: fetch first user message for every non-main session to populate labels upfront.
+        // Background: fetch first user message for every unlabeled non-main session to populate labels upfront.
         // Uses a small limit so it's cheap; runs in parallel and doesn't block anything.
-        const sessionsToLabel = sessionsWithCurrent.filter((s) => !s.key.endsWith(':main'));
+        const sessionsToLabel = sessionsWithCurrent.filter((s) => !s.key.endsWith(':main') && !s.label);
         if (sessionsToLabel.length > 0) {
           void Promise.all(
             sessionsToLabel.map(async (session) => {
@@ -1010,8 +1011,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
                 set((s) => {
                   const next: Partial<typeof s> = {};
                   if (firstUser) {
+                    const hasExplicitLabel = s.sessions.some((entry) => entry.key === session.key && Boolean(entry.label));
                     const labelText = getMessageText(firstUser.content).trim();
-                    if (labelText) {
+                    if (labelText && !hasExplicitLabel) {
                       const truncated = labelText.length > 50 ? `${labelText.slice(0, 50)}…` : labelText;
                       next.sessionLabels = { ...s.sessionLabels, [session.key]: truncated };
                     }
@@ -1157,6 +1159,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }));
   },
 
+  renameSession: async (key: string, label: string) => {
+    const normalized = label.trim();
+    if (!normalized) {
+      throw new Error('session label cannot be empty');
+    }
+
+    await useGatewayStore.getState().rpc(
+      'sessions.patch',
+      { key, label: normalized },
+    );
+
+    set((s) => ({
+      sessions: s.sessions.map((session) => (
+        session.key === key ? { ...session, label: normalized } : session
+      )),
+      sessionLabels: { ...s.sessionLabels, [key]: normalized },
+    }));
+  },
+
   // ── Cleanup empty session on navigate away ──
 
   cleanupEmptySession: () => {
@@ -1226,7 +1247,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // Skip main sessions (key ends with ":main") — they rely on the Gateway-provided
         // displayName (e.g. the configured agent name "ClawX") instead.
         const isMainSession = currentSessionKey.endsWith(':main');
-        if (!isMainSession) {
+        const hasExplicitLabel = get().sessions.some((session) => session.key === currentSessionKey && Boolean(session.label));
+        if (!isMainSession && !hasExplicitLabel) {
           const firstUserMsg = finalMessages.find((m) => m.role === 'user');
           if (firstUserMsg) {
             const labelText = getMessageText(firstUserMsg.content).trim();
@@ -1340,9 +1362,10 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }));
 
     // Update session label with first user message text as soon as it's sent
-    const { sessionLabels, messages } = get();
+    const { sessionLabels, messages, sessions } = get();
     const isFirstMessage = !messages.slice(0, -1).some((m) => m.role === 'user');
-    if (!currentSessionKey.endsWith(':main') && isFirstMessage && !sessionLabels[currentSessionKey] && trimmed) {
+    const hasExplicitLabel = sessions.some((session) => session.key === currentSessionKey && Boolean(session.label));
+    if (!currentSessionKey.endsWith(':main') && !hasExplicitLabel && isFirstMessage && !sessionLabels[currentSessionKey] && trimmed) {
       const truncated = trimmed.length > 50 ? `${trimmed.slice(0, 50)}…` : trimmed;
       set((s) => ({ sessionLabels: { ...s.sessionLabels, [currentSessionKey]: truncated } }));
     }


### PR DESCRIPTION
## Linked Issues
- Closes #306

## Summary
- Add manual session rename flow in sidebar for non-main sessions.
- Persist renamed title via `sessions.patch` (`label`).
- Keep explicit/manual labels from being overwritten by auto-generated first-message labels.
- Prioritize backend `label` over derived local labels in sidebar rendering.
- Add zh/en/ja i18n strings for rename/delete session actions and feedback.

## Why
Users reported that session titles change automatically and cannot be manually edited, making it difficult to find prior conversations.

## Validation
- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run test`
