### PR TITLE
fix: update MiniMax model display to M2.7 on OAuth re-login

### DIFF
--- a/electron/utils/device-oauth.ts
+++ b/electron/utils/device-oauth.ts
@@ -283,7 +283,7 @@ class DeviceOAuthManager extends EventEmitter {
             enabled: existing?.enabled ?? true,
             baseUrl, // Save the dynamically resolved URL (Global vs CN)
 
-            model: existing?.model || getProviderDefaultModel(providerType),
+            model: getProviderDefaultModel(providerType) || existing?.model,
             createdAt: existing?.createdAt || new Date().toISOString(),
             updatedAt: new Date().toISOString(),
         };


### PR DESCRIPTION
## Summary

fix: update MiniMax model display to M2.7 on OAuth re-login


## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [ ] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [ ] I verified there are no unrelated changes in this PR.
