### PR TITLE
[codex] fix installer preflight cleanup on Windows upgrade

### DIFF
--- a/scripts/installer-preflight.ps1
+++ b/scripts/installer-preflight.ps1
@@ -1,0 +1,83 @@
+param(
+    [Parameter(Mandatory = $true)]
+    [string]$AppExecutableName,
+
+    [int]$GatewayPort = 18789
+)
+
+$ErrorActionPreference = 'SilentlyContinue'
+
+function Invoke-TaskKill {
+    param(
+        [Parameter(Mandatory = $true)]
+        [string[]]$Arguments
+    )
+
+    $taskkill = Join-Path $env:SystemRoot 'System32\taskkill.exe'
+    if (-not (Test-Path $taskkill)) {
+        return
+    }
+
+    $proc = Start-Process -FilePath $taskkill -ArgumentList $Arguments -WindowStyle Hidden -Wait -PassThru
+    if ($proc.ExitCode -notin 0, 128, 255) {
+        Write-Output "taskkill exit code $($proc.ExitCode) for: $($Arguments -join ' ')"
+    }
+}
+
+function Get-ListeningPids {
+    param(
+        [int]$Port
+    )
+
+    $netstat = Join-Path $env:SystemRoot 'System32\netstat.exe'
+    if (-not (Test-Path $netstat)) {
+        return @()
+    }
+
+    $matches = @()
+    $output = & $netstat -ano -p tcp
+    foreach ($line in $output) {
+        if ($line -match "^\s*TCP\s+\S+:$Port\s+\S+\s+LISTENING\s+(\d+)\s*$") {
+            $matches += $Matches[1]
+        }
+    }
+    return $matches | Sort-Object -Unique
+}
+
+function Remove-StaleLockFiles {
+    $paths = @(
+        (Join-Path $env:APPDATA 'ClawX\clawx.instance.lock'),
+        (Join-Path $env:APPDATA 'clawx\clawx.instance.lock')
+    ) | Sort-Object -Unique
+
+    foreach ($path in $paths) {
+        if (Test-Path $path) {
+            Remove-Item $path -Force -ErrorAction SilentlyContinue
+            if (-not (Test-Path $path)) {
+                Write-Output "Removed stale lock: $path"
+            }
+        }
+    }
+}
+
+$normalizedExe = [System.IO.Path]::GetFileName($AppExecutableName)
+$lockPaths = @(
+    (Join-Path $env:APPDATA 'ClawX\clawx.instance.lock'),
+    (Join-Path $env:APPDATA 'clawx\clawx.instance.lock')
+) | Sort-Object -Unique
+$hadLockFile = $lockPaths | Where-Object { Test-Path $_ } | Select-Object -First 1
+$appWasRunning = Get-Process -Name ([System.IO.Path]::GetFileNameWithoutExtension($normalizedExe)) -ErrorAction SilentlyContinue
+
+Write-Output "Stopping $normalizedExe process tree (best effort)..."
+Invoke-TaskKill -Arguments @('/F', '/T', '/IM', $normalizedExe)
+
+if ($appWasRunning -or $hadLockFile) {
+    $portPids = Get-ListeningPids -Port $GatewayPort
+    foreach ($pid in $portPids) {
+        Write-Output "Stopping listener on port $GatewayPort (pid=$pid)..."
+        Invoke-TaskKill -Arguments @('/F', '/T', '/PID', $pid)
+    }
+}
+
+Start-Sleep -Milliseconds 800
+Remove-StaleLockFiles

--- a/scripts/installer.nsh
+++ b/scripts/installer.nsh
@@ -18,6 +18,22 @@
   SetDetailsPrint both
   DetailPrint "Preparing installation..."
   DetailPrint "Extracting ClawX runtime files. This can take a few minutes on slower disks or while antivirus scanning is active."
+  ${if} ${isUpdated}
+    DetailPrint "Running upgrade preflight cleanup for ClawX, Gateway, and stale locks..."
+
+    InitPluginsDir
+    ClearErrors
+    File "/oname=$PLUGINSDIR\installer-preflight.ps1" "${PROJECT_DIR}\scripts\installer-preflight.ps1"
+    nsExec::ExecToStack '"$SYSDIR\WindowsPowerShell\v1.0\powershell.exe" -NoProfile -NonInteractive -ExecutionPolicy Bypass -File "$PLUGINSDIR\installer-preflight.ps1" -AppExecutableName "${APP_EXECUTABLE_FILENAME}" -GatewayPort 18789'
+    Pop $0
+    Pop $1
+    StrCmp $0 "error" 0 +2
+      DetailPrint "Warning: Failed to launch installer preflight cleanup."
+    StrCmp $0 "timeout" 0 +2
+      DetailPrint "Warning: Installer preflight cleanup timed out."
+    StrCmp $0 "0" 0 +2
+      DetailPrint "Warning: Installer preflight cleanup exited with code $0."
+  ${endIf}
 
   ${nsProcess::FindProcess} "${APP_EXECUTABLE_FILENAME}" $R0
 
@@ -33,7 +49,7 @@
     doStopProcess:
     DetailPrint `Closing running "${PRODUCT_NAME}"...`
 
-    # Silently kill the process using nsProcess instead of taskkill / cmd.exe
+    # Retry closing the app entry process in case it relaunched during preflight.
     ${nsProcess::KillProcess} "${APP_EXECUTABLE_FILENAME}" $R0
     
     # to ensure that files are not "in-use"


### PR DESCRIPTION
## Summary

This change hardens the Windows upgrade path against residual ClawX/OpenClaw processes that can block the first launch after an in-place update.

## What changed

- added an installer preflight PowerShell script that runs during NSIS upgrade installs
- terminates the `ClawX.exe` process tree before file replacement
- terminates lingering listeners on gateway port `18789` when a prior app instance or stale lock is detected
- removes stale `clawx.instance.lock` files before the upgraded app launches
- keeps this cleanup scoped to upgrade installs so fresh installs do not aggressively kill unrelated listeners

## Why

Issue [#680](https://github.com/ValueCell-ai/ClawX/issues/680) points to a Windows-specific failure mode where an older install leaves behind gateway/python descendants and stale instance-lock state. The app already has runtime-side cleanup, but the external NSIS installer was still only targeting the top-level app process, leaving a gap during upgrade.

## Impact

- reduces "another instance is already running" failures after Windows upgrades
- reduces first-launch failures caused by orphaned gateway descendants holding port `18789`
- leaves macOS/Linux behavior unchanged

## Validation

- `git diff --check -- scripts/installer.nsh scripts/installer-preflight.ps1`
- static review of existing runtime cleanup paths in `electron/main` and `electron/gateway`

## Limitations

- not fully runtime-tested in this environment
- `pwsh` / `makensis` were unavailable locally, so installer execution was not simulated here
