### PR TITLE
feat(scripts): 为下载脚本添加网络代理和TLS证书支持

### DIFF
--- a/package.json
+++ b/package.json
@@ -134,6 +134,7 @@
         "tailwindcss": "^3.4.19",
         "tailwindcss-animate": "^1.0.7",
         "typescript": "^5.9.3",
+        "undici": "^7.24.6",
         "use-stick-to-bottom": "^1.1.3",
         "vite": "^7.3.1",
         "vite-plugin-electron": "^0.29.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -208,6 +208,9 @@ importers:
       typescript:
         specifier: ^5.9.3
         version: 5.9.3
+      undici:
+        specifier: ^7.24.6
+        version: 7.24.6
       use-stick-to-bottom:
         specifier: ^1.1.3
         version: 1.1.3(react@19.2.4)
@@ -2523,8 +2526,8 @@ packages:
       link-preview-js:
         optional: true
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
-    resolution: {tarball: https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67}
+  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+    resolution: {commit: 1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67, repo: https://github.com/whiskeysockets/libsignal-node.git, type: git}
     version: 2.0.1
 
   '@xmldom/xmldom@0.8.11':
@@ -8672,7 +8675,7 @@ snapshots:
       '@cacheable/node-cache': 1.7.6
       '@hapi/boom': 9.1.4
       async-mutex: 0.5.0
-      libsignal: '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
+      libsignal: '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67'
       lru-cache: 11.2.7
       music-metadata: 11.12.3
       p-queue: 9.1.0
@@ -8685,7 +8688,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  '@whiskeysockets/libsignal-node@https://codeload.github.com/whiskeysockets/libsignal-node/tar.gz/1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
+  '@whiskeysockets/libsignal-node@git+https://github.com/whiskeysockets/libsignal-node.git#1c30d7d7e76a3b0aa120b04dc6a26f5a12dccf67':
     dependencies:
       curve25519-js: 0.0.4
       protobufjs: 6.8.8

--- a/scripts/download-bundled-node.mjs
+++ b/scripts/download-bundled-node.mjs
@@ -1,11 +1,60 @@
 #!/usr/bin/env zx
 
 import 'zx/globals';
+import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const NODE_VERSION = '22.16.0';
 const BASE_URL = `https://nodejs.org/dist/v${NODE_VERSION}`;
 const OUTPUT_BASE = path.join(ROOT_DIR, 'resources', 'bin');
+
+let networkConfigured = false;
+let networkInfo = { proxy: undefined, caFile: undefined, rejectUnauthorized: true };
+async function configureNetworkOnce() {
+  if (networkConfigured) return;
+  networkConfigured = true;
+
+  const proxy =
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy;
+
+  const caFile =
+    process.env.NODE_DOWNLOAD_CA_FILE ??
+    process.env.CLAWX_CA_FILE ??
+    process.env.NODE_EXTRA_CA_CERTS;
+
+  const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0' ? false : true;
+  networkInfo = { proxy, caFile, rejectUnauthorized };
+
+  let ca;
+  if (caFile) {
+    try {
+      ca = await fs.readFile(caFile);
+    } catch {
+      ca = undefined;
+    }
+  }
+
+  if (!proxy && rejectUnauthorized && !ca) return;
+
+  if (proxy) {
+    setGlobalDispatcher(
+      new ProxyAgent({
+        uri: proxy,
+        connect: { ca, rejectUnauthorized },
+      }),
+    );
+    return;
+  }
+
+  setGlobalDispatcher(
+    new Agent({
+      connect: { ca, rejectUnauthorized },
+    }),
+  );
+}
 
 const TARGETS = {
   'win32-x64': {
@@ -48,7 +97,33 @@ async function setupTarget(id) {
 
   try {
     echo`⬇️ Downloading: ${downloadUrl}`;
-    const response = await fetch(downloadUrl);
+    await configureNetworkOnce();
+    let response;
+    try {
+      response = await fetch(downloadUrl);
+    } catch (err) {
+      const cause = err?.cause;
+      const code = cause?.code ?? err?.code;
+      if (code === 'ECONNREFUSED' && networkInfo.proxy) {
+        throw new Error(
+          `Proxy connection refused when downloading ${downloadUrl}.\n\n` +
+            `Detected proxy: ${networkInfo.proxy}\n\n` +
+            `Fix options:\n` +
+            `- Start your proxy service, or\n` +
+            `- Unset HTTPS_PROXY/HTTP_PROXY for this build environment.\n`,
+        );
+      }
+      if (code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+        throw new Error(
+          `TLS certificate verification failed when downloading ${downloadUrl}.\n\n` +
+            `Fix options:\n` +
+            `- Preferred: export your corporate root CA to a PEM file and set NODE_EXTRA_CA_CERTS or NODE_DOWNLOAD_CA_FILE to that file path.\n` +
+            `- If you must use a proxy, set HTTPS_PROXY/HTTP_PROXY as well.\n` +
+            `- Last resort (insecure): set NODE_TLS_REJECT_UNAUTHORIZED=0.\n`,
+        );
+      }
+      throw err;
+    }
     if (!response.ok) throw new Error(`Failed to download: ${response.statusText}`);
     const buffer = await response.arrayBuffer();
     await fs.writeFile(archivePath, Buffer.from(buffer));

--- a/scripts/download-bundled-uv.mjs
+++ b/scripts/download-bundled-uv.mjs
@@ -1,11 +1,60 @@
 #!/usr/bin/env zx
 
 import 'zx/globals';
+import { Agent, ProxyAgent, setGlobalDispatcher } from 'undici';
 
 const ROOT_DIR = path.resolve(__dirname, '..');
 const UV_VERSION = '0.10.0';
 const BASE_URL = `https://github.com/astral-sh/uv/releases/download/${UV_VERSION}`;
 const OUTPUT_BASE = path.join(ROOT_DIR, 'resources', 'bin');
+
+let networkConfigured = false;
+let networkInfo = { proxy: undefined, caFile: undefined, rejectUnauthorized: true };
+async function configureNetworkOnce() {
+  if (networkConfigured) return;
+  networkConfigured = true;
+
+  const proxy =
+    process.env.HTTPS_PROXY ??
+    process.env.https_proxy ??
+    process.env.HTTP_PROXY ??
+    process.env.http_proxy;
+
+  const caFile =
+    process.env.UV_DOWNLOAD_CA_FILE ??
+    process.env.CLAWX_CA_FILE ??
+    process.env.NODE_EXTRA_CA_CERTS;
+
+  const rejectUnauthorized = process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0' ? false : true;
+  networkInfo = { proxy, caFile, rejectUnauthorized };
+
+  let ca;
+  if (caFile) {
+    try {
+      ca = await fs.readFile(caFile);
+    } catch {
+      ca = undefined;
+    }
+  }
+
+  if (!proxy && rejectUnauthorized && !ca) return;
+
+  if (proxy) {
+    setGlobalDispatcher(
+      new ProxyAgent({
+        uri: proxy,
+        connect: { ca, rejectUnauthorized },
+      }),
+    );
+    return;
+  }
+
+  setGlobalDispatcher(
+    new Agent({
+      connect: { ca, rejectUnauthorized },
+    }),
+  );
+}
 
 // Mapping Node platforms/archs to uv release naming
 const TARGETS = {
@@ -65,7 +114,33 @@ async function setupTarget(id) {
   try {
     // Download
     echo`⬇️ Downloading: ${downloadUrl}`;
-    const response = await fetch(downloadUrl);
+    await configureNetworkOnce();
+    let response;
+    try {
+      response = await fetch(downloadUrl);
+    } catch (err) {
+      const cause = err?.cause;
+      const code = cause?.code ?? err?.code;
+      if (code === 'ECONNREFUSED' && networkInfo.proxy) {
+        throw new Error(
+          `Proxy connection refused when downloading ${downloadUrl}.\n\n` +
+            `Detected proxy: ${networkInfo.proxy}\n\n` +
+            `Fix options:\n` +
+            `- Start your proxy service, or\n` +
+            `- Unset HTTPS_PROXY/HTTP_PROXY for this build environment.\n`,
+        );
+      }
+      if (code === 'UNABLE_TO_VERIFY_LEAF_SIGNATURE') {
+        throw new Error(
+          `TLS certificate verification failed when downloading ${downloadUrl}.\n\n` +
+            `Fix options:\n` +
+            `- Preferred: export your corporate root CA to a PEM file and set NODE_EXTRA_CA_CERTS or UV_DOWNLOAD_CA_FILE to that file path.\n` +
+            `- If you must use a proxy, set HTTPS_PROXY/HTTP_PROXY as well.\n` +
+            `- Last resort (insecure): set NODE_TLS_REJECT_UNAUTHORIZED=0.\n`,
+        );
+      }
+      throw err;
+    }
     if (!response.ok) throw new Error(`Failed to download: ${response.statusText}`);
     const buffer = await response.arrayBuffer();
     await fs.writeFile(archivePath, Buffer.from(buffer));


### PR DESCRIPTION


## Summary

<!-- What does this PR change and why? -->
     添加 configureNetworkOnce 函数以支持通过环境变量配置 HTTP/HTTPS 代理和自定义 CA 证书。 新增对代理连接失败和 TLS      证书验证错误的详细错误提示，提高在企业网络环境下的可用性。
## Related Issue(s)

<!-- e.g. Closes #123 -->

## Type of Change  

- [√] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [√] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [ ] I verified there are no unrelated changes in this PR.
