### PR TITLE
fix(win-installer): preserve user PATH during uninstall/upgrade

### DIFF
--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -263,7 +263,8 @@ Function un._ci_StrReplace
   StrCpy $R2 0
 
   _usr_loop:
-    IntCmp $R2 $R4 _usr_done _usr_done
+    ; IntCmp jumps are: equal, less, greater. Keep scanning while $R2 < $R4.
+    IntCmp $R2 $R4 _usr_done 0 _usr_done
     StrCpy $1 $R1 $R3 $R2
     StrCmp $1 $R0 _usr_found
     StrCpy $1 $R1 1 $R2


### PR DESCRIPTION
## Summary
- fix the NSIS uninstaller PATH removal loop so it scans the full user PATH instead of bailing out immediately
- preserve existing user PATH entries during uninstall/upgrade on Windows
- add an inline comment explaining the `IntCmp` jump order to avoid regressions

Fixes #351.

## Root cause
`un._ci_StrReplace` used:

```nsh
IntCmp $R2 $R4 _usr_done _usr_done
```

In NSIS, `IntCmp` jump order is: equal, less, greater.
That means the loop exited immediately for any non-empty haystack because `$R2` starts at `0` and `$R4` is the haystack length.

During upgrade, the uninstall phase therefore returned an empty PATH after trying to remove `"$INSTDIR\\resources\\cli"`, which then caused the uninstaller to delete the whole user `Path` registry value before the new installer re-added only ClawX's CLI entry.

## Validation
- traced the Windows installer/uninstaller PATH flow in `scripts/installer.nsh`
- confirmed the broken `IntCmp` branch order matches the reported symptom in #351
- `makensis` is not available in this environment, so I could not run a local NSIS compile check
