### PR TITLE
fix: extend /models fallback to cover 400/405/501 for custom providers

### DIFF
--- a/electron/services/providers/provider-validation.ts
+++ b/electron/services/providers/provider-validation.ts
@@ -147,6 +147,15 @@ function classifyAuthResponse(
   return { valid: false, error: msg };
 }
 
+function isModelsEndpointUnavailable(status: number | undefined): boolean {
+  if (status === undefined) return false;
+  // 404: endpoint doesn't exist
+  // 400: endpoint rejects the request format (some providers don't implement /models)
+  // 405: GET method not allowed on /models
+  // 501: endpoint not implemented
+  return status === 404 || status === 400 || status === 405 || status === 501;
+}
+
 async function validateOpenAiCompatibleKey(
   providerType: string,
   apiKey: string,
@@ -162,9 +171,9 @@ async function validateOpenAiCompatibleKey(
   const { modelsUrl, probeUrl } = resolveOpenAiProbeUrls(trimmedBaseUrl, apiProtocol);
   const modelsResult = await performProviderValidationRequest(providerType, modelsUrl, headers);
 
-  if (modelsResult.status === 404) {
+  if (isModelsEndpointUnavailable(modelsResult.status)) {
     console.log(
-      `[clawx-validate] ${providerType} /models returned 404, falling back to ${apiProtocol} probe`,
+      `[clawx-validate] ${providerType} /models returned ${modelsResult.status}, falling back to ${apiProtocol} probe`,
     );
     if (apiProtocol === 'openai-responses') {
       return await performResponsesProbe(providerType, probeUrl, headers);

--- a/tests/unit/provider-validation.test.ts
+++ b/tests/unit/provider-validation.test.ts
@@ -121,6 +121,82 @@ describe('validateApiKeyWithProvider', () => {
     );
   });
 
+  it('falls back to /chat/completions for openai-completions when /models returns 400', async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Bad Request' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unknown model' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-mobile-cloud-test', {
+      baseUrl: 'https://ai.example-mobile.com/v1',
+      apiProtocol: 'openai-completions',
+    });
+
+    expect(result).toMatchObject({ valid: true });
+    expect(proxyAwareFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://ai.example-mobile.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('falls back to /chat/completions for openai-completions when /models returns 405', async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Method Not Allowed' } }), {
+          status: 405,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ id: 'chatcmpl-123' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-opencode-test', {
+      baseUrl: 'https://opencode.example.com/v1',
+      apiProtocol: 'openai-completions',
+    });
+
+    expect(result).toMatchObject({ valid: true });
+    expect(proxyAwareFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://opencode.example.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' })
+    );
+  });
+
+  it('does not fall back when /models returns 401 (invalid key)', async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-bad-key', {
+      baseUrl: 'https://api.example.com/v1',
+      apiProtocol: 'openai-completions',
+    });
+
+    expect(result).toMatchObject({ valid: false });
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('does not duplicate endpoint suffix when baseUrl already points to /responses', async () => {
     proxyAwareFetch
       .mockResolvedValueOnce(


### PR DESCRIPTION
Fixes #768

## Problem

Custom model providers like Mobile Cloud and opencode cannot be saved in ClawX — the save dialog shows "Invalid API key" even though the same key works correctly in openclaw/copaw.

Root cause: `validateOpenAiCompatibleKey()` only fell back from `GET /models` to `POST /chat/completions` when `/models` returned **404**. However, some OpenAI-compatible providers that don't implement the `/models` endpoint return **400** (Bad Request) or **405** (Method Not Allowed) instead. These non-auth error codes were incorrectly treated as definitive validation failures.

## Solution

Introduce `isModelsEndpointUnavailable()` to also treat status codes 400, 405, and 501 as signals that the provider's `/models` endpoint is unavailable — matching the broader fallback logic already used by the Anthropic-header validation path. Auth failure codes (401, 403) are intentionally excluded and still return an immediate invalid-key result.

## Testing

- Added 3 new unit tests covering the 400, 405, and 401 cases
- All 8 unit tests pass: `pnpm exec vitest run tests/unit/provider-validation.test.ts`
- TypeScript type check passes: `pnpm exec tsc -p tsconfig.json --noEmit`