### PR TITLE
fix(linux): Can't change Chinese IMEs on Debian

### DIFF
--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -113,6 +113,8 @@ function getAppIcon(): Electron.NativeImage | undefined {
  */
 function createWindow(): BrowserWindow {
   const isMac = process.platform === 'darwin';
+  const isWindows = process.platform === 'win32';
+  const useCustomTitleBar = isWindows;
 
   const win = new BrowserWindow({
     width: 1280,
@@ -127,9 +129,9 @@ function createWindow(): BrowserWindow {
       sandbox: false,
       webviewTag: true, // Enable <webview> for embedding OpenClaw Control UI
     },
-    titleBarStyle: isMac ? 'hiddenInset' : 'hidden',
+    titleBarStyle: isMac ? 'hiddenInset' : useCustomTitleBar ? 'hidden' : 'default',
     trafficLightPosition: isMac ? { x: 16, y: 16 } : undefined,
-    frame: isMac,
+    frame: isMac || !useCustomTitleBar,
     show: false,
   });
 

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -2194,7 +2194,7 @@ function registerUsageHandlers(): void {
   });
 }
 /**
- * Window control handlers (for custom title bar on Windows/Linux)
+ * Window control handlers (for custom title bar on Windows)
  */
 function registerWindowHandlers(mainWindow: BrowserWindow): void {
   ipcMain.handle('window:minimize', () => {

--- a/src/components/layout/TitleBar.tsx
+++ b/src/components/layout/TitleBar.tsx
@@ -1,18 +1,24 @@
 /**
  * TitleBar Component
  * macOS: empty drag region (native traffic lights handled by hiddenInset).
- * Windows/Linux: drag region on left, minimize/maximize/close on right.
+ * Windows: drag region with custom minimize/maximize/close controls.
+ * Linux: use native window chrome (no custom title bar).
  */
 import { useState, useEffect } from 'react';
 import { Minus, Square, X, Copy } from 'lucide-react';
 import { invokeIpc } from '@/lib/api-client';
 
-const isMac = window.electron?.platform === 'darwin';
-
 export function TitleBar() {
-  if (isMac) {
+  const platform = window.electron?.platform;
+
+  if (platform === 'darwin') {
     // macOS: just a drag region, traffic lights are native
     return <div className="drag-region h-10 shrink-0 border-b bg-background" />;
+  }
+
+  // Linux keeps the native frame/title bar for better IME compatibility.
+  if (platform !== 'win32') {
+    return null;
   }
 
   return <WindowsTitleBar />;

--- a/tests/unit/title-bar.test.tsx
+++ b/tests/unit/title-bar.test.tsx
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { TitleBar } from '@/components/layout/TitleBar';
+
+const invokeIpcMock = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api-client', () => ({
+  invokeIpc: (...args: unknown[]) => invokeIpcMock(...args),
+}));
+
+describe('TitleBar platform behavior', () => {
+  beforeEach(() => {
+    invokeIpcMock.mockReset();
+    invokeIpcMock.mockResolvedValue(false);
+  });
+
+  it('renders macOS drag region', () => {
+    window.electron.platform = 'darwin';
+
+    const { container } = render(<TitleBar />);
+
+    expect(container.querySelector('.drag-region')).toBeInTheDocument();
+    expect(screen.queryByTitle('Minimize')).not.toBeInTheDocument();
+    expect(invokeIpcMock).not.toHaveBeenCalled();
+  });
+
+  it('renders custom controls on Windows', async () => {
+    window.electron.platform = 'win32';
+
+    render(<TitleBar />);
+
+    expect(screen.getByTitle('Minimize')).toBeInTheDocument();
+    expect(screen.getByTitle('Maximize')).toBeInTheDocument();
+    expect(screen.getByTitle('Close')).toBeInTheDocument();
+
+    await waitFor(() => {
+      expect(invokeIpcMock).toHaveBeenCalledWith('window:isMaximized');
+    });
+  });
+
+  it('renders no custom title bar on Linux', () => {
+    window.electron.platform = 'linux';
+
+    const { container } = render(<TitleBar />);
+
+    expect(container.firstChild).toBeNull();
+    expect(screen.queryByTitle('Minimize')).not.toBeInTheDocument();
+    expect(invokeIpcMock).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the inability to switch Input Method Editors (IMEs) on Linux, specifically addressing issues reported for Chinese IMEs on Debian 13 (Closes #560). The problem stemmed from Linux incorrectly using a frameless window with a custom title bar, a configuration intended only for Windows.

The changes restore the native window frame for Linux, ensuring proper IME integration and system-level window management. The custom title bar is now exclusively applied to Windows, while macOS behavior remains unchanged.

## Related Issue(s)

Closes #560

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

- Ran `pnpm run lint`, `pnpm run typecheck`, and unit tests including `tests/unit/title-bar.test.tsx`.
- Successfully packaged the Linux application using `pnpm run package:linux`.
- Manually verified on a Linux environment that the native OS title bar is displayed and basic input functionality works.
- *Note: Full IME composition validation was limited due to environment constraints in the development environment.*

## Checklist

- [x] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

<div><a href="https://cursor.com/agents/bc-9ed9239d-420f-4b3b-a8c3-0d9dea8f18ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9ed9239d-420f-4b3b-a8c3-0d9dea8f18ae"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>


<!-- CURSOR_AGENT_PR_BODY_END -->