### PR TITLE
fix(packaging): generate valid Linux desktop entry comment

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -157,10 +157,7 @@ linux:
   maintainer: ClawX Team <public@valuecell.ai>
   vendor: ClawX
   synopsis: AI Assistant powered by OpenClaw
-  description: |
-    ClawX is a graphical AI assistant application that integrates with
-    OpenClaw Gateway to provide intelligent automation and assistance
-    across multiple messaging platforms.
+  description: ClawX is a graphical AI assistant application that integrates with OpenClaw Gateway to provide intelligent automation and assistance across multiple messaging platforms.
   desktop:
     entry:
       Name: ClawX


### PR DESCRIPTION
## Summary
Fix Linux desktop entry generation by changing `linux.description` to a single-line string in `electron-builder.yml`.

## Problem
`linux.description` was defined as a YAML multiline scalar. Packaged `.deb` could generate an invalid `/usr/share/applications/clawx.desktop` where `Comment=` is followed by raw continuation lines, breaking desktop file syntax.

Result: app may install successfully but not appear in launcher/search.

## Changes
- `electron-builder.yml`
  - Replace multiline `linux.description` with one-line description.

## Validation
- Reproduced invalid desktop file on installed `v0.1.22` (`desktop-file-validate` fails).
- With this config change, generated `Comment` value is single-line and desktop entry is valid.

Fixes #321