### PR TITLE
fix(feishu): move new feishu plugin installer from save state to gateway start state

### DIFF
--- a/electron/api/routes/channels.ts
+++ b/electron/api/routes/channels.ts
@@ -13,6 +13,7 @@ import {
   validateChannelCredentials,
 } from '../../utils/channel-config';
 import { clearAllBindingsForChannel } from '../../utils/agent-config';
+import { ensureFeishuPluginInstalled } from '../../utils/channel-plugin-install';
 import { whatsAppLoginManager } from '../../utils/whatsapp-login';
 import type { HostApiContext } from '../context';
 import { parseJsonBody, sendJson } from '../route-utils';
@@ -104,47 +105,6 @@ async function ensureWeComPluginInstalled(): Promise<{ installed: boolean; warni
     return { installed: true };
   } catch {
     return { installed: false, warning: 'Failed to install bundled WeCom plugin mirror' };
-  }
-}
-
-async function ensureFeishuPluginInstalled(): Promise<{ installed: boolean; warning?: string }> {
-  const targetDir = join(homedir(), '.openclaw', 'extensions', 'feishu-openclaw-plugin');
-  const targetManifest = join(targetDir, 'openclaw.plugin.json');
-
-  if (existsSync(targetManifest)) {
-    return { installed: true };
-  }
-
-  const candidateSources = app.isPackaged
-    ? [
-      join(process.resourcesPath, 'openclaw-plugins', 'feishu-openclaw-plugin'),
-      join(process.resourcesPath, 'app.asar.unpacked', 'build', 'openclaw-plugins', 'feishu-openclaw-plugin'),
-      join(process.resourcesPath, 'app.asar.unpacked', 'openclaw-plugins', 'feishu-openclaw-plugin'),
-    ]
-    : [
-      join(app.getAppPath(), 'build', 'openclaw-plugins', 'feishu-openclaw-plugin'),
-      join(process.cwd(), 'build', 'openclaw-plugins', 'feishu-openclaw-plugin'),
-      join(__dirname, '../../../build/openclaw-plugins/feishu-openclaw-plugin'),
-    ];
-
-  const sourceDir = candidateSources.find((dir) => existsSync(join(dir, 'openclaw.plugin.json')));
-  if (!sourceDir) {
-    return {
-      installed: false,
-      warning: `Bundled Feishu plugin mirror not found. Checked: ${candidateSources.join(' | ')}`,
-    };
-  }
-
-  try {
-    mkdirSync(join(homedir(), '.openclaw', 'extensions'), { recursive: true });
-    rmSync(targetDir, { recursive: true, force: true });
-    cpSync(sourceDir, targetDir, { recursive: true, dereference: true });
-    if (!existsSync(targetManifest)) {
-      return { installed: false, warning: 'Failed to install Feishu plugin mirror (manifest missing).' };
-    }
-    return { installed: true };
-  } catch {
-    return { installed: false, warning: 'Failed to install bundled Feishu plugin mirror' };
   }
 }
 

--- a/electron/gateway/config-sync.ts
+++ b/electron/gateway/config-sync.ts
@@ -7,6 +7,7 @@ import { getProviderEnvVar, getKeyableProviderTypes } from '../utils/provider-re
 import { getOpenClawDir, getOpenClawEntryPath, isOpenClawPresent } from '../utils/paths';
 import { getUvMirrorEnv } from '../utils/uv-env';
 import { listConfiguredChannels } from '../utils/channel-config';
+import { ensureFeishuPluginInstalled } from '../utils/channel-plugin-install';
 import { syncGatewayTokenToConfig, syncBrowserConfigToOpenClaw, sanitizeOpenClawConfig } from '../utils/openclaw-auth';
 import { buildProxyEnv, resolveProxySettings } from '../utils/proxy';
 import { syncProxyConfigToOpenClaw } from '../utils/openclaw-proxy';
@@ -29,6 +30,18 @@ export async function syncGatewayConfigBeforeLaunch(
   appSettings: Awaited<ReturnType<typeof getAllSettings>>,
 ): Promise<void> {
   await syncProxyConfigToOpenClaw(appSettings);
+
+  try {
+    const configuredChannels = await listConfiguredChannels();
+    if (configuredChannels.includes('feishu')) {
+      const installResult = await ensureFeishuPluginInstalled();
+      if (!installResult.installed) {
+        logger.warn(installResult.warning || 'Failed to ensure Feishu plugin is installed before Gateway launch');
+      }
+    }
+  } catch (err) {
+    logger.warn('Failed to ensure Feishu plugin is installed before Gateway launch:', err);
+  }
 
   try {
     await sanitizeOpenClawConfig();

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -33,6 +33,7 @@ import {
 import { checkUvInstalled, installUv, setupManagedPython } from '../utils/uv-setup';
 import { updateSkillConfig, getSkillConfig, getAllSkillConfigs } from '../utils/skill-config';
 import { whatsAppLoginManager } from '../utils/whatsapp-login';
+import { ensureFeishuPluginInstalled } from '../utils/channel-plugin-install';
 import { getProviderConfig } from '../utils/provider-registry';
 import { deviceOAuthManager, OAuthProviderType } from '../utils/device-oauth';
 import { browserOAuthManager, type BrowserOAuthProviderType } from '../utils/browser-oauth';
@@ -1605,6 +1606,22 @@ function registerOpenClawHandlers(gatewayManager: GatewayManager): void {
         } else {
           logger.info(`Gateway is stopped; skip immediate reload after channel:saveConfig (${channelType})`);
         }
+        return {
+          success: true,
+          pluginInstalled: installResult.installed,
+          warning: installResult.warning,
+        };
+      }
+      if (channelType === 'feishu') {
+        const installResult = await ensureFeishuPluginInstalled();
+        if (!installResult.installed) {
+          return {
+            success: false,
+            error: installResult.warning || 'Feishu plugin install failed',
+          };
+        }
+        await saveChannelConfig(channelType, config);
+        scheduleGatewayChannelRestart(`channel:saveConfig (${channelType})`);
         return {
           success: true,
           pluginInstalled: installResult.installed,

--- a/electron/utils/channel-plugin-install.ts
+++ b/electron/utils/channel-plugin-install.ts
@@ -1,0 +1,64 @@
+import { app } from 'electron';
+import { existsSync, cpSync, mkdirSync, rmSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import { logger } from './logger';
+
+export interface PluginInstallResult {
+  installed: boolean;
+  warning?: string;
+}
+
+async function ensureBundledPluginInstalled(pluginId: string, displayName: string): Promise<PluginInstallResult> {
+  const targetDir = join(homedir(), '.openclaw', 'extensions', pluginId);
+  const targetManifest = join(targetDir, 'openclaw.plugin.json');
+
+  if (existsSync(targetManifest)) {
+    logger.info(`${displayName} plugin already installed from local mirror`);
+    return { installed: true };
+  }
+
+  const candidateSources = app.isPackaged
+    ? [
+      join(process.resourcesPath, 'openclaw-plugins', pluginId),
+      join(process.resourcesPath, 'app.asar.unpacked', 'build', 'openclaw-plugins', pluginId),
+      join(process.resourcesPath, 'app.asar.unpacked', 'openclaw-plugins', pluginId),
+    ]
+    : [
+      join(app.getAppPath(), 'build', 'openclaw-plugins', pluginId),
+      join(process.cwd(), 'build', 'openclaw-plugins', pluginId),
+      join(__dirname, '../../build/openclaw-plugins', pluginId),
+    ];
+
+  const sourceDir = candidateSources.find((dir) => existsSync(join(dir, 'openclaw.plugin.json')));
+  if (!sourceDir) {
+    logger.warn(`Bundled ${displayName} plugin mirror not found in candidate paths`, { candidateSources });
+    return {
+      installed: false,
+      warning: `Bundled ${displayName} plugin mirror not found. Checked: ${candidateSources.join(' | ')}`,
+    };
+  }
+
+  try {
+    mkdirSync(join(homedir(), '.openclaw', 'extensions'), { recursive: true });
+    rmSync(targetDir, { recursive: true, force: true });
+    cpSync(sourceDir, targetDir, { recursive: true, dereference: true });
+
+    if (!existsSync(targetManifest)) {
+      return { installed: false, warning: `Failed to install ${displayName} plugin mirror (manifest missing).` };
+    }
+
+    logger.info(`Installed ${displayName} plugin from bundled mirror: ${sourceDir}`);
+    return { installed: true };
+  } catch (error) {
+    logger.warn(`Failed to install ${displayName} plugin from bundled mirror:`, error);
+    return {
+      installed: false,
+      warning: `Failed to install bundled ${displayName} plugin mirror`,
+    };
+  }
+}
+
+export async function ensureFeishuPluginInstalled(): Promise<PluginInstallResult> {
+  return await ensureBundledPluginInstalled('feishu-openclaw-plugin', 'Feishu');
+}

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -26,6 +26,7 @@ import {
 
 const AUTH_STORE_VERSION = 1;
 const AUTH_PROFILE_FILENAME = 'auth-profiles.json';
+const FEISHU_PLUGIN_ID = 'feishu-openclaw-plugin';
 
 function getOAuthPluginId(provider: string): string {
   return `${provider}-auth`;
@@ -1026,10 +1027,49 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
   if (channelsObj && typeof channelsObj === 'object') {
     for (const [channelType, section] of Object.entries(channelsObj)) {
       if (!section || typeof section !== 'object') continue;
+
+      if (channelType === 'feishu') {
+        const pluginsObj = !config.plugins || (typeof config.plugins === 'object' && !Array.isArray(config.plugins))
+          ? ((config.plugins as Record<string, unknown> | undefined) || {})
+          : null;
+        if (pluginsObj) {
+          const allow = Array.isArray(pluginsObj.allow) ? [...pluginsObj.allow as string[]] : [];
+          const normalizedAllow = allow.filter((pluginId) => pluginId !== 'feishu');
+          if (!normalizedAllow.includes(FEISHU_PLUGIN_ID)) {
+            normalizedAllow.push(FEISHU_PLUGIN_ID);
+          }
+
+          const entries = (
+            pluginsObj.entries && typeof pluginsObj.entries === 'object' && !Array.isArray(pluginsObj.entries)
+              ? pluginsObj.entries as Record<string, Record<string, unknown>>
+              : {}
+          );
+          const currentFeishuPluginEntry = entries[FEISHU_PLUGIN_ID];
+          const nextFeishuPluginEntry = currentFeishuPluginEntry?.enabled === true
+            ? currentFeishuPluginEntry
+            : { ...(currentFeishuPluginEntry || {}), enabled: true };
+
+          if (
+            pluginsObj.enabled !== true
+            || normalizedAllow.length !== allow.length
+            || normalizedAllow.some((pluginId, index) => pluginId !== allow[index])
+            || nextFeishuPluginEntry !== currentFeishuPluginEntry
+          ) {
+            pluginsObj.enabled = true;
+            pluginsObj.allow = normalizedAllow;
+            entries[FEISHU_PLUGIN_ID] = nextFeishuPluginEntry;
+            pluginsObj.entries = entries;
+            config.plugins = pluginsObj;
+            modified = true;
+            console.log('[sanitize] Normalized Feishu plugin allowlist and enabled official plugin entry');
+          }
+        }
+      }
+
       const accounts = section.accounts as Record<string, Record<string, unknown>> | undefined;
       const defaultAccount = accounts?.default;
       if (!defaultAccount || typeof defaultAccount !== 'object') continue;
-      // Mirror each missing key from accounts.default to the top level
+
       let mirrored = false;
       for (const [key, value] of Object.entries(defaultAccount)) {
         if (!(key in section)) {

--- a/tests/unit/config-sync.test.ts
+++ b/tests/unit/config-sync.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+  listConfiguredChannels: vi.fn(),
+  ensureFeishuPluginInstalled: vi.fn(),
+  syncProxyConfigToOpenClaw: vi.fn(),
+  sanitizeOpenClawConfig: vi.fn(),
+  syncGatewayTokenToConfig: vi.fn(),
+  syncBrowserConfigToOpenClaw: vi.fn(),
+  loggerWarn: vi.fn(),
+}));
+
+vi.mock('electron', () => ({
+  app: { isPackaged: false },
+}));
+
+vi.mock('@electron/utils/store', () => ({
+  getAllSettings: vi.fn(),
+}));
+
+vi.mock('@electron/utils/secure-storage', () => ({
+  getApiKey: vi.fn(),
+  getDefaultProvider: vi.fn(),
+  getProvider: vi.fn(),
+}));
+
+vi.mock('@electron/utils/provider-registry', () => ({
+  getProviderEnvVar: vi.fn(),
+  getKeyableProviderTypes: vi.fn(() => []),
+}));
+
+vi.mock('@electron/utils/paths', () => ({
+  getOpenClawDir: vi.fn(),
+  getOpenClawEntryPath: vi.fn(),
+  isOpenClawPresent: vi.fn(() => true),
+}));
+
+vi.mock('@electron/utils/uv-env', () => ({
+  getUvMirrorEnv: vi.fn(async () => ({})),
+}));
+
+vi.mock('@electron/utils/channel-config', () => ({
+  listConfiguredChannels: mocks.listConfiguredChannels,
+}));
+
+vi.mock('@electron/utils/channel-plugin-install', () => ({
+  ensureFeishuPluginInstalled: mocks.ensureFeishuPluginInstalled,
+}));
+
+vi.mock('@electron/utils/openclaw-auth', () => ({
+  sanitizeOpenClawConfig: mocks.sanitizeOpenClawConfig,
+  syncGatewayTokenToConfig: mocks.syncGatewayTokenToConfig,
+  syncBrowserConfigToOpenClaw: mocks.syncBrowserConfigToOpenClaw,
+}));
+
+vi.mock('@electron/utils/proxy', () => ({
+  buildProxyEnv: vi.fn(() => ({})),
+  resolveProxySettings: vi.fn(() => ({})),
+}));
+
+vi.mock('@electron/utils/openclaw-proxy', () => ({
+  syncProxyConfigToOpenClaw: mocks.syncProxyConfigToOpenClaw,
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    warn: mocks.loggerWarn,
+    info: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+import { syncGatewayConfigBeforeLaunch } from '@electron/gateway/config-sync';
+
+describe('syncGatewayConfigBeforeLaunch', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.listConfiguredChannels.mockResolvedValue([]);
+    mocks.ensureFeishuPluginInstalled.mockResolvedValue({ installed: true });
+    mocks.syncProxyConfigToOpenClaw.mockResolvedValue(undefined);
+    mocks.sanitizeOpenClawConfig.mockResolvedValue(undefined);
+    mocks.syncGatewayTokenToConfig.mockResolvedValue(undefined);
+    mocks.syncBrowserConfigToOpenClaw.mockResolvedValue(undefined);
+  });
+
+  it('installs the bundled Feishu plugin before launch when Feishu is configured', async () => {
+    mocks.listConfiguredChannels.mockResolvedValue(['feishu']);
+
+    await syncGatewayConfigBeforeLaunch({ gatewayToken: 'token-123' } as never);
+
+    expect(mocks.ensureFeishuPluginInstalled).toHaveBeenCalledTimes(1);
+    expect(mocks.sanitizeOpenClawConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.syncGatewayTokenToConfig).toHaveBeenCalledWith('token-123');
+  });
+
+  it('skips bundled Feishu installation when Feishu is not configured', async () => {
+    mocks.listConfiguredChannels.mockResolvedValue(['discord']);
+
+    await syncGatewayConfigBeforeLaunch({ gatewayToken: 'token-456' } as never);
+
+    expect(mocks.ensureFeishuPluginInstalled).not.toHaveBeenCalled();
+    expect(mocks.sanitizeOpenClawConfig).toHaveBeenCalledTimes(1);
+    expect(mocks.syncGatewayTokenToConfig).toHaveBeenCalledWith('token-456');
+  });
+});

--- a/tests/unit/openclaw-auth.test.ts
+++ b/tests/unit/openclaw-auth.test.ts
@@ -36,6 +36,11 @@ async function writeOpenClawJson(config: unknown): Promise<void> {
   await writeFile(join(openclawDir, 'openclaw.json'), JSON.stringify(config, null, 2), 'utf8');
 }
 
+async function readOpenClawJson(): Promise<Record<string, unknown>> {
+  const content = await readFile(join(testHome, '.openclaw', 'openclaw.json'), 'utf8');
+  return JSON.parse(content) as Record<string, unknown>;
+}
+
 async function readAuthProfiles(agentId: string): Promise<Record<string, unknown>> {
   const content = await readFile(join(testHome, '.openclaw', 'agents', agentId, 'agent', 'auth-profiles.json'), 'utf8');
   return JSON.parse(content) as Record<string, unknown>;
@@ -109,5 +114,64 @@ describe('saveProviderKeyToOpenClaw', () => {
     );
 
     logSpy.mockRestore();
+  });
+});
+
+describe('sanitizeOpenClawConfig', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+  });
+
+  it('normalizes legacy Feishu plugin config and mirrors default credentials', async () => {
+    await writeOpenClawJson({
+      channels: {
+        feishu: {
+          accounts: {
+            default: {
+              appId: 'cli_a',
+              appSecret: 'secret_b',
+              domain: 'feishu',
+            },
+          },
+        },
+      },
+      plugins: {
+        enabled: false,
+        allow: ['feishu'],
+        entries: {
+          feishu: { enabled: false },
+        },
+      },
+    });
+
+    const { sanitizeOpenClawConfig } = await import('@electron/utils/openclaw-auth');
+    await sanitizeOpenClawConfig();
+
+    const result = await readOpenClawJson();
+    expect(result.plugins).toEqual({
+      enabled: true,
+      allow: ['feishu-openclaw-plugin'],
+      entries: {
+        'feishu-openclaw-plugin': { enabled: true },
+      },
+    });
+
+    expect(result.channels).toEqual({
+      feishu: {
+        accounts: {
+          default: {
+            appId: 'cli_a',
+            appSecret: 'secret_b',
+            domain: 'feishu',
+          },
+        },
+        appId: 'cli_a',
+        appSecret: 'secret_b',
+        domain: 'feishu',
+      },
+    });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Install Feishu plugin and normalize its config during startup to fix Gateway failures for upgraded users.

The `v0.2.0-beta.7` release migrated Feishu from a bundled extension to an official plugin mirror. This PR addresses an upgrade path where existing user configurations referencing `feishu` were not fully migrated or had the new plugin installed at startup, causing config validation errors like `unknown channel id: feishu` and `unknown heartbeat target: feishu`. The patch ensures the Feishu plugin is installed and its configuration is normalized before the Gateway attempts to start.

<div><a href="https://cursor.com/agents/bc-c7b3c7c8-1d05-408b-a188-0134a89cfe26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c7b3c7c8-1d05-408b-a188-0134a89cfe26"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->