### PR TITLE
fix(feishu): resolve feishu connect failures by fixing config mismatch and channel collision

### DIFF
--- a/electron/utils/channel-config.ts
+++ b/electron/utils/channel-config.ts
@@ -103,7 +103,6 @@ function ensurePluginAllowlist(currentConfig: OpenClawConfig, channelType: strin
                 allow: [FEISHU_PLUGIN_ID],
                 enabled: true,
                 entries: {
-                    feishu: { enabled: false },
                     [FEISHU_PLUGIN_ID]: { enabled: true }
                 }
             };
@@ -122,10 +121,10 @@ function ensurePluginAllowlist(currentConfig: OpenClawConfig, channelType: strin
             if (!currentConfig.plugins.entries) {
                 currentConfig.plugins.entries = {};
             }
-            if (!currentConfig.plugins.entries['feishu']) {
-                currentConfig.plugins.entries['feishu'] = {};
-            }
-            currentConfig.plugins.entries['feishu'].enabled = false;
+            // Remove legacy 'feishu' entry — the official plugin registers its
+            // channel AS 'feishu' via openclaw.plugin.json, so an explicit
+            // entries.feishu.enabled=false would block the official plugin's channel.
+            delete currentConfig.plugins.entries['feishu'];
 
             if (!currentConfig.plugins.entries[FEISHU_PLUGIN_ID]) {
                 currentConfig.plugins.entries[FEISHU_PLUGIN_ID] = {};

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -1001,6 +1001,42 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
     console.log('[sanitize] Enforced tools.profile="full" and tools.sessions.visibility="all" for OpenClaw 3.8+');
   }
 
+  // ── plugins.entries.feishu cleanup ──────────────────────────────
+  // The official feishu plugin registers its channel AS 'feishu' via
+  // openclaw.plugin.json.  An explicit entries.feishu.enabled=false
+  // (set by older ClawX to disable the legacy built-in) blocks the
+  // official plugin's channel from starting.  Delete it.
+  if (typeof plugins === 'object' && !Array.isArray(plugins)) {
+    const pluginsObj = plugins as Record<string, unknown>;
+    const pEntries = pluginsObj.entries as Record<string, Record<string, unknown>> | undefined;
+    if (pEntries?.feishu) {
+      console.log('[sanitize] Removing stale plugins.entries.feishu that blocks the official feishu plugin channel');
+      delete pEntries.feishu;
+      modified = true;
+    }
+  }
+
+  // ── channels.feishu migration ──────────────────────────────────
+  // The official feishu plugin reads the default account's credentials from
+  // the top level of `channels.feishu` (appId, appSecret), but ClawX
+  // historically stored them only under `channels.feishu.accounts.default`.
+  // Mirror the default account credentials at the top level so the plugin
+  // can discover them.
+  const feishuSection = (config.channels as Record<string, Record<string, unknown>> | undefined)?.feishu;
+  if (feishuSection) {
+    const feishuAccounts = feishuSection.accounts as Record<string, Record<string, unknown>> | undefined;
+    const defaultAccount = feishuAccounts?.default;
+    if (defaultAccount?.appId && defaultAccount?.appSecret && !feishuSection.appId) {
+      for (const [key, value] of Object.entries(defaultAccount)) {
+        if (key !== 'enabled' && !(key in feishuSection)) {
+          feishuSection[key] = value;
+        }
+      }
+      modified = true;
+      console.log('[sanitize] Mirrored feishu default account credentials to top-level channels.feishu');
+    }
+  }
+
   if (modified) {
     await writeOpenClawJson(config);
     console.log('[sanitize] openclaw.json sanitized successfully');


### PR DESCRIPTION
The official feishu plugin (`@larksuite/openclaw-lark`) was failing to start the gateway channel due to two overlapping issues with `openclaw.json` configuration structure:
1. Credential discovery format mismatch: 
The plugin reads the default account's credentials (`appId`, `appSecret`) from the top-level `channels.feishu.*`, while ClawX saved them nested under `channels.feishu.accounts.default.*`. 
- Fix: Modified [saveChannelConfig()](cci:1://file:///Users/zhonghaolu/Documents/GitHub/ClawX/electron/utils/channel-config.ts:314:0-382:1) to mirror the default account credentials to the top-level of `channels.feishu`.
- Fix: Added an automatic migration to [sanitizeOpenClawConfig()](cci:1://file:///Users/zhonghaolu/Documents/GitHub/ClawX/electron/utils/openclaw-auth.ts:862:0-1043:1) that auto-mirrors credentials for existing configs on gateway startup.
2. Plugin channel ID collision: 
ClawX historically set `plugins.entries.feishu.enabled = false` to disable the old legacy built-in plugin. However, the official plugin also registers its channel ID as `feishu` in its manifest. The gateway was reading `entries.feishu.enabled = false` and subsequently disabling the official plugin's channel.
- Fix: Removed the logic writing `feishu.enabled=false` from [ensurePluginAllowlist](cci:1://file:///Users/zhonghaolu/Documents/GitHub/ClawX/electron/utils/channel-config.ts:98:0-178:1).
- Fix: Added cleanup logic in [sanitizeOpenClawConfig()](cci:1://file:///Users/zhonghaolu/Documents/GitHub/ClawX/electron/utils/openclaw-auth.ts:862:0-1043:1) to automatically strip stale `entries.feishu` blocks blocking the official plugin.