### PR TITLE
feat(tray): 添加系统托盘多语言支持

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -7,7 +7,7 @@ import type { Server } from 'node:http';
 import { join } from 'path';
 import { GatewayManager } from '../gateway/manager';
 import { registerIpcHandlers } from './ipc-handlers';
-import { createTray } from './tray';
+import { createTray, updateTrayStatus } from './tray';
 import { createMenu } from './menu';
 
 import { appUpdater, registerUpdateHandlers } from './updater';
@@ -236,6 +236,7 @@ async function initialize(): Promise<void> {
   // renderer subscribers observe the full startup lifecycle.
   gatewayManager.on('status', (status: { state: string }) => {
     hostEventBus.emit('gateway:status', status);
+    updateTrayStatus(status.state);
     if (status.state === 'running') {
       void ensureClawXContext().catch((error) => {
         logger.warn('Failed to re-merge ClawX context after gateway reconnect:', error);

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -51,6 +51,7 @@ import {
 } from '../services/providers/provider-runtime-sync';
 import { validateApiKeyWithProvider } from '../services/providers/provider-validation';
 import { appUpdater } from './updater';
+import { updateTrayMenu, type TrayTranslations } from './tray';
 import { PORTS } from '../utils/config';
 
 type AppRequest = {
@@ -2268,6 +2269,11 @@ function registerSettingsHandlers(gatewayManager: GatewayManager): void {
     const settings = await getAllSettings();
     await handleProxySettingsChange();
     return { success: true, settings };
+  });
+
+  ipcMain.handle('tray:updateLanguage', async (_, translations: TrayTranslations, gatewayRunning: boolean) => {
+    updateTrayMenu(translations, gatewayRunning);
+    return { success: true };
   });
 }
 function registerUsageHandlers(): void {

--- a/electron/main/tray.ts
+++ b/electron/main/tray.ts
@@ -6,6 +6,39 @@ import { Tray, Menu, BrowserWindow, app, nativeImage } from 'electron';
 import { join } from 'path';
 
 let tray: Tray | null = null;
+let mainWindowRef: BrowserWindow | null = null;
+
+export interface TrayTranslations {
+  tooltipRunning: string;
+  tooltipStopped: string;
+  show: string;
+  gatewayStatus: string;
+  running: string;
+  stopped: string;
+  quickActions: string;
+  openDashboard: string;
+  openChat: string;
+  openSettings: string;
+  checkUpdates: string;
+  quit: string;
+}
+
+const defaultTranslations: TrayTranslations = {
+  tooltipRunning: 'ClawX - Gateway Running',
+  tooltipStopped: 'ClawX - Gateway Stopped',
+  show: 'Show ClawX',
+  gatewayStatus: 'Gateway Status',
+  running: 'Running',
+  stopped: 'Stopped',
+  quickActions: 'Quick Actions',
+  openDashboard: 'Open Dashboard',
+  openChat: 'Open Chat',
+  openSettings: 'Open Settings',
+  checkUpdates: 'Check for Updates...',
+  quit: 'Quit ClawX',
+};
+
+let currentTranslations: TrayTranslations = defaultTranslations;
 
 /**
  * Resolve the icons directory path (works in both dev and packaged mode)
@@ -17,10 +50,92 @@ function getIconsDir(): string {
   return join(__dirname, '../../resources/icons');
 }
 
+function buildContextMenu(translations: TrayTranslations, gatewayRunning: boolean): Electron.Menu {
+  const showWindow = () => {
+    if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+    mainWindowRef.show();
+    mainWindowRef.focus();
+  };
+
+  return Menu.buildFromTemplate([
+    {
+      label: translations.show,
+      click: showWindow,
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: translations.gatewayStatus,
+      enabled: false,
+    },
+    {
+      label: `  ${gatewayRunning ? translations.running : translations.stopped}`,
+      type: 'checkbox',
+      checked: gatewayRunning,
+      enabled: false,
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: translations.quickActions,
+      submenu: [
+        {
+          label: translations.openDashboard,
+          click: () => {
+            if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+            mainWindowRef.show();
+            mainWindowRef.webContents.send('navigate', '/');
+          },
+        },
+        {
+          label: translations.openChat,
+          click: () => {
+            if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+            mainWindowRef.show();
+            mainWindowRef.webContents.send('navigate', '/chat');
+          },
+        },
+        {
+          label: translations.openSettings,
+          click: () => {
+            if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+            mainWindowRef.show();
+            mainWindowRef.webContents.send('navigate', '/settings');
+          },
+        },
+      ],
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: translations.checkUpdates,
+      click: () => {
+        if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+        mainWindowRef.webContents.send('update:check');
+      },
+    },
+    {
+      type: 'separator',
+    },
+    {
+      label: translations.quit,
+      click: () => {
+        app.quit();
+      },
+    },
+  ]);
+}
+
 /**
  * Create system tray icon and menu
  */
 export function createTray(mainWindow: BrowserWindow): Tray {
+  // Store window reference for later use
+  mainWindowRef = mainWindow;
+
   // Use platform-appropriate icon for system tray
   const iconsDir = getIconsDir();
   let iconPath: string;
@@ -56,117 +171,59 @@ export function createTray(mainWindow: BrowserWindow): Tray {
   
   tray = new Tray(icon);
   
-  // Set tooltip
-  tray.setToolTip('ClawX - AI Assistant');
+  // Set initial tooltip (will be updated via updateTrayMenu)
+  tray.setToolTip(defaultTranslations.tooltipRunning);
   
-  const showWindow = () => {
-    if (mainWindow.isDestroyed()) return;
-    mainWindow.show();
-    mainWindow.focus();
-  };
-
-  // Create context menu
-  const contextMenu = Menu.buildFromTemplate([
-    {
-      label: 'Show ClawX',
-      click: showWindow,
-    },
-    {
-      type: 'separator',
-    },
-    {
-      label: 'Gateway Status',
-      enabled: false,
-    },
-    {
-      label: '  Running',
-      type: 'checkbox',
-      checked: true,
-      enabled: false,
-    },
-    {
-      type: 'separator',
-    },
-    {
-      label: 'Quick Actions',
-      submenu: [
-        {
-          label: 'Open Dashboard',
-          click: () => {
-            if (mainWindow.isDestroyed()) return;
-            mainWindow.show();
-            mainWindow.webContents.send('navigate', '/');
-          },
-        },
-        {
-          label: 'Open Chat',
-          click: () => {
-            if (mainWindow.isDestroyed()) return;
-            mainWindow.show();
-            mainWindow.webContents.send('navigate', '/chat');
-          },
-        },
-        {
-          label: 'Open Settings',
-          click: () => {
-            if (mainWindow.isDestroyed()) return;
-            mainWindow.show();
-            mainWindow.webContents.send('navigate', '/settings');
-          },
-        },
-      ],
-    },
-    {
-      type: 'separator',
-    },
-    {
-      label: 'Check for Updates...',
-      click: () => {
-        if (mainWindow.isDestroyed()) return;
-        mainWindow.webContents.send('update:check');
-      },
-    },
-    {
-      type: 'separator',
-    },
-    {
-      label: 'Quit ClawX',
-      click: () => {
-        app.quit();
-      },
-    },
-  ]);
-  
-  tray.setContextMenu(contextMenu);
+  // Set context menu
+  tray.setContextMenu(buildContextMenu(defaultTranslations, true));
   
   // Click to show window (Windows/Linux)
   tray.on('click', () => {
-    if (mainWindow.isDestroyed()) return;
-    if (mainWindow.isVisible()) {
-      mainWindow.hide();
+    if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+    if (mainWindowRef.isVisible()) {
+      mainWindowRef.hide();
     } else {
-      mainWindow.show();
-      mainWindow.focus();
+      mainWindowRef.show();
+      mainWindowRef.focus();
     }
   });
   
   // Double-click to show window (Windows)
   tray.on('double-click', () => {
-    if (mainWindow.isDestroyed()) return;
-    mainWindow.show();
-    mainWindow.focus();
+    if (!mainWindowRef || mainWindowRef.isDestroyed()) return;
+    mainWindowRef.show();
+    mainWindowRef.focus();
   });
   
   return tray;
 }
 
 /**
- * Update tray tooltip with Gateway status
+ * Update tray menu with translations and gateway status
  */
-export function updateTrayStatus(status: string): void {
-  if (tray) {
-    tray.setToolTip(`ClawX - ${status}`);
-  }
+export function updateTrayMenu(translations: TrayTranslations, gatewayRunning: boolean): void {
+  if (!tray) return;
+  
+  currentTranslations = translations;
+  tray.setToolTip(gatewayRunning ? translations.tooltipRunning : translations.tooltipStopped);
+  tray.setContextMenu(buildContextMenu(translations, gatewayRunning));
+}
+
+/**
+ * Get current tray translations
+ */
+export function getCurrentTrayTranslations(): TrayTranslations {
+  return currentTranslations;
+}
+
+/**
+ * Update tray tooltip with Gateway status (legacy function)
+ */
+export function updateTrayStatus(status: 'running' | 'stopped'): void {
+  if (!tray) return;
+  const isRunning = status === 'running';
+  tray.setToolTip(isRunning ? currentTranslations.tooltipRunning : currentTranslations.tooltipStopped);
+  tray.setContextMenu(buildContextMenu(currentTranslations, isRunning));
 }
 
 /**
@@ -176,5 +233,6 @@ export function destroyTray(): void {
   if (tray) {
     tray.destroy();
     tray = null;
+    mainWindowRef = null;
   }
 }

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -55,6 +55,7 @@ const electronAPI = {
         'settings:setMany',
         'settings:getAll',
         'settings:reset',
+        'tray:updateLanguage',
         'usage:recentTokenHistory',
         // Update
         'update:status',

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -55,5 +55,19 @@
         "notRunning": "Gateway Not Running",
         "notRunningDesc": "The OpenClaw Gateway needs to be running to use this feature. It will start automatically, or you can start it from Settings.",
         "warning": "Gateway is not running."
+    },
+    "tray": {
+        "tooltipRunning": "ClawX - Gateway Running",
+        "tooltipStopped": "ClawX - Gateway Stopped",
+        "show": "Show ClawX",
+        "gatewayStatus": "Gateway Status",
+        "running": "Running",
+        "stopped": "Stopped",
+        "quickActions": "Quick Actions",
+        "openDashboard": "Open Dashboard",
+        "openChat": "Open Chat",
+        "openSettings": "Open Settings",
+        "checkUpdates": "Check for Updates...",
+        "quit": "Quit ClawX"
     }
 }

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -55,5 +55,19 @@
         "notRunning": "ゲートウェイが停止中",
         "notRunningDesc": "この機能を使用するには OpenClaw ゲートウェイが実行されている必要があります。自動的に起動するか、設定から起動できます。",
         "warning": "ゲートウェイが停止中です。"
+    },
+    "tray": {
+        "tooltipRunning": "ClawX - ゲートウェイ実行中",
+        "tooltipStopped": "ClawX - ゲートウェイ停止",
+        "show": "ClawX を表示",
+        "gatewayStatus": "ゲートウェイ状態",
+        "running": "実行中",
+        "stopped": "停止",
+        "quickActions": "クイックアクション",
+        "openDashboard": "ダッシュボードを開く",
+        "openChat": "チャットを開く",
+        "openSettings": "設定を開く",
+        "checkUpdates": "アップデートを確認...",
+        "quit": "ClawX を終了"
     }
 }

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -55,5 +55,19 @@
         "notRunning": "网关未运行",
         "notRunningDesc": "OpenClaw 网关需要运行才能使用此功能。它将自动启动，或者您可以从设置中启动。",
         "warning": "网关未运行。"
+    },
+    "tray": {
+        "tooltipRunning": "ClawX - 网关运行中",
+        "tooltipStopped": "ClawX - 网关已停止",
+        "show": "显示 ClawX",
+        "gatewayStatus": "网关状态",
+        "running": "运行中",
+        "stopped": "已停止",
+        "quickActions": "快捷操作",
+        "openDashboard": "打开仪表盘",
+        "openChat": "打开聊天",
+        "openSettings": "打开设置",
+        "checkUpdates": "检查更新...",
+        "quit": "退出 ClawX"
     }
 }

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -6,6 +6,8 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import i18n from '@/i18n';
 import { hostApiFetch } from '@/lib/host-api';
+import { invokeIpc } from '@/lib/api-client';
+import { useGatewayStore } from './gateway';
 
 type Theme = 'light' | 'dark' | 'system';
 type UpdateChannel = 'stable' | 'beta' | 'dev';
@@ -88,6 +90,24 @@ const defaultSettings = {
   setupComplete: false,
 };
 
+async function syncTrayTranslations(): Promise<void> {
+  const isGatewayRunning = useGatewayStore.getState().status.state === 'running';
+  await invokeIpc('tray:updateLanguage', {
+    tooltipRunning: i18n.t('tray.tooltipRunning'),
+    tooltipStopped: i18n.t('tray.tooltipStopped'),
+    show: i18n.t('tray.show'),
+    gatewayStatus: i18n.t('tray.gatewayStatus'),
+    running: i18n.t('tray.running'),
+    stopped: i18n.t('tray.stopped'),
+    quickActions: i18n.t('tray.quickActions'),
+    openDashboard: i18n.t('tray.openDashboard'),
+    openChat: i18n.t('tray.openChat'),
+    openSettings: i18n.t('tray.openSettings'),
+    checkUpdates: i18n.t('tray.checkUpdates'),
+    quit: i18n.t('tray.quit'),
+  }, isGatewayRunning);
+}
+
 export const useSettingsStore = create<SettingsState>()(
   persist(
     (set) => ({
@@ -114,6 +134,7 @@ export const useSettingsStore = create<SettingsState>()(
           method: 'PUT',
           body: JSON.stringify({ value: language }),
         }).catch(() => {});
+        void syncTrayTranslations();
       },
       setStartMinimized: (startMinimized) => set({ startMinimized }),
       setLaunchAtStartup: (launchAtStartup) => set({ launchAtStartup }),


### PR DESCRIPTION
实现系统托盘菜单和提示的多语言切换功能，包括：
1. 新增 tray:updateLanguage IPC 接口用于更新语言
2. 重构托盘模块以支持动态语言切换
3. 在设置变更时同步更新托盘语言
4. 添加中英日三语的托盘菜单翻译