### PR TITLE
fix(chat): preserve message history when gateway returns fewer messages during active send

### DIFF
--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1386,6 +1386,23 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       }
 
+      // Guard: during an active send, don't let a history poll replace the local
+      // conversation with fewer messages from the gateway. This can happen when
+      // the gateway is reconnecting after a brief disconnect or hasn't fully
+      // persisted the conversation yet. Without this guard, the history poll
+      // causes chat history to vanish mid-conversation (issue #709).
+      {
+        const preApplyState = get();
+        if (
+          preApplyState.sending &&
+          preApplyState.lastUserMessageAt &&
+          finalMessages.length < preApplyState.messages.length &&
+          preApplyState.messages.length > 1
+        ) {
+          finalMessages = preApplyState.messages;
+        }
+      }
+
       set({ messages: finalMessages, thinkingLevel, loading: false });
 
       // Extract first user message text as a session label for display in the toolbar.


### PR DESCRIPTION
Fixes #709

## Problem

During an active send, the periodic history poll (every 4 seconds) can race with a brief gateway disconnect/reconnect. If the gateway's view of the session is incomplete at that moment — because it is mid-reconnect or hasn't fully persisted the conversation yet — the loaded history returns fewer messages than the local UI state. This causes the entire conversation to vanish from the UI; the user sees only the latest partial response and must restart ClawX to recover their chat history.

Root cause: `applyLoadedMessages` unconditionally replaces `state.messages` with whatever the gateway returns, even if the returned list is shorter than what the user currently sees.

## Solution

Add a guard in `applyLoadedMessages` (inside `loadHistory`): if a send is currently in progress **and** the loaded history contains fewer messages than the current local state, keep the existing local messages instead of replacing them. The conditions are:

- `state.sending === true` — an active run is in flight
- `state.lastUserMessageAt` is set — confirms this is a real ongoing conversation, not initial load
- `finalMessages.length < state.messages.length` — gateway returned a shorter list
- `state.messages.length > 1` — at least two messages exist locally (i.e., an actual conversation)

Once the run finishes, the next history load happens outside of `sending` and will reconcile the final state normally.

## Testing

- Verified TypeScript compiles cleanly (`pnpm exec tsc -p tsconfig.json --noEmit`)
- All 61 unit tests pass (`pnpm exec vitest run tests/unit/`)
- Manual logic review: the guard only fires when all four conditions are met, so it does not affect:
  - Normal history loads (not during a send)
  - Initial session load (messages.length ≤ 1)
  - History loads that return more messages (finalMessages ≥ current)