### PR TITLE
feat(chat): add session-level model picker

### DIFF
--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -1,26 +1,30 @@
 {
-    "gatewayNotRunning": "Gateway Not Running",
-    "gatewayRequired": "The OpenClaw Gateway needs to be running to use chat. It will start automatically, or you can start it from Settings.",
-    "welcome": {
-        "title": "ClawX Chat",
-        "subtitle": "Your AI assistant is ready. Start a conversation below.",
-        "askQuestions": "Ask Questions",
-        "askQuestionsDesc": "Get answers on any topic",
-        "creativeTasks": "Creative Tasks",
-        "creativeTasksDesc": "Writing, brainstorming, ideas"
-    },
-    "noLogs": "(No logs available yet)",
-    "toolbar": {
-        "refresh": "Refresh chat",
-        "showThinking": "Show thinking",
-        "hideThinking": "Hide thinking"
-    },
-    "historyBuckets": {
-        "today": "Today",
-        "yesterday": "Yesterday",
-        "withinWeek": "Within 1 Week",
-        "withinTwoWeeks": "Within 2 Weeks",
-        "withinMonth": "Within 1 Month",
-        "older": "Older than 1 Month"
-    }
+  "gatewayNotRunning": "Gateway Not Running",
+  "gatewayRequired": "The OpenClaw Gateway needs to be running to use chat. It will start automatically, or you can start it from Settings.",
+  "welcome": {
+    "title": "ClawX Chat",
+    "subtitle": "Your AI assistant is ready. Start a conversation below.",
+    "askQuestions": "Ask Questions",
+    "askQuestionsDesc": "Get answers on any topic",
+    "creativeTasks": "Creative Tasks",
+    "creativeTasksDesc": "Writing, brainstorming, ideas"
+  },
+  "noLogs": "(No logs available yet)",
+  "toolbar": {
+    "refresh": "Refresh chat",
+    "showThinking": "Show thinking",
+    "hideThinking": "Hide thinking",
+    "sessionModel": "Session model",
+    "sessionModelDefault": "Use agent default model",
+    "sessionModelLoading": "Loading models...",
+    "sessionModelUpdateFailed": "Failed to change session model"
+  },
+  "historyBuckets": {
+    "today": "Today",
+    "yesterday": "Yesterday",
+    "withinWeek": "Within 1 Week",
+    "withinTwoWeeks": "Within 2 Weeks",
+    "withinMonth": "Within 1 Month",
+    "older": "Older than 1 Month"
+  }
 }

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -1,26 +1,30 @@
 {
-    "gatewayNotRunning": "ゲートウェイが停止中",
-    "gatewayRequired": "チャットを使用するには OpenClaw ゲートウェイが実行されている必要があります。自動的に起動するか、設定から起動できます。",
-    "welcome": {
-        "title": "ClawX チャット",
-        "subtitle": "AI アシスタントの準備ができました。下の入力欄から会話を始めましょう。",
-        "askQuestions": "質問する",
-        "askQuestionsDesc": "あらゆるトピックについて回答を得る",
-        "creativeTasks": "クリエイティブタスク",
-        "creativeTasksDesc": "ライティング、ブレスト、アイデア"
-    },
-    "noLogs": "（ログはまだありません）",
-    "toolbar": {
-        "refresh": "チャットを更新",
-        "showThinking": "思考を表示",
-        "hideThinking": "思考を非表示"
-    },
-    "historyBuckets": {
-        "today": "今日",
-        "yesterday": "昨日",
-        "withinWeek": "1週間以内",
-        "withinTwoWeeks": "2週間以内",
-        "withinMonth": "1か月以内",
-        "older": "1か月より前"
-    }
+  "gatewayNotRunning": "ゲートウェイが停止中",
+  "gatewayRequired": "チャットを使用するには OpenClaw ゲートウェイが実行されている必要があります。自動的に起動するか、設定から起動できます。",
+  "welcome": {
+    "title": "ClawX チャット",
+    "subtitle": "AI アシスタントの準備ができました。下の入力欄から会話を始めましょう。",
+    "askQuestions": "質問する",
+    "askQuestionsDesc": "あらゆるトピックについて回答を得る",
+    "creativeTasks": "クリエイティブタスク",
+    "creativeTasksDesc": "ライティング、ブレスト、アイデア"
+  },
+  "noLogs": "（ログはまだありません）",
+  "toolbar": {
+    "refresh": "チャットを更新",
+    "showThinking": "思考を表示",
+    "hideThinking": "思考を非表示",
+    "sessionModel": "セッションモデル",
+    "sessionModelDefault": "エージェントのデフォルトモデルを使用",
+    "sessionModelLoading": "モデルを読み込み中...",
+    "sessionModelUpdateFailed": "セッションモデルの切り替えに失敗しました"
+  },
+  "historyBuckets": {
+    "today": "今日",
+    "yesterday": "昨日",
+    "withinWeek": "1週間以内",
+    "withinTwoWeeks": "2週間以内",
+    "withinMonth": "1か月以内",
+    "older": "1か月より前"
+  }
 }

--- a/src/i18n/locales/zh/chat.json
+++ b/src/i18n/locales/zh/chat.json
@@ -1,26 +1,30 @@
 {
-    "gatewayNotRunning": "网关未运行",
-    "gatewayRequired": "OpenClaw 网关需要运行才能使用聊天。它将自动启动，或者您可以从设置中启动。",
-    "welcome": {
-        "title": "ClawX 聊天",
-        "subtitle": "您的 AI 助手已就绪。在下方开始对话。",
-        "askQuestions": "提问",
-        "askQuestionsDesc": "获取任何话题的答案",
-        "creativeTasks": "创意任务",
-        "creativeTasksDesc": "写作、头脑风暴、创意"
-    },
-    "noLogs": "（暂无日志）",
-    "toolbar": {
-        "refresh": "刷新聊天",
-        "showThinking": "显示思考过程",
-        "hideThinking": "隐藏思考过程"
-    },
-    "historyBuckets": {
-        "today": "今天",
-        "yesterday": "昨天",
-        "withinWeek": "一周内",
-        "withinTwoWeeks": "两周内",
-        "withinMonth": "一个月内",
-        "older": "一个月之前"
-    }
+  "gatewayNotRunning": "网关未运行",
+  "gatewayRequired": "OpenClaw 网关需要运行才能使用聊天。它将自动启动，或者您可以从设置中启动。",
+  "welcome": {
+    "title": "ClawX 聊天",
+    "subtitle": "您的 AI 助手已就绪。在下方开始对话。",
+    "askQuestions": "提问",
+    "askQuestionsDesc": "获取任何话题的答案",
+    "creativeTasks": "创意任务",
+    "creativeTasksDesc": "写作、头脑风暴、创意"
+  },
+  "noLogs": "（暂无日志）",
+  "toolbar": {
+    "refresh": "刷新聊天",
+    "showThinking": "显示思考过程",
+    "hideThinking": "隐藏思考过程",
+    "sessionModel": "会话模型",
+    "sessionModelDefault": "跟随 Agent 默认模型",
+    "sessionModelLoading": "正在加载模型列表...",
+    "sessionModelUpdateFailed": "切换会话模型失败"
+  },
+  "historyBuckets": {
+    "today": "今天",
+    "yesterday": "昨天",
+    "withinWeek": "一周内",
+    "withinTwoWeeks": "两周内",
+    "withinMonth": "一个月内",
+    "older": "一个月之前"
+  }
 }

--- a/src/pages/Chat/ChatToolbar.tsx
+++ b/src/pages/Chat/ChatToolbar.tsx
@@ -1,25 +1,96 @@
 /**
  * Chat Toolbar
- * Session selector, new session, refresh, and thinking toggle.
+ * Session model selector, refresh, and thinking toggle.
  * Rendered in the Header when on the Chat page.
  */
-import { RefreshCw, Brain } from 'lucide-react';
+import { useEffect, type ChangeEvent } from 'react';
+import { RefreshCw, Brain, Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
+import { Select } from '@/components/ui/select';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { toUserMessage } from '@/lib/api-client';
 import { useChatStore } from '@/stores/chat';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 
+const DEFAULT_MODEL_VALUE = '__agent_default__';
+
+function buildModelValue(provider?: string, model?: string): string {
+  if (!provider || !model) return DEFAULT_MODEL_VALUE;
+  return `${provider}/${model}`;
+}
+
+function formatModelOptionLabel(name: string, provider: string): string {
+  return `${name} · ${provider}`;
+}
+
 export function ChatToolbar() {
   const refresh = useChatStore((s) => s.refresh);
   const loading = useChatStore((s) => s.loading);
+  const sending = useChatStore((s) => s.sending);
   const showThinking = useChatStore((s) => s.showThinking);
   const toggleThinking = useChatStore((s) => s.toggleThinking);
+  const currentSessionKey = useChatStore((s) => s.currentSessionKey);
+  const currentSession = useChatStore((s) => s.sessions.find((session) => session.key === currentSessionKey));
+  const sessionModelOptions = useChatStore((s) => s.sessionModelOptions);
+  const sessionModelLoading = useChatStore((s) => s.sessionModelLoading);
+  const sessionModelSaving = useChatStore((s) => s.sessionModelSaving);
+  const loadSessionModelOptions = useChatStore((s) => s.loadSessionModelOptions);
+  const updateCurrentSessionModel = useChatStore((s) => s.updateCurrentSessionModel);
   const { t } = useTranslation('chat');
+
+  useEffect(() => {
+    void loadSessionModelOptions();
+  }, [loadSessionModelOptions]);
+
+  const currentModelValue = buildModelValue(currentSession?.modelProvider, currentSession?.model);
+  const hasCurrentModelOption = currentModelValue === DEFAULT_MODEL_VALUE
+    || sessionModelOptions.some((option) => option.value === currentModelValue);
+  const currentModelFallbackLabel = currentSession?.model && currentSession?.modelProvider
+    ? formatModelOptionLabel(currentSession.model, currentSession.modelProvider)
+    : null;
+  const disableModelSelect = sending || sessionModelSaving || (sessionModelLoading && sessionModelOptions.length === 0);
+
+  const handleModelChange = async (event: ChangeEvent<HTMLSelectElement>) => {
+    const nextValue = event.target.value;
+    try {
+      await updateCurrentSessionModel(nextValue === DEFAULT_MODEL_VALUE ? null : nextValue);
+    } catch (error) {
+      toast.error(`${t('toolbar.sessionModelUpdateFailed')}: ${toUserMessage(error)}`);
+    }
+  };
 
   return (
     <div className="flex items-center gap-2">
-      {/* Refresh */}
+      <Select
+        aria-label={t('toolbar.sessionModel')}
+        className="h-8 min-w-[220px] max-w-[320px] text-xs"
+        value={currentModelValue}
+        onChange={handleModelChange}
+        disabled={disableModelSelect}
+        title={currentModelValue === DEFAULT_MODEL_VALUE
+          ? t('toolbar.sessionModelDefault')
+          : currentModelFallbackLabel || currentModelValue}
+      >
+        <option value={DEFAULT_MODEL_VALUE}>{t('toolbar.sessionModelDefault')}</option>
+        {!hasCurrentModelOption && currentModelFallbackLabel ? (
+          <option value={currentModelValue}>{currentModelFallbackLabel}</option>
+        ) : null}
+        {sessionModelLoading && sessionModelOptions.length === 0 ? (
+          <option value={DEFAULT_MODEL_VALUE} disabled>{t('toolbar.sessionModelLoading')}</option>
+        ) : null}
+        {sessionModelOptions.map((option) => (
+          <option key={option.value} value={option.value}>
+            {formatModelOptionLabel(option.name, option.provider)}
+          </option>
+        ))}
+      </Select>
+
+      {(sessionModelLoading || sessionModelSaving) ? (
+        <Loader2 className="h-4 w-4 animate-spin text-muted-foreground" />
+      ) : null}
+
       <Tooltip>
         <TooltipTrigger asChild>
           <Button
@@ -37,7 +108,6 @@ export function ChatToolbar() {
         </TooltipContent>
       </Tooltip>
 
-      {/* Thinking Toggle */}
       <Tooltip>
         <TooltipTrigger asChild>
           <Button

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -55,6 +55,17 @@ export interface ChatSession {
   displayName?: string;
   thinkingLevel?: string;
   model?: string;
+  modelProvider?: string;
+}
+
+export interface SessionModelOption {
+  value: string;
+  id: string;
+  name: string;
+  provider: string;
+  contextWindow?: number;
+  reasoning?: boolean;
+  input?: Array<'text' | 'image'>;
 }
 
 export interface ToolStatus {
@@ -91,6 +102,9 @@ interface ChatState {
   sessionLabels: Record<string, string>;
   /** Last message timestamp (ms) per session key, used for sorting */
   sessionLastActivity: Record<string, number>;
+  sessionModelOptions: SessionModelOption[];
+  sessionModelLoading: boolean;
+  sessionModelSaving: boolean;
 
   // Thinking
   showThinking: boolean;
@@ -98,6 +112,8 @@ interface ChatState {
 
   // Actions
   loadSessions: () => Promise<void>;
+  loadSessionModelOptions: (force?: boolean) => Promise<void>;
+  updateCurrentSessionModel: (model: string | null) => Promise<void>;
   switchSession: (key: string) => void;
   newSession: () => void;
   deleteSession: (key: string) => Promise<void>;
@@ -121,6 +137,15 @@ let _lastChatEventAt = 0;
 function toMs(ts: number): number {
   // Timestamps < 1e12 are in seconds (before ~2033); >= 1e12 are milliseconds
   return ts < 1e12 ? ts * 1000 : ts;
+}
+
+function renameRecordKey<T>(record: Record<string, T>, from: string, to: string): Record<string, T> {
+  if (from === to || !Object.prototype.hasOwnProperty.call(record, from)) return record;
+  const next = { ...record };
+  const value = next[from];
+  delete next[from];
+  next[to] = value;
+  return next;
 }
 
 // Timer for fallback history polling during active sends.
@@ -925,6 +950,9 @@ export const useChatStore = create<ChatState>((set, get) => ({
   currentSessionKey: DEFAULT_SESSION_KEY,
   sessionLabels: {},
   sessionLastActivity: {},
+  sessionModelOptions: [],
+  sessionModelLoading: false,
+  sessionModelSaving: false,
 
   showThinking: true,
   thinkingLevel: null,
@@ -942,6 +970,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
           displayName: s.displayName ? String(s.displayName) : undefined,
           thinkingLevel: s.thinkingLevel ? String(s.thinkingLevel) : undefined,
           model: s.model ? String(s.model) : undefined,
+          modelProvider: s.modelProvider ? String(s.modelProvider) : undefined,
         })).filter((s: ChatSession) => s.key);
 
         const canonicalBySuffix = new Map<string, string>();
@@ -1028,6 +1057,134 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
     } catch (err) {
       console.warn('Failed to load sessions:', err);
+    }
+  },
+
+  loadSessionModelOptions: async (force = false) => {
+    const { sessionModelOptions, sessionModelLoading } = get();
+    if (sessionModelLoading) return;
+    if (!force && sessionModelOptions.length > 0) return;
+
+    set({ sessionModelLoading: true });
+    try {
+      const result = await invokeIpc(
+        'gateway:rpc',
+        'models.list',
+        {},
+      ) as { success: boolean; result?: Record<string, unknown>; error?: string };
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to load session models');
+      }
+
+      const rawModels = Array.isArray(result.result?.models) ? result.result.models : [];
+      const seen = new Set<string>();
+      const nextOptions: SessionModelOption[] = rawModels.flatMap((entry) => {
+        if (!entry || typeof entry !== 'object') return [];
+        const model = entry as Record<string, unknown>;
+        const provider = typeof model.provider === 'string' ? model.provider.trim() : '';
+        const id = typeof model.id === 'string' ? model.id.trim() : '';
+        if (!provider || !id) return [];
+
+        const value = `${provider}/${id}`;
+        if (seen.has(value)) return [];
+        seen.add(value);
+
+        const input = Array.isArray(model.input)
+          ? model.input.filter((item): item is 'text' | 'image' => item === 'text' || item === 'image')
+          : undefined;
+
+        return [{
+          value,
+          provider,
+          id,
+          name: typeof model.name === 'string' && model.name.trim() ? model.name.trim() : id,
+          contextWindow: typeof model.contextWindow === 'number' && Number.isFinite(model.contextWindow)
+            ? model.contextWindow
+            : undefined,
+          reasoning: typeof model.reasoning === 'boolean' ? model.reasoning : undefined,
+          input: input && input.length > 0 ? input : undefined,
+        }];
+      });
+
+      set({ sessionModelOptions: nextOptions, sessionModelLoading: false });
+    } catch (err) {
+      console.warn('Failed to load session models:', err);
+      set({ sessionModelLoading: false });
+    }
+  },
+
+  updateCurrentSessionModel: async (model) => {
+    const { currentSessionKey } = get();
+    if (!currentSessionKey) return;
+
+    set({ sessionModelSaving: true });
+    try {
+      const result = await invokeIpc(
+        'gateway:rpc',
+        'sessions.patch',
+        { key: currentSessionKey, model },
+      ) as {
+        success: boolean;
+        result?: {
+          key?: string;
+          resolved?: {
+            model?: string;
+            modelProvider?: string;
+          };
+        };
+        error?: string;
+      };
+
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to update session model');
+      }
+
+      const resolvedKey = typeof result.result?.key === 'string' && result.result.key.trim()
+        ? result.result.key.trim()
+        : currentSessionKey;
+      const resolvedModel = typeof result.result?.resolved?.model === 'string' && result.result.resolved.model.trim()
+        ? result.result.resolved.model.trim()
+        : undefined;
+      const resolvedModelProvider = typeof result.result?.resolved?.modelProvider === 'string' && result.result.resolved.modelProvider.trim()
+        ? result.result.resolved.modelProvider.trim()
+        : undefined;
+
+      set((s) => {
+        const currentSession = s.sessions.find((session) => session.key === currentSessionKey || session.key === resolvedKey);
+        const nextSession: ChatSession = currentSession
+          ? {
+              ...currentSession,
+              key: resolvedKey,
+              model: resolvedModel,
+              modelProvider: resolvedModelProvider,
+            }
+          : {
+              key: resolvedKey,
+              displayName: resolvedKey,
+              model: resolvedModel,
+              modelProvider: resolvedModelProvider,
+            };
+
+        const nextSessions = s.sessions.some((session) => session.key === currentSessionKey || session.key === resolvedKey)
+          ? s.sessions.map((session) => (
+            session.key === currentSessionKey || session.key === resolvedKey
+              ? nextSession
+              : session
+          ))
+          : [...s.sessions, nextSession];
+
+        return {
+          currentSessionKey: resolvedKey,
+          sessions: nextSessions,
+          sessionLabels: renameRecordKey(s.sessionLabels, currentSessionKey, resolvedKey),
+          sessionLastActivity: renameRecordKey(s.sessionLastActivity, currentSessionKey, resolvedKey),
+        };
+      });
+
+      await get().loadSessions();
+    } finally {
+      set({ sessionModelSaving: false });
     }
   },
 
@@ -1797,8 +1954,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
   // ── Refresh: reload history + sessions ──
 
   refresh: async () => {
-    const { loadHistory, loadSessions } = get();
-    await Promise.all([loadHistory(), loadSessions()]);
+    const { loadHistory, loadSessions, loadSessionModelOptions } = get();
+    await Promise.all([loadHistory(), loadSessions(), loadSessionModelOptions(true)]);
   },
 
   clearError: () => set({ error: null }),

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1067,17 +1067,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     set({ sessionModelLoading: true });
     try {
-      const result = await invokeIpc(
-        'gateway:rpc',
+      const data = await useGatewayStore.getState().rpc<Record<string, unknown>>(
         'models.list',
         {},
-      ) as { success: boolean; result?: Record<string, unknown>; error?: string };
+      );
 
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to load session models');
-      }
-
-      const rawModels = Array.isArray(result.result?.models) ? result.result.models : [];
+      const rawModels = Array.isArray(data?.models) ? data.models : [];
       const seen = new Set<string>();
       const nextOptions: SessionModelOption[] = rawModels.flatMap((entry) => {
         if (!entry || typeof entry !== 'object') return [];
@@ -1120,34 +1115,25 @@ export const useChatStore = create<ChatState>((set, get) => ({
 
     set({ sessionModelSaving: true });
     try {
-      const result = await invokeIpc(
-        'gateway:rpc',
+      const result = await useGatewayStore.getState().rpc<{
+        key?: string;
+        resolved?: {
+          model?: string;
+          modelProvider?: string;
+        };
+      }>(
         'sessions.patch',
         { key: currentSessionKey, model },
-      ) as {
-        success: boolean;
-        result?: {
-          key?: string;
-          resolved?: {
-            model?: string;
-            modelProvider?: string;
-          };
-        };
-        error?: string;
-      };
+      );
 
-      if (!result.success) {
-        throw new Error(result.error || 'Failed to update session model');
-      }
-
-      const resolvedKey = typeof result.result?.key === 'string' && result.result.key.trim()
-        ? result.result.key.trim()
+      const resolvedKey = typeof result?.key === 'string' && result.key.trim()
+        ? result.key.trim()
         : currentSessionKey;
-      const resolvedModel = typeof result.result?.resolved?.model === 'string' && result.result.resolved.model.trim()
-        ? result.result.resolved.model.trim()
+      const resolvedModel = typeof result?.resolved?.model === 'string' && result.resolved.model.trim()
+        ? result.resolved.model.trim()
         : undefined;
-      const resolvedModelProvider = typeof result.result?.resolved?.modelProvider === 'string' && result.result.resolved.modelProvider.trim()
-        ? result.result.resolved.modelProvider.trim()
+      const resolvedModelProvider = typeof result?.resolved?.modelProvider === 'string' && result.resolved.modelProvider.trim()
+        ? result.resolved.modelProvider.trim()
         : undefined;
 
       set((s) => {

--- a/tests/unit/chat-store-session-model.test.ts
+++ b/tests/unit/chat-store-session-model.test.ts
@@ -1,0 +1,181 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { invokeIpcMock } = vi.hoisted(() => ({
+  invokeIpcMock: vi.fn(),
+}));
+
+vi.mock('@/lib/api-client', () => ({
+  invokeIpc: invokeIpcMock,
+}));
+
+import { useChatStore } from '@/stores/chat';
+
+const DEFAULT_SESSION_KEY = 'agent:main:main';
+
+function resetChatStore(): void {
+  useChatStore.setState({
+    messages: [],
+    loading: false,
+    error: null,
+    sending: false,
+    activeRunId: null,
+    streamingText: '',
+    streamingMessage: null,
+    streamingTools: [],
+    pendingFinal: false,
+    lastUserMessageAt: null,
+    pendingToolImages: [],
+    sessions: [],
+    currentSessionKey: DEFAULT_SESSION_KEY,
+    sessionLabels: {},
+    sessionLastActivity: {},
+    sessionModelOptions: [],
+    sessionModelLoading: false,
+    sessionModelSaving: false,
+    showThinking: true,
+    thinkingLevel: null,
+  });
+}
+
+describe('chat store session model actions', () => {
+  beforeEach(() => {
+    invokeIpcMock.mockReset();
+    resetChatStore();
+  });
+
+  it('loads and normalizes session model options from models.list', async () => {
+    invokeIpcMock.mockResolvedValueOnce({
+      success: true,
+      result: {
+        models: [
+          {
+            provider: 'openai-codex',
+            id: 'gpt-5.3-codex',
+            name: 'GPT-5.3 Codex',
+            contextWindow: 400000,
+            reasoning: true,
+            input: ['text', 'image'],
+          },
+          {
+            provider: 'openai-codex',
+            id: 'gpt-5.3-codex',
+            name: 'GPT-5.3 Codex Duplicate',
+          },
+          {
+            provider: '',
+            id: 'ignored-model',
+          },
+        ],
+      },
+    });
+
+    await useChatStore.getState().loadSessionModelOptions();
+
+    expect(invokeIpcMock).toHaveBeenCalledWith('gateway:rpc', 'models.list', {});
+    expect(useChatStore.getState().sessionModelOptions).toEqual([
+      {
+        value: 'openai-codex/gpt-5.3-codex',
+        provider: 'openai-codex',
+        id: 'gpt-5.3-codex',
+        name: 'GPT-5.3 Codex',
+        contextWindow: 400000,
+        reasoning: true,
+        input: ['text', 'image'],
+      },
+    ]);
+    expect(useChatStore.getState().sessionModelLoading).toBe(false);
+  });
+
+  it('updates the current session model and reloads session metadata', async () => {
+    useChatStore.setState({
+      currentSessionKey: 'agent:main:session-1',
+      sessions: [{ key: 'agent:main:session-1', displayName: 'Session 1' }],
+    });
+
+    invokeIpcMock
+      .mockResolvedValueOnce({
+        success: true,
+        result: {
+          key: 'agent:main:session-1',
+          resolved: {
+            model: 'gpt-5.3-codex',
+            modelProvider: 'openai-codex',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        result: {
+          sessions: [
+            {
+              key: 'agent:main:session-1',
+              displayName: 'Session 1',
+              model: 'gpt-5.3-codex',
+              modelProvider: 'openai-codex',
+            },
+          ],
+        },
+      });
+
+    await useChatStore.getState().updateCurrentSessionModel('openai-codex/gpt-5.3-codex');
+
+    expect(invokeIpcMock).toHaveBeenNthCalledWith(1, 'gateway:rpc', 'sessions.patch', {
+      key: 'agent:main:session-1',
+      model: 'openai-codex/gpt-5.3-codex',
+    });
+    expect(invokeIpcMock).toHaveBeenNthCalledWith(2, 'gateway:rpc', 'sessions.list', {});
+    expect(useChatStore.getState().sessions).toEqual([
+      {
+        key: 'agent:main:session-1',
+        displayName: 'Session 1',
+        model: 'gpt-5.3-codex',
+        modelProvider: 'openai-codex',
+      },
+    ]);
+    expect(useChatStore.getState().sessionModelSaving).toBe(false);
+  });
+
+  it('preserves local label and activity maps when the patched key is canonicalized', async () => {
+    useChatStore.setState({
+      currentSessionKey: 'session-2',
+      sessions: [{ key: 'session-2', displayName: 'Session 2', model: 'old-model', modelProvider: 'openai' }],
+      sessionLabels: { 'session-2': 'Pinned label' },
+      sessionLastActivity: { 'session-2': 1700000000000 },
+    });
+
+    invokeIpcMock
+      .mockResolvedValueOnce({
+        success: true,
+        result: {
+          key: 'agent:main:session-2',
+          resolved: {
+            model: 'claude-opus-4.6',
+            modelProvider: 'anthropic',
+          },
+        },
+      })
+      .mockResolvedValueOnce({
+        success: true,
+        result: {
+          sessions: [
+            {
+              key: 'agent:main:session-2',
+              displayName: 'Session 2',
+              model: 'claude-opus-4.6',
+              modelProvider: 'anthropic',
+            },
+          ],
+        },
+      });
+
+    await useChatStore.getState().updateCurrentSessionModel(null);
+
+    expect(invokeIpcMock).toHaveBeenNthCalledWith(1, 'gateway:rpc', 'sessions.patch', {
+      key: 'session-2',
+      model: null,
+    });
+    expect(useChatStore.getState().currentSessionKey).toBe('agent:main:session-2');
+    expect(useChatStore.getState().sessionLabels).toEqual({ 'agent:main:session-2': 'Pinned label' });
+    expect(useChatStore.getState().sessionLastActivity).toEqual({ 'agent:main:session-2': 1700000000000 });
+  });
+});

--- a/tests/unit/chat-store-session-model.test.ts
+++ b/tests/unit/chat-store-session-model.test.ts
@@ -71,7 +71,7 @@ describe('chat store session model actions', () => {
 
     await useChatStore.getState().loadSessionModelOptions();
 
-    expect(invokeIpcMock).toHaveBeenCalledWith('gateway:rpc', 'models.list', {});
+    expect(invokeIpcMock).toHaveBeenCalledWith('gateway:rpc', 'models.list', {}, undefined);
     expect(useChatStore.getState().sessionModelOptions).toEqual([
       {
         value: 'openai-codex/gpt-5.3-codex',
@@ -122,8 +122,8 @@ describe('chat store session model actions', () => {
     expect(invokeIpcMock).toHaveBeenNthCalledWith(1, 'gateway:rpc', 'sessions.patch', {
       key: 'agent:main:session-1',
       model: 'openai-codex/gpt-5.3-codex',
-    });
-    expect(invokeIpcMock).toHaveBeenNthCalledWith(2, 'gateway:rpc', 'sessions.list', {});
+    }, undefined);
+    expect(invokeIpcMock).toHaveBeenNthCalledWith(2, 'gateway:rpc', 'sessions.list', {}, undefined);
     expect(useChatStore.getState().sessions).toEqual([
       {
         key: 'agent:main:session-1',
@@ -173,7 +173,7 @@ describe('chat store session model actions', () => {
     expect(invokeIpcMock).toHaveBeenNthCalledWith(1, 'gateway:rpc', 'sessions.patch', {
       key: 'session-2',
       model: null,
-    });
+    }, undefined);
     expect(useChatStore.getState().currentSessionKey).toBe('agent:main:session-2');
     expect(useChatStore.getState().sessionLabels).toEqual({ 'agent:main:session-2': 'Pinned label' });
     expect(useChatStore.getState().sessionLastActivity).toEqual({ 'agent:main:session-2': 1700000000000 });


### PR DESCRIPTION
## Summary / 摘要

This PR adds a session-level model picker to the chat toolbar.
Users can switch the current session to another allowed model, or reset it back to the agent default model without leaving the chat view.

这个 PR 为聊天工具栏增加了“会话级模型选择”。
用户可以直接在当前会话里切换到其他允许的模型，或者一键恢复为 agent 默认模型，而不需要离开聊天页面。

## What Changed / 改动内容

- Added session model option loading in the chat store via `models.list`
- Added current-session model update flow via `sessions.patch`
- Synced `model` and `modelProvider` metadata back into the current session state
- Added a compact model selector to `ChatToolbar`
- Added zh/en/ja i18n strings for the new UI
- Added unit tests for model option normalization and session metadata updates

- 在 chat store 中接入 `models.list`，加载可选模型目录
- 在 chat store 中接入 `sessions.patch`，更新当前会话模型
- 把 `model` / `modelProvider` 同步回当前会话状态，保证选中态稳定
- 在 `ChatToolbar` 中增加紧凑的模型选择器
- 补充中英日三套文案
- 增加单测，覆盖模型列表解析与会话元数据更新

## Scope / 范围说明

This PR intentionally only covers the session-level model picker part discussed in #339.
It does not include agent switching during new session creation, backup/restore, or broader multi-agent workflow changes.

这个 PR 有意只覆盖 #339 中“会话级模型选择”这一子项。
不包含“新建会话时切换 agent”、备份恢复、或更大范围的多 agent 工作流改动。

## Testing / 验证

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test`

Related to #339
