### PR TITLE
fix duplicate gateway spawn during reconnect after service restart

### DIFF
--- a/electron/gateway/startup-orchestrator.ts
+++ b/electron/gateway/startup-orchestrator.ts
@@ -54,6 +54,20 @@ export async function runGatewayStartupSequence(hooks: StartupHooks): Promise<vo
       if (hooks.shouldWaitForPortFree) {
         await hooks.waitForPortFree(hooks.port);
         hooks.assertLifecycle('start/wait-port');
+
+        // Windows service restarts can temporarily drop the WebSocket while the
+        // same gateway process continues owning the port. Re-probe here before
+        // spawning a new process so we reconnect to the recovered gateway
+        // instead of launching a duplicate that will fail on the port lock.
+        const existingAfterWait = await hooks.findExistingGateway(hooks.port, hooks.ownedPid);
+        hooks.assertLifecycle('start/find-existing-after-wait');
+        if (existingAfterWait) {
+          logger.debug(`Found existing Gateway on port ${existingAfterWait.port} after waiting for port availability`);
+          await hooks.connect(existingAfterWait.port, existingAfterWait.externalToken);
+          hooks.assertLifecycle('start/connect-existing-after-wait');
+          hooks.onConnectedToExistingGateway();
+          return;
+        }
       }
 
       await hooks.startProcess();

--- a/electron/utils/channel-config.ts
+++ b/electron/utils/channel-config.ts
@@ -359,8 +359,13 @@ export async function writeOpenClawConfig(config: OpenClawConfig): Promise<void>
                 : {};
         commands.restart = true;
         config.commands = commands;
+        const nextContent = JSON.stringify(config, null, 2);
+        const currentContent = await readFile(CONFIG_FILE, 'utf-8').catch(() => null);
+        if (currentContent === nextContent) {
+            return;
+        }
 
-        await writeFile(CONFIG_FILE, JSON.stringify(config, null, 2), 'utf-8');
+        await writeFile(CONFIG_FILE, nextContent, 'utf-8');
     } catch (error) {
         logger.error('Failed to write OpenClaw config', error);
         console.error('Failed to write OpenClaw config:', error);

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -62,10 +62,17 @@ async function readJsonFile<T>(filePath: string): Promise<T | null> {
   }
 }
 
-/** Write a JSON file, creating parent directories if needed. */
-async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
+/** Write a JSON file only when its serialized content changes. */
+async function writeJsonFile(filePath: string, data: unknown): Promise<boolean> {
+  const nextContent = JSON.stringify(data, null, 2);
+  const currentContent = await readFile(filePath, 'utf-8').catch(() => null);
+  if (currentContent === nextContent) {
+    return false;
+  }
+
   await ensureDir(join(filePath, '..'));
-  await writeFile(filePath, JSON.stringify(data, null, 2), 'utf-8');
+  await writeFile(filePath, nextContent, 'utf-8');
+  return true;
 }
 
 // ── Types ────────────────────────────────────────────────────────
@@ -185,7 +192,7 @@ function normalizeAgentsDefaultsCompactionMode(config: Record<string, unknown>):
   }
 }
 
-async function writeOpenClawJson(config: Record<string, unknown>): Promise<void> {
+async function writeOpenClawJson(config: Record<string, unknown>): Promise<boolean> {
   normalizeAgentsDefaultsCompactionMode(config);
 
   // Ensure SIGUSR1 graceful reload is authorized by OpenClaw config.
@@ -197,7 +204,7 @@ async function writeOpenClawJson(config: Record<string, unknown>): Promise<void>
   commands.restart = true;
   config.commands = commands;
 
-  await writeJsonFile(OPENCLAW_CONFIG_PATH, config);
+  return await writeJsonFile(OPENCLAW_CONFIG_PATH, config);
 }
 
 // ── Exported Functions (all async) ───────────────────────────────
@@ -878,8 +885,9 @@ export async function syncGatewayTokenToConfig(token: string): Promise<void> {
     if (!gateway.mode) gateway.mode = 'local';
     config.gateway = gateway;
 
-    await writeOpenClawJson(config);
-    console.log('Synced gateway token to openclaw.json');
+    if (await writeOpenClawJson(config)) {
+      console.log('Synced gateway token to openclaw.json');
+    }
   });
 }
 
@@ -911,8 +919,9 @@ export async function syncBrowserConfigToOpenClaw(): Promise<void> {
     if (!changed) return;
 
     config.browser = browser;
-    await writeOpenClawJson(config);
-    console.log('Synced browser config to openclaw.json');
+    if (await writeOpenClawJson(config)) {
+      console.log('Synced browser config to openclaw.json');
+    }
   });
 }
 
@@ -950,8 +959,9 @@ export async function syncSessionIdleMinutesToOpenClaw(): Promise<void> {
     session.idleMinutes = DEFAULT_IDLE_MINUTES;
     config.session = session;
 
-    await writeOpenClawJson(config);
-    console.log(`Synced session.idleMinutes=${DEFAULT_IDLE_MINUTES} (7d) to openclaw.json`);
+    if (await writeOpenClawJson(config)) {
+      console.log(`Synced session.idleMinutes=${DEFAULT_IDLE_MINUTES} (7d) to openclaw.json`);
+    }
   });
 }
 
@@ -1415,8 +1425,9 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
     }
 
     if (modified) {
-      await writeOpenClawJson(config);
-      console.log('[sanitize] openclaw.json sanitized successfully');
+      if (await writeOpenClawJson(config)) {
+        console.log('[sanitize] openclaw.json sanitized successfully');
+      }
     }
   });
 }

--- a/electron/utils/openclaw-proxy.ts
+++ b/electron/utils/openclaw-proxy.ts
@@ -43,6 +43,10 @@ export async function syncProxyConfigToOpenClaw(
       return;
     }
 
+    if (nextProxy === currentProxy) {
+      return;
+    }
+
     if (!config.channels) {
       config.channels = {};
     }

--- a/tests/unit/gateway-startup-orchestrator.test.ts
+++ b/tests/unit/gateway-startup-orchestrator.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import { runGatewayStartupSequence } from '@electron/gateway/startup-orchestrator';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp',
+    getVersion: () => '0.3.1-test',
+    isPackaged: false,
+  },
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+}));
+
+describe('gateway startup orchestrator', () => {
+  it('re-probes for an existing gateway after waiting for the port on Windows', async () => {
+    const findExistingGateway = vi
+      .fn<(_port: number, _ownedPid?: number) => Promise<{ port: number } | null>>()
+      .mockResolvedValueOnce(null)
+      .mockResolvedValueOnce({ port: 18789 });
+    const connect = vi.fn().mockResolvedValue(undefined);
+    const onConnectedToExistingGateway = vi.fn();
+    const waitForPortFree = vi.fn().mockResolvedValue(undefined);
+    const startProcess = vi.fn().mockResolvedValue(undefined);
+    const waitForReady = vi.fn().mockResolvedValue(undefined);
+    const onConnectedToManagedGateway = vi.fn();
+
+    await runGatewayStartupSequence({
+      port: 18789,
+      ownedPid: 7476,
+      shouldWaitForPortFree: true,
+      resetStartupStderrLines: vi.fn(),
+      getStartupStderrLines: () => [],
+      assertLifecycle: vi.fn(),
+      findExistingGateway,
+      connect,
+      onConnectedToExistingGateway,
+      waitForPortFree,
+      startProcess,
+      waitForReady,
+      onConnectedToManagedGateway,
+      runDoctorRepair: vi.fn().mockResolvedValue(false),
+      onDoctorRepairSuccess: vi.fn(),
+      delay: vi.fn().mockResolvedValue(undefined),
+    });
+
+    expect(findExistingGateway).toHaveBeenCalledTimes(2);
+    expect(findExistingGateway).toHaveBeenNthCalledWith(1, 18789, 7476);
+    expect(findExistingGateway).toHaveBeenNthCalledWith(2, 18789, 7476);
+    expect(waitForPortFree).toHaveBeenCalledWith(18789);
+    expect(connect).toHaveBeenCalledWith(18789, undefined);
+    expect(onConnectedToExistingGateway).toHaveBeenCalledTimes(1);
+    expect(startProcess).not.toHaveBeenCalled();
+    expect(waitForReady).not.toHaveBeenCalled();
+    expect(onConnectedToManagedGateway).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/openclaw-auth.test.ts
+++ b/tests/unit/openclaw-auth.test.ts
@@ -201,3 +201,41 @@ describe('sanitizeOpenClawConfig', () => {
     logSpy.mockRestore();
   });
 });
+
+describe('syncGatewayTokenToConfig', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+  });
+
+  it('does not rewrite openclaw.json when gateway auth config is already up to date', async () => {
+    await writeOpenClawJson({
+      commands: { restart: true },
+      gateway: {
+        mode: 'local',
+        auth: {
+          mode: 'token',
+          token: 'gw-token',
+        },
+        controlUi: {
+          allowedOrigins: ['file://'],
+        },
+      },
+    });
+
+    const configPath = join(testHome, '.openclaw', 'openclaw.json');
+    const before = await readFile(configPath, 'utf8');
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    const { syncGatewayTokenToConfig } = await import('@electron/utils/openclaw-auth');
+    await syncGatewayTokenToConfig('gw-token');
+
+    const after = await readFile(configPath, 'utf8');
+    expect(after).toBe(before);
+    expect(logSpy).not.toHaveBeenCalled();
+
+    logSpy.mockRestore();
+  });
+});

--- a/tests/unit/openclaw-proxy.test.ts
+++ b/tests/unit/openclaw-proxy.test.ts
@@ -86,4 +86,28 @@ describe('syncProxyConfigToOpenClaw', () => {
     };
     expect(updatedConfig.channels.telegram.proxy).toBeUndefined();
   });
+
+  it('skips rewriting telegram proxy when the desired value is already present', async () => {
+    readOpenClawConfigMock.mockResolvedValue({
+      channels: {
+        telegram: {
+          botToken: 'token',
+          proxy: 'socks5://127.0.0.1:7891',
+        },
+      },
+    });
+
+    const { syncProxyConfigToOpenClaw } = await import('@electron/utils/openclaw-proxy');
+
+    await syncProxyConfigToOpenClaw({
+      proxyEnabled: true,
+      proxyServer: '',
+      proxyHttpServer: '',
+      proxyHttpsServer: '',
+      proxyAllServer: 'socks5://127.0.0.1:7891',
+      proxyBypassRules: '',
+    });
+
+    expect(writeOpenClawConfigMock).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
## Summary

This fixes a gateway reconnect race on Windows where ClawX could spawn a second gateway process while the original process was still restarting and still owned port `18789`.

## Problem

When the gateway WebSocket dropped during an internal gateway restart or transient reconnect window, ClawX would:

1. schedule a reconnect
2. wait for the port to become available
3. proceed to `startProcess()`

The problem is that the original gateway could already be back by that point, still owning the port. That caused the replacement process to fail with errors like:

- `gateway already running`
- `Port 18789 is already in use`

This matches the restart loop seen in the attached logs.

## Fix

After `waitForPortFree()` in the startup orchestrator, re-probe for an existing gateway before spawning a new process.

If the original gateway has recovered, ClawX now reconnects to it instead of launching a duplicate process.

## Tests

Added a regression test covering the Windows-style recovery path where:

- initial probe finds no gateway
- port wait completes
- second probe finds the recovered gateway
- ClawX reconnects instead of calling `startProcess()`

Also re-ran related gateway unit tests.

## Verification

- `mise exec -- pnpm test tests/unit/gateway-startup-orchestrator.test.ts tests/unit/gateway-supervisor.test.ts tests/unit/gateway-manager-heartbeat.test.ts`
- `mise exec -- pnpm test tests/unit/gateway-startup-recovery.test.ts tests/unit/gateway-process-policy.test.ts`

## Notes

This addresses the duplicate-spawn / `gateway already running` loop.

It does not fully explain every underlying heartbeat or socket drop, but it prevents those transient disconnects from cascading into an avoidable process start failure.