### PR TITLE
fix(windows): enable VT processing on stdout and raw mode fallback for TUI

### DIFF
--- a/resources/cli/win32/openclaw.cmd
+++ b/resources/cli/win32/openclaw.cmd
@@ -15,6 +15,16 @@ rem on non-English Windows (e.g. Chinese CP936). Save the previous codepage to r
 for /f "tokens=2 delims=:." %%a in ('chcp') do set /a "_CP=%%a" 2>nul
 chcp 65001 >nul 2>&1
 
+rem For the TUI, pre-enable Virtual Terminal Processing on the console output
+rem handle. This ensures ANSI escape sequences render correctly on the legacy
+rem Windows console (conhost.exe). Windows Terminal (WT_SESSION set) already
+rem supports VT natively, so this step is skipped there. The pi-tui library
+rem also sets this via koffi from inside the process as a secondary safety net.
+if /i "%1"=="tui" if not defined WT_SESSION (
+    >nul 2>&1 powershell -NoProfile -NoLogo -NonInteractive -Command ^
+      "Add-Type -TypeDefinition 'using System;using System.Runtime.InteropServices;public class WinCon{[DllImport(\"kernel32.dll\")]public static extern IntPtr GetStdHandle(int h);[DllImport(\"kernel32.dll\")]public static extern bool GetConsoleMode(IntPtr h,out int m);[DllImport(\"kernel32.dll\")]public static extern bool SetConsoleMode(IntPtr h,int m);}';$o=[WinCon]::GetStdHandle(-11);$m=0;if([WinCon]::GetConsoleMode($o,[ref]$m)){[void][WinCon]::SetConsoleMode($o,$m -bor 0x000C)}"
+)
+
 set ELECTRON_RUN_AS_NODE=1
 set OPENCLAW_EMBEDDED_IN=ClawX
 "%~dp0..\..\ClawX.exe" "%~dp0..\openclaw\openclaw.mjs" %*

--- a/scripts/bundle-openclaw.mjs
+++ b/scripts/bundle-openclaw.mjs
@@ -425,6 +425,116 @@ function patchBrokenModules(nodeModulesDir) {
             windowsHide: true,
         });`,
     },
+    // ── Windows TUI console fix ─────────────────────────────────────────────
+    // When ClawX.exe (GUI subsystem) runs with ELECTRON_RUN_AS_NODE=1,
+    // Electron calls AttachConsole(ATTACH_PARENT_PROCESS) to connect to the
+    // parent console. However, libuv may not detect stdout as a TTY, which
+    // means ENABLE_VIRTUAL_TERMINAL_PROCESSING is never set on the output
+    // handle. Without it, the legacy Windows console (conhost.exe) does not
+    // process ANSI escape sequences, so the TUI renders as garbled text.
+    //
+    // Additionally, if stdin is not detected as a TTY, setRawMode is
+    // unavailable and input falls back to line-buffered mode with echo,
+    // which fights with the TUI renderer for the screen.
+    //
+    // The fix extends enableWindowsVTInput() to:
+    //   1. Enable ENABLE_VIRTUAL_TERMINAL_PROCESSING on stdout via koffi.
+    //   2. When setRawMode is missing, manually set raw mode on stdin by
+    //      clearing ENABLE_LINE_INPUT + ENABLE_ECHO_INPUT and setting
+    //      ENABLE_WINDOW_INPUT via the Win32 console API.
+    {
+      rel: '@mariozechner/pi-tui/dist/terminal.js',
+      search: `    enableWindowsVTInput() {
+        if (process.platform !== "win32")
+            return;
+        try {
+            // Dynamic require to avoid bundling koffi's 74MB of cross-platform
+            // native binaries into every compiled binary. Koffi is only needed
+            // on Windows for VT input support.
+            const koffi = cjsRequire("koffi");
+            const k32 = koffi.load("kernel32.dll");
+            const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
+            const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");
+            const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
+            const STD_INPUT_HANDLE = -10;
+            const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+            const handle = GetStdHandle(STD_INPUT_HANDLE);
+            const mode = new Uint32Array(1);
+            GetConsoleMode(handle, mode);
+            SetConsoleMode(handle, mode[0] | ENABLE_VIRTUAL_TERMINAL_INPUT);
+        }
+        catch {
+            // koffi not available — Shift+Tab won't be distinguishable from Tab
+        }
+    }`,
+      replace: `    enableWindowsVTInput() {
+        if (process.platform !== "win32")
+            return;
+        try {
+            const koffi = cjsRequire("koffi");
+            const k32 = koffi.load("kernel32.dll");
+            const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
+            const GetConsoleMode = k32.func("bool __stdcall GetConsoleMode(void*, _Out_ uint32_t*)");
+            const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
+            const STD_INPUT_HANDLE = -10;
+            const STD_OUTPUT_HANDLE = -11;
+            const ENABLE_VIRTUAL_TERMINAL_INPUT = 0x0200;
+            const ENABLE_VIRTUAL_TERMINAL_PROCESSING = 0x0004;
+            const DISABLE_NEWLINE_AUTO_RETURN = 0x0008;
+            const ENABLE_LINE_INPUT = 0x0002;
+            const ENABLE_ECHO_INPUT = 0x0004;
+            const ENABLE_WINDOW_INPUT = 0x0008;
+            const ENABLE_PROCESSED_INPUT = 0x0001;
+            const inHandle = GetStdHandle(STD_INPUT_HANDLE);
+            const inMode = new Uint32Array(1);
+            if (GetConsoleMode(inHandle, inMode)) {
+                let newInMode = inMode[0] | ENABLE_VIRTUAL_TERMINAL_INPUT;
+                if (!process.stdin.setRawMode) {
+                    this._savedWinConsoleMode = inMode[0];
+                    newInMode = (newInMode & ~(ENABLE_LINE_INPUT | ENABLE_ECHO_INPUT))
+                        | ENABLE_WINDOW_INPUT | ENABLE_PROCESSED_INPUT;
+                }
+                SetConsoleMode(inHandle, newInMode);
+            }
+            const outHandle = GetStdHandle(STD_OUTPUT_HANDLE);
+            const outMode = new Uint32Array(1);
+            if (GetConsoleMode(outHandle, outMode)) {
+                SetConsoleMode(outHandle, outMode[0]
+                    | ENABLE_VIRTUAL_TERMINAL_PROCESSING
+                    | DISABLE_NEWLINE_AUTO_RETURN);
+            }
+        }
+        catch {
+            // koffi not available — VT input/output sequences won't be enabled
+        }
+    }`,
+    },
+    // Patch stop() to restore the original Win32 console mode when raw mode
+    // was set via koffi (because setRawMode was unavailable).
+    {
+      rel: '@mariozechner/pi-tui/dist/terminal.js',
+      search: `        // Restore raw mode state
+        if (process.stdin.setRawMode) {
+            process.stdin.setRawMode(this.wasRaw);
+        }
+    }`,
+      replace: `        // Restore raw mode state
+        if (process.stdin.setRawMode) {
+            process.stdin.setRawMode(this.wasRaw);
+        }
+        else if (this._savedWinConsoleMode !== undefined) {
+            try {
+                const koffi = cjsRequire("koffi");
+                const k32 = koffi.load("kernel32.dll");
+                const GetStdHandle = k32.func("void* __stdcall GetStdHandle(int)");
+                const SetConsoleMode = k32.func("bool __stdcall SetConsoleMode(void*, uint32_t)");
+                SetConsoleMode(GetStdHandle(-10), this._savedWinConsoleMode);
+                this._savedWinConsoleMode = undefined;
+            }
+            catch { /* koffi not available */ }
+        }
+    }`,
+    },
   ];
 
   let count = 0;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When running `openclaw tui` on Windows after installing ClawX and adding the `openclaw` CLI to PATH, the TUI interface does not render correctly. Instead, the user sees:
- The native PowerShell prompt appearing over the TUI
- Messages being refreshed/cleared
- Garbled output instead of the proper TUI interface

## Root Cause

`ClawX.exe` is a Windows GUI subsystem application (built with `/SUBSYSTEM:WINDOWS`). When it runs with `ELECTRON_RUN_AS_NODE=1` via `openclaw.cmd`, Electron calls `AttachConsole(ATTACH_PARENT_PROCESS)` to connect to the parent console. However:

1. **Missing VT output processing**: libuv may not detect `process.stdout` as a TTY (since the GUI app starts without console handles and `AttachConsole` may happen after libuv's stdio initialization). When `process.stdout.isTTY` is `false`, libuv does NOT enable `ENABLE_VIRTUAL_TERMINAL_PROCESSING` on the output handle. Without this flag, the legacy Windows console (`conhost.exe`) does not process ANSI escape sequences, so the TUI renders as garbled text.

2. **Missing raw mode**: Similarly, if `process.stdin` is not detected as a TTY, `setRawMode` is `undefined`. The TUI falls back to line-buffered input mode with echo, which fights with the TUI renderer — causing the "native PowerShell page" appearance where input echo overwrites TUI content.

3. **`enableWindowsVTInput()` only handles stdin**: The pi-tui library's `enableWindowsVTInput()` method enables `ENABLE_VIRTUAL_TERMINAL_INPUT` on stdin via koffi/kernel32.dll but completely omits the corresponding `ENABLE_VIRTUAL_TERMINAL_PROCESSING` flag on stdout.

## Fix

### `scripts/bundle-openclaw.mjs`

Added two new patches to the `patchBrokenModules` section:

**Patch 1 — `enableWindowsVTInput()` enhancement:**
- Enables `ENABLE_VIRTUAL_TERMINAL_PROCESSING` + `DISABLE_NEWLINE_AUTO_RETURN` on stdout via `SetConsoleMode` (koffi/kernel32.dll)
- Adds raw mode fallback: when `process.stdin.setRawMode` is unavailable (GUI subsystem Electron), manually clears `ENABLE_LINE_INPUT` + `ENABLE_ECHO_INPUT` and sets `ENABLE_WINDOW_INPUT` on stdin via Win32 console API
- Saves original console mode for clean restore on exit

**Patch 2 — `stop()` restore:**
- When raw mode was set via koffi (because `setRawMode` was unavailable), restores the original Win32 console mode on exit

### `resources/cli/win32/openclaw.cmd`

- Added a pre-launch step that enables VT processing on the console output handle via a PowerShell one-liner
- Only runs for the `tui` subcommand (no overhead for other commands)
- Skipped when running in Windows Terminal (`WT_SESSION` set), which already supports VT natively
- Acts as a secondary safety net alongside the koffi-based fix inside the process

## Testing

- ✅ ESLint passes (0 errors)
- ✅ TypeScript type check passes
- ✅ All 230 unit tests pass
- ✅ Vite build completes successfully
- ✅ Patch search strings verified against actual `@mariozechner/pi-tui@0.58.0` `terminal.js`
- ✅ Simulated patch application verified (both patches apply cleanly)

> **Note**: Full end-to-end testing on Windows is required to confirm the fix resolves the TUI display issue. The fix addresses the identified root causes but the actual behavior depends on the specific Windows version, terminal emulator (conhost vs Windows Terminal), and Electron's `AttachConsole` behavior.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-332489d6-9eb3-44c4-9030-b23a1ddfefbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-332489d6-9eb3-44c4-9030-b23a1ddfefbf"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

