### PR TITLE
fix: persist theme setting to main process store

### DIFF
--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -112,7 +112,13 @@ export const useSettingsStore = create<SettingsState>()(
         }
       },
 
-      setTheme: (theme) => set({ theme }),
+      setTheme: (theme) => {
+        set({ theme });
+        void hostApiFetch('/api/settings/theme', {
+          method: 'PUT',
+          body: JSON.stringify({ value: theme }),
+        }).catch(() => { });
+      },
       setLanguage: (language) => {
         const resolvedLanguage = resolveSupportedLanguage(language);
         i18n.changeLanguage(resolvedLanguage);


### PR DESCRIPTION
## Problem

Dark theme resets to default (system) after app restart (#625, #627).

## Root Cause

`setTheme` was the only setting action in `src/stores/settings.ts` that did not sync to the main process store via `hostApiFetch`. Compare:

| Setting | Syncs to main process? |
|---------|----------------------|
| language | ✅ |
| launchAtStartup | ✅ |
| telemetryEnabled | ✅ |
| gatewayAutoStart | ✅ |
| gatewayPort | ✅ |
| devModeUnlocked | ✅ |
| **theme** | ❌ **Missing** |

On restart, `init()` fetches settings from the main process (`/api/settings`) and merges them into the renderer state. Since theme was never persisted to the main process store, the backend returned the default (`'system'`), overwriting the user's choice.

## Fix

Add the same `hostApiFetch` call to `setTheme` that all other persisted settings already use.

Fixes #625, fixes #627