### PR TITLE
fix: sync Ollama provider config to gateway runtime (fixes #448)

### DIFF
--- a/electron/services/providers/provider-runtime-sync.ts
+++ b/electron/services/providers/provider-runtime-sync.ts
@@ -286,7 +286,7 @@ async function syncProviderSecretToRuntime(
 async function resolveRuntimeSyncContext(config: ProviderConfig): Promise<RuntimeProviderSyncContext | null> {
   const runtimeProviderKey = await resolveRuntimeProviderKey(config);
   const meta = getProviderConfig(config.type);
-  const api = config.apiProtocol || (config.type === 'custom' ? 'openai-completions' : meta?.api);
+  const api = config.apiProtocol || ((config.type === 'custom' || config.type === 'ollama') ? 'openai-completions' : meta?.api);
   if (!api) {
     return null;
   }
@@ -315,7 +315,7 @@ async function syncCustomProviderAgentModel(
   runtimeProviderKey: string,
   apiKey: string | undefined,
 ): Promise<void> {
-  if (config.type !== 'custom') {
+  if (config.type !== 'custom' && config.type !== 'ollama') {
     return;
   }
 
@@ -402,7 +402,7 @@ async function buildAgentModelProviderEntry(
   authHeader?: boolean;
 } | null> {
   const meta = getProviderConfig(config.type);
-  const api = config.apiProtocol || (config.type === 'custom' ? 'openai-completions' : meta?.api);
+  const api = config.apiProtocol || ((config.type === 'custom' || config.type === 'ollama') ? 'openai-completions' : meta?.api);
   const baseUrl = normalizeProviderBaseUrl(config, config.baseUrl || meta?.baseUrl, api);
   if (!api || !baseUrl) {
     return null;
@@ -593,7 +593,7 @@ export async function syncDefaultProviderToRuntime(
       ? (provider.model.startsWith(`${ock}/`) ? provider.model : `${ock}/${provider.model}`)
       : undefined;
 
-    if (provider.type === 'custom') {
+    if (provider.type === 'custom' || provider.type === 'ollama') {
       await setOpenClawDefaultModelWithOverride(ock, modelOverride, {
         baseUrl: normalizeProviderBaseUrl(provider, provider.baseUrl, provider.apiProtocol || 'openai-completions'),
         api: provider.apiProtocol || 'openai-completions',
@@ -689,7 +689,7 @@ export async function syncDefaultProviderToRuntime(
   }
 
   if (
-    provider.type === 'custom' &&
+    (provider.type === 'custom' || provider.type === 'ollama') &&
     providerKey &&
     provider.baseUrl
   ) {

--- a/tests/unit/provider-runtime-sync.test.ts
+++ b/tests/unit/provider-runtime-sync.test.ts
@@ -256,4 +256,58 @@ describe('provider-runtime-sync refresh strategy', () => {
       }),
     );
   });
+
+  it('syncs Ollama provider config to runtime without adding model prefix', async () => {
+    const ollamaProvider = createProvider({
+      id: 'ollamafd',
+      type: 'ollama',
+      name: 'Ollama',
+      model: 'qwen3:30b',
+      baseUrl: 'http://localhost:11434/v1',
+    });
+
+    mocks.getProviderConfig.mockReturnValue(undefined);
+    mocks.getProviderSecret.mockResolvedValue({ type: 'local', apiKey: 'ollama-local' });
+
+    const gateway = createGateway('running');
+    await syncSavedProviderToRuntime(ollamaProvider, undefined, gateway as GatewayManager);
+
+    expect(mocks.syncProviderConfigToOpenClaw).toHaveBeenCalledWith(
+      'ollama-ollamafd',
+      'qwen3:30b',
+      expect.objectContaining({
+        baseUrl: 'http://localhost:11434/v1',
+        api: 'openai-completions',
+      }),
+    );
+    expect(gateway.debouncedReload).toHaveBeenCalledTimes(1);
+  });
+
+  it('syncs Ollama as default provider with correct baseUrl and api protocol', async () => {
+    const ollamaProvider = createProvider({
+      id: 'ollamafd',
+      type: 'ollama',
+      name: 'Ollama',
+      model: 'qwen3:30b',
+      baseUrl: 'http://localhost:11434/v1',
+    });
+
+    mocks.getProvider.mockResolvedValue(ollamaProvider);
+    mocks.getDefaultProvider.mockResolvedValue('ollamafd');
+    mocks.getProviderConfig.mockReturnValue(undefined);
+    mocks.getApiKey.mockResolvedValue('ollama-local');
+
+    const gateway = createGateway('running');
+    await syncDefaultProviderToRuntime('ollamafd', gateway as GatewayManager);
+
+    expect(mocks.setOpenClawDefaultModelWithOverride).toHaveBeenCalledWith(
+      'ollama-ollamafd',
+      'ollama-ollamafd/qwen3:30b',
+      expect.objectContaining({
+        baseUrl: 'http://localhost:11434/v1',
+        api: 'openai-completions',
+      }),
+      expect.any(Array),
+    );
+  });
 });


### PR DESCRIPTION
Fixes #448

## 问题

配置 Ollama 本地提供商后，发送消息时报 `Unknown model: ollama-<id>/qwen3:30b` 错误。

根本原因：`resolveRuntimeSyncContext` 在确定 API 协议时，对 `ollama` 类型的提供商没有像 `custom` 那样默认使用 `openai-completions`。由于 Ollama 在 provider registry 中没有 `providerConfig.api`，`api` 变量解析为 `undefined`，导致函数提前返回 `null`，Ollama 的配置从未写入 `openclaw.json`。网关无法识别 `ollama-<id>` 前缀，报出 "Unknown model" 错误。

## 修复方案

在以下几处将 `ollama` 与 `custom` 统一处理，均默认使用 `openai-completions` 协议：

- `resolveRuntimeSyncContext`：允许 Ollama 进入 runtime 同步流程
- `buildAgentModelProviderEntry`：为 agent 构建 Ollama 提供商配置时正确设置 api 协议
- `syncCustomProviderAgentModel`：同时处理 `ollama` 类型的 agent model 更新
- `syncDefaultProviderToRuntime`：将 Ollama 设为默认提供商时写入完整的提供商配置

## 测试

新增两个单元测试：
1. 验证 `syncSavedProviderToRuntime` 对 Ollama 提供商调用 `syncProviderConfigToOpenClaw`，且 `api` 为 `openai-completions`
2. 验证 `syncDefaultProviderToRuntime` 以正确的 baseUrl 和协议调用 `setOpenClawDefaultModelWithOverride`

```
pnpm exec vitest run tests/unit/provider-runtime-sync.test.ts
# 10 tests passed
```