### PR TITLE
chore(telemetry): stop sending gateway reconnect payloads to PostHog

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -978,7 +978,7 @@ export class GatewayManager extends EventEmitter {
     };
 
     trackMetric('gateway.reconnect', properties);
-    captureTelemetryEvent('gateway_reconnect', properties);
+    // Keep local metrics only; do not upload reconnect details to PostHog.
   }
 
   /**


### PR DESCRIPTION
## Summary
- stop uploading gateway reconnect telemetry payloads to PostHog
- keep local metric logging (trackMetric) unchanged
- preserve reconnect behavior and retry logic (no functional runtime change)

## Change
- remove captureTelemetryEvent for gateway_reconnect from the reconnect metric emission path

## Verification
- pnpm run typecheck
- pnpm exec vitest run tests/unit/gateway-restart-governor.test.ts