### PR TITLE
fix: avoid systemd-supervised gateway retry loop in owned launcher

### DIFF
--- a/electron/gateway/config-sync-env.ts
+++ b/electron/gateway/config-sync-env.ts
@@ -1,0 +1,22 @@
+export const SUPERVISED_SYSTEMD_ENV_KEYS = [
+  'OPENCLAW_SYSTEMD_UNIT',
+  'INVOCATION_ID',
+  'SYSTEMD_EXEC_PID',
+  'JOURNAL_STREAM',
+] as const;
+
+export type GatewayEnv = Record<string, string | undefined>;
+
+/**
+ * OpenClaw CLI treats certain environment variables as systemd supervisor hints.
+ * When present in ClawX-owned child-process launches, it can mistakenly enter
+ * a supervised process retry loop. Strip those variables so startup follows
+ * ClawX lifecycle.
+ */
+export function stripSystemdSupervisorEnv(env: GatewayEnv): GatewayEnv {
+  const next = { ...env };
+  for (const key of SUPERVISED_SYSTEMD_ENV_KEYS) {
+    delete next[key];
+  }
+  return next;
+}

--- a/electron/gateway/config-sync.ts
+++ b/electron/gateway/config-sync.ts
@@ -27,6 +27,8 @@ import { syncProxyConfigToOpenClaw } from '../utils/openclaw-proxy';
 import { logger } from '../utils/logger';
 import { prependPathEntry } from '../utils/env-path';
 import { copyPluginFromNodeModules, fixupPluginManifest, cpSyncSafe } from '../utils/plugin-install';
+import { stripSystemdSupervisorEnv } from './config-sync-env';
+
 
 export interface GatewayLaunchContext {
   appSettings: Awaited<ReturnType<typeof getAllSettings>>;
@@ -317,7 +319,7 @@ export async function prepareGatewayLaunchContext(port: number): Promise<Gateway
     ? prependPathEntry(baseEnvRecord, binPath).env
     : baseEnvRecord;
   const forkEnv: Record<string, string | undefined> = {
-    ...baseEnvPatched,
+    ...stripSystemdSupervisorEnv(baseEnvPatched),
     ...providerEnv,
     ...uvEnv,
     ...proxyEnv,

--- a/tests/unit/config-sync.test.ts
+++ b/tests/unit/config-sync.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { stripSystemdSupervisorEnv } from '@electron/gateway/config-sync-env';
+
+describe('stripSystemdSupervisorEnv', () => {
+  it('removes systemd supervisor marker env vars', () => {
+    const env = {
+      PATH: '/usr/bin:/bin',
+      OPENCLAW_SYSTEMD_UNIT: 'openclaw-gateway.service',
+      INVOCATION_ID: 'abc123',
+      SYSTEMD_EXEC_PID: '777',
+      JOURNAL_STREAM: '8:12345',
+      OTHER: 'keep-me',
+    };
+
+    const result = stripSystemdSupervisorEnv(env);
+
+    expect(result).toEqual({
+      PATH: '/usr/bin:/bin',
+      OTHER: 'keep-me',
+    });
+  });
+
+  it('keeps unrelated variables unchanged', () => {
+    const env = {
+      NODE_ENV: 'production',
+      OPENCLAW_GATEWAY_TOKEN: 'token',
+      CLAWDBOT_SKIP_CHANNELS: '0',
+    };
+
+    expect(stripSystemdSupervisorEnv(env)).toEqual(env);
+  });
+
+  it('does not mutate source env object', () => {
+    const env = {
+      OPENCLAW_SYSTEMD_UNIT: 'openclaw-gateway.service',
+      VALUE: '1',
+    };
+    const before = { ...env };
+
+    const result = stripSystemdSupervisorEnv(env);
+
+    expect(env).toEqual(before);
+    expect(result).toEqual({ VALUE: '1' });
+  });
+});


### PR DESCRIPTION
### Summary
- In `electron/gateway/config-sync.ts`, strip systemd supervisor marker environment variables before spawning the gateway child process.
- This prevents `openclaw gateway` from mis-detecting the owned ClawX child process as a supervised systemd instance and entering the 5s retry loop (`already running under systemd`).

### Risk / Tradeoff
- This change intentionally drops systemd hint env vars only in ClawX-owned gateway launches.
- Risk: if external/system-managed invocation paths rely on these env vars for gateway behavior, those paths should continue to pass through direct CLI paths unchanged, so impact is scoped to spawned gateway from ClawX.
- Existing behavior is still preserved when not launching from ClawX-owned context.

### Tests
- `pnpm exec tsc -p tsconfig.json --noEmit`
- `pnpm exec vitest run tests/unit/config-sync.test.ts`

### Notes
- Added helper for sanitizer coverage:
  - `stripSystemdSupervisorEnv`.
- Added unit tests in `tests/unit/config-sync.test.ts` to cover marker removal, unrelated-key preservation, and immutability.