### PR TITLE
fix(skills): update tavily-search repoPath in preinstalled manifest

### DIFF
--- a/resources/skills/preinstalled-manifest.json
+++ b/resources/skills/preinstalled-manifest.json
@@ -51,7 +51,7 @@
     {
       "slug": "tavily-search",
       "repo": "tavily-ai/skills",
-      "repoPath": "skills/tavily/search",
+      "repoPath": "skills/tavily-search",
       "ref": "main",
       "version": "main",
       "autoEnable": true


### PR DESCRIPTION
## Summary
Fix preinstalled skill manifest for `tavily-search` by updating:
- `repoPath`: `skills/tavily/search` -> `skills/tavily-search`

## Why
Upstream `tavily-ai/skills` now exposes the skill at `skills/tavily-search`.
The old path causes install/bundle failure:

fatal: pathspec 'skills/tavily/search' did not match any files

## Scope
- Updated only `resources/skills/preinstalled-manifest.json`
- No runtime behavior changes beyond successful skill fetch/install