### PR TITLE
feat(gateway): add websocket pong timeout and channel auto-reconnect watchdog

### DIFF
--- a/electron/gateway/connection-monitor.ts
+++ b/electron/gateway/connection-monitor.ts
@@ -4,16 +4,43 @@ type HealthResult = { ok: boolean; error?: string };
 
 export class GatewayConnectionMonitor {
   private pingInterval: NodeJS.Timeout | null = null;
+  private pongTimeout: NodeJS.Timeout | null = null;
   private healthCheckInterval: NodeJS.Timeout | null = null;
 
-  startPing(sendPing: () => void, intervalMs = 30000): void {
+  startPing(
+    sendPing: () => void,
+    onPongTimeout?: () => void,
+    intervalMs = 30000,
+    timeoutMs = 15000,
+  ): void {
     if (this.pingInterval) {
       clearInterval(this.pingInterval);
+    }
+    if (this.pongTimeout) {
+      clearTimeout(this.pongTimeout);
+      this.pongTimeout = null;
     }
 
     this.pingInterval = setInterval(() => {
       sendPing();
+
+      if (onPongTimeout) {
+        if (this.pongTimeout) {
+          clearTimeout(this.pongTimeout);
+        }
+        this.pongTimeout = setTimeout(() => {
+          this.pongTimeout = null;
+          onPongTimeout();
+        }, timeoutMs);
+      }
     }, intervalMs);
+  }
+
+  handlePong(): void {
+    if (this.pongTimeout) {
+      clearTimeout(this.pongTimeout);
+      this.pongTimeout = null;
+    }
   }
 
   startHealthCheck(options: {
@@ -50,6 +77,10 @@ export class GatewayConnectionMonitor {
     if (this.pingInterval) {
       clearInterval(this.pingInterval);
       this.pingInterval = null;
+    }
+    if (this.pongTimeout) {
+      clearTimeout(this.pongTimeout);
+      this.pongTimeout = null;
     }
     if (this.healthCheckInterval) {
       clearInterval(this.healthCheckInterval);

--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -109,6 +109,8 @@ export class GatewayManager extends EventEmitter {
   private reconnectAttemptsTotal = 0;
   private reconnectSuccessTotal = 0;
   private static readonly RELOAD_POLICY_REFRESH_MS = 15_000;
+  public static readonly RESTART_COOLDOWN_MS = 5_000;
+  private lastRestartAt = 0;
 
   constructor(config?: Partial<ReconnectConfig>) {
     super();
@@ -727,6 +729,9 @@ export class GatewayManager extends EventEmitter {
       getToken: async () => await import('../utils/store').then(({ getSetting }) => getSetting('gatewayToken')),
       onHandshakeComplete: (ws) => {
         this.ws = ws;
+        this.ws.on('pong', () => {
+          this.connectionMonitor.handlePong();
+        });
         this.setStatus({
           state: 'running',
           port,
@@ -802,11 +807,24 @@ export class GatewayManager extends EventEmitter {
    * Start ping interval to keep connection alive
    */
   private startPing(): void {
-    this.connectionMonitor.startPing(() => {
-      if (this.ws?.readyState === WebSocket.OPEN) {
-        this.ws.ping();
+    this.connectionMonitor.startPing(
+      () => {
+        if (this.ws?.readyState === WebSocket.OPEN) {
+          this.ws.ping();
+        }
+      },
+      () => {
+        logger.error('Gateway WebSocket dead connection detected (pong timeout)');
+        if (this.ws) {
+          this.ws.terminate(); // Force close the dead connection immediately
+          this.ws = null;
+        }
+        if (this.status.state === 'running') {
+          this.setStatus({ state: 'error', error: 'WebSocket ping timeout' });
+          this.scheduleReconnect();
+        }
       }
-    });
+    );
   }
 
   /**

--- a/src/stores/channels.ts
+++ b/src/stores/channels.ts
@@ -33,7 +33,12 @@ interface ChannelsState {
   setChannels: (channels: Channel[]) => void;
   updateChannel: (channelId: string, updates: Partial<Channel>) => void;
   clearError: () => void;
+  scheduleAutoReconnect: (channelId: string) => void;
+  clearAutoReconnect: (channelId: string) => void;
 }
+
+const reconnectTimers = new Map<string, NodeJS.Timeout>();
+const reconnectAttempts = new Map<string, number>();
 
 export const useChannelsStore = create<ChannelsState>((set, get) => ({
   channels: [],
@@ -194,7 +199,8 @@ export const useChannelsStore = create<ChannelsState>((set, get) => ({
   },
 
   disconnectChannel: async (channelId) => {
-    const { updateChannel } = get();
+    const { updateChannel, clearAutoReconnect } = get();
+    clearAutoReconnect(channelId);
 
     try {
       await useGatewayStore.getState().rpc('channels.disconnect', { channelId });
@@ -223,4 +229,37 @@ export const useChannelsStore = create<ChannelsState>((set, get) => ({
   },
 
   clearError: () => set({ error: null }),
+
+  scheduleAutoReconnect: (channelId) => {
+    if (reconnectTimers.has(channelId)) return;
+    
+    const attempts = reconnectAttempts.get(channelId) || 0;
+    // Exponential backoff capped at 2 minutes
+    const delay = Math.min(5000 * Math.pow(2, attempts), 120000);
+    
+    console.log(`[Watchdog] Scheduling auto-reconnect for ${channelId} in ${delay}ms (attempt ${attempts + 1})`);
+    
+    const timer = setTimeout(() => {
+      reconnectTimers.delete(channelId);
+      const state = get();
+      const channel = state.channels.find((c) => c.id === channelId);
+      
+      if (channel && (channel.status === 'disconnected' || channel.status === 'error')) {
+        reconnectAttempts.set(channelId, attempts + 1);
+        console.log(`[Watchdog] Executing auto-reconnect for ${channelId} (attempt ${attempts + 1})`);
+        state.connectChannel(channelId).catch(() => {});
+      }
+    }, delay);
+    
+    reconnectTimers.set(channelId, timer);
+  },
+
+  clearAutoReconnect: (channelId) => {
+    const timer = reconnectTimers.get(channelId);
+    if (timer) {
+      clearTimeout(timer);
+      reconnectTimers.delete(channelId);
+    }
+    reconnectAttempts.delete(channelId);
+  },
 }));

--- a/src/stores/gateway.ts
+++ b/src/stores/gateway.ts
@@ -269,7 +269,14 @@ export const useGatewayStore = create<GatewayState>((set, get) => ({
                   const state = useChannelsStore.getState();
                   const channel = state.channels.find((item) => item.type === update.channelId);
                   if (channel) {
-                    state.updateChannel(channel.id, { status: mapChannelStatus(update.status) });
+                    const newStatus = mapChannelStatus(update.status);
+                    state.updateChannel(channel.id, { status: newStatus });
+                    
+                    if (newStatus === 'disconnected' || newStatus === 'error') {
+                      state.scheduleAutoReconnect(channel.id);
+                    } else if (newStatus === 'connected' || newStatus === 'connecting') {
+                      state.clearAutoReconnect(channel.id);
+                    }
                   }
                 })
                 .catch(() => {});


### PR DESCRIPTION
## Summary

<!-- What does this PR change and why? -->

add websocket pong timeout and channel auto-reconnect watchdog

## Related Issue(s)

<!-- e.g. Closes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [x] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.
