### PR TITLE
fix(scripts): configure zx quote function for Windows PowerShell

### DIFF
--- a/scripts/bundle-preinstalled-skills.mjs
+++ b/scripts/bundle-preinstalled-skills.mjs
@@ -3,6 +3,14 @@
 import 'zx/globals';
 import { readFileSync, existsSync, mkdirSync, rmSync, cpSync, writeFileSync } from 'node:fs';
 import { join, dirname, basename } from 'node:path';
+
+// zx requires a quote function for non-Bash shells (e.g. PowerShell on Windows).
+// Without this, all $ commands fail with "No quote function is defined".
+// See: https://google.github.io/zx/quotes
+if (process.platform === 'win32' && !$.quote) {
+  const { quotePowerShell } = await import('zx');
+  $.quote = quotePowerShell;
+}
 import { fileURLToPath } from 'node:url';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));

--- a/scripts/download-bundled-node.mjs
+++ b/scripts/download-bundled-node.mjs
@@ -2,6 +2,13 @@
 
 import 'zx/globals';
 
+// zx requires a quote function for non-Bash shells (e.g. PowerShell on Windows).
+// See: https://google.github.io/zx/quotes
+if (process.platform === 'win32' && !$.quote) {
+  const { quotePowerShell } = await import('zx');
+  $.quote = quotePowerShell;
+}
+
 const ROOT_DIR = path.resolve(__dirname, '..');
 const NODE_VERSION = '22.16.0';
 const BASE_URL = `https://nodejs.org/dist/v${NODE_VERSION}`;

--- a/scripts/download-bundled-uv.mjs
+++ b/scripts/download-bundled-uv.mjs
@@ -2,6 +2,13 @@
 
 import 'zx/globals';
 
+// zx requires a quote function for non-Bash shells (e.g. PowerShell on Windows).
+// See: https://google.github.io/zx/quotes
+if (process.platform === 'win32' && !$.quote) {
+  const { quotePowerShell } = await import('zx');
+  $.quote = quotePowerShell;
+}
+
 const ROOT_DIR = path.resolve(__dirname, '..');
 const UV_VERSION = '0.10.0';
 const BASE_URL = `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}`;

--- a/scripts/prepare-preinstalled-skills-dev.mjs
+++ b/scripts/prepare-preinstalled-skills-dev.mjs
@@ -1,6 +1,13 @@
 #!/usr/bin/env zx
 
 import 'zx/globals';
+
+// zx requires a quote function for non-Bash shells (e.g. PowerShell on Windows).
+// See: https://google.github.io/zx/quotes
+if (process.platform === 'win32' && !$.quote) {
+  const { quotePowerShell } = await import('zx');
+  $.quote = quotePowerShell;
+}
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';


### PR DESCRIPTION
## Summary

On Windows, zx requires an explicit quote function for non-Bash shells (PowerShell/cmd). Without it, all `$` template commands fail with:

```
No quote function is defined: https://google.github.io/zx/quotes
```

## Related Issue

Fixes #645.

## Changes

Add the documented `quotePowerShell` guard to all 4 scripts that use zx `$` template literals:

- `scripts/bundle-preinstalled-skills.mjs` (reported in #645)
- `scripts/download-bundled-node.mjs`
- `scripts/download-bundled-uv.mjs`
- `scripts/prepare-preinstalled-skills-dev.mjs`

The guard checks `process.platform === "win32"` and is a no-op on macOS/Linux.

3 other zx scripts (`bundle-openclaw.mjs`, `bundle-openclaw-plugins.mjs`, `generate-icons.mjs`) do not use `$` template literals and are unaffected.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Verified the fix matches [zx official documentation](https://google.github.io/zx/quotes)
- [x] Confirmed the guard is a no-op on non-Windows platforms (no behavior change for Linux/macOS)
- [x] Checked all 7 zx scripts — only the 4 using `$` templates are affected
- ⚠️ Not tested on Windows (developed on Linux) — would appreciate a Windows tester confirming

## Checklist

- [x] Single-purpose PR — one fix across related files
- [x] No competing PR for this issue