### PR TITLE
fix(mac): improve macOS installation stability with build verification, signing hardening, and diagnostics

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -96,6 +96,73 @@ jobs:
           echo "File descriptor limit: $(ulimit -n)"
           pnpm run package:mac
 
+      # Verify macOS code signature, notarization staple, and Gatekeeper acceptance.
+      # This catches silently broken signatures BEFORE artifacts are published.
+      # Modelled after VSCode's post-build verification (build/darwin/sign.ts).
+      - name: Verify macOS code signature and notarization
+        if: matrix.platform == 'mac'
+        run: |
+          set -euo pipefail
+
+          verify_app() {
+            local APP_PATH="$1"
+            local LABEL="$2"
+
+            if [ ! -d "$APP_PATH" ]; then
+              echo "⚠️  ${APP_PATH} not found, skipping verification for ${LABEL}"
+              return 0
+            fi
+
+            echo ""
+            echo "🔍 Verifying ${LABEL}: ${APP_PATH}"
+
+            # 1. Deep code signature verification (same flags as VSCode CI)
+            echo "  [1/4] Checking code signature (--deep --strict)..."
+            codesign --verify --deep --strict --verbose=2 "$APP_PATH"
+            echo "        ✅ Code signature valid"
+
+            # 2. Verify secure timestamp exists (prevents expiry-based rejection)
+            echo "  [2/4] Checking for secure timestamp..."
+            CODESIGN_DISPLAY=$(codesign -dvvv "$APP_PATH" 2>&1 || true)
+            if echo "$CODESIGN_DISPLAY" | grep -q "Timestamp="; then
+              TIMESTAMP=$(echo "$CODESIGN_DISPLAY" | grep "Timestamp=" | head -1)
+              echo "        ✅ ${TIMESTAMP}"
+            else
+              echo "        ❌ ERROR: No secure timestamp found in signature!"
+              echo "$CODESIGN_DISPLAY"
+              exit 1
+            fi
+
+            # 3. Gatekeeper assessment (will the OS allow this app to launch?)
+            echo "  [3/4] Assessing Gatekeeper acceptance..."
+            spctl --assess --type execute --verbose "$APP_PATH" 2>&1
+            echo "        ✅ Gatekeeper accepted"
+
+            # 4. Verify notarization ticket is stapled
+            echo "  [4/4] Verifying notarization staple..."
+            xcrun stapler validate "$APP_PATH" 2>&1
+            echo "        ✅ Notarization staple valid"
+
+            echo "  ✅ All checks passed for ${LABEL}"
+          }
+
+          # Verify both architecture builds
+          verify_app "release/mac/ClawX.app" "macOS x64"
+          verify_app "release/mac-arm64/ClawX.app" "macOS arm64"
+
+          # Verify DMG files (informational — DMGs themselves are often unsigned)
+          echo ""
+          echo "🔍 Checking DMG artifacts..."
+          for dmg in release/*.dmg; do
+            if [ -f "$dmg" ]; then
+              echo "  DMG: $(basename "$dmg")"
+              xcrun stapler validate "$dmg" 2>&1 && echo "    ✅ DMG stapled" || echo "    ℹ️  DMG not stapled (expected if only .app is stapled)"
+            fi
+          done
+
+          echo ""
+          echo "✅ All macOS verification checks passed"
+
       # Windows specific steps
       - name: Build Windows
         if: matrix.platform == 'win'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -404,10 +404,28 @@ jobs:
             
             ### ⚠️ Installation Notes
             
-            - **macOS**: On first launch, you may see "cannot verify developer". Go to System Preferences → Security & Privacy to allow the app to run
-            - **Windows**: SmartScreen may block the app. Click "More info" → "Run anyway" to proceed
-            - **Linux AppImage**: First run `chmod +x ClawX-*.AppImage` to add execute permission. On Ubuntu 22.04 you may also need `sudo apt install libfuse2`; on Ubuntu 24.04 use `sudo apt install libfuse2t64`
-            - **Linux .deb (Ubuntu 24.04)**: If installation fails due to missing dependencies, use `sudo apt install libgtk-3-0t64 libnotify4t64 libxss1t64` before installing
+            #### macOS 安装说明
+            
+            - **首次启动**: 如果看到"无法验证开发者"提示，请前往 系统设置 → 隐私与安全性，点击"仍要打开"
+            - **首次启动 (备选方法)**: 右键点击 ClawX.app → 选择"打开"（而非双击），可绕过 Gatekeeper 首次检查
+            - **"已损坏，无法打开" / "File is damaged"**: 这通常是 macOS 隔离属性导致的。请在终端运行：
+              ```
+              xattr -cr /Applications/ClawX.app
+              ```
+              然后重新打开应用
+            - **"已不能再打开" / "Can't be opened"**: 这通常是应用文件损坏（可能由更新失败导致）。请：
+              1. 从"应用程序"文件夹删除 ClawX.app
+              2. 从本页面重新下载对应架构的 DMG
+              3. 重新拖入"应用程序"文件夹并打开
+            
+            #### Windows
+            
+            - **SmartScreen may block the app**: Click "More info" → "Run anyway" to proceed
+            
+            #### Linux
+            
+            - **AppImage**: First run `chmod +x ClawX-*.AppImage` to add execute permission. On Ubuntu 22.04 you may also need `sudo apt install libfuse2`; on Ubuntu 24.04 use `sudo apt install libfuse2t64`
+            - **.deb (Ubuntu 24.04)**: If installation fails due to missing dependencies, use `sudo apt install libgtk-3-0t64 libnotify4t64 libxss1t64` before installing
             
             ---
             

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -85,6 +85,10 @@ mac:
   entitlements: entitlements.mac.plist
   entitlementsInherit: entitlements.mac.plist
   notarize: true
+  # Explicit Apple TSA ensures a secure timestamp is embedded in the signature.
+  # Without it, CI network issues can silently omit the timestamp, causing
+  # Gatekeeper to reject the app with "damaged" after the signing cert expires.
+  timestamp: "http://timestamp.apple.com/ts01"
   extendInfo:
     NSMicrophoneUsageDescription: ClawX requires microphone access for voice features
     NSCameraUsageDescription: ClawX requires camera access for video features

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -282,6 +282,32 @@ async function initialize(): Promise<void> {
     `Runtime: platform=${process.platform}/${process.arch}, electron=${process.versions.electron}, node=${process.versions.node}, packaged=${app.isPackaged}, pid=${process.pid}, ppid=${process.ppid}`
   );
 
+  // macOS-only: verify the running app bundle's code signature at startup.
+  // A broken signature (e.g. from a failed auto-update or manual tampering)
+  // causes macOS to show "应用程序已不能再打开" on the *next* launch.
+  // This early diagnostic logs a warning so the issue is captured in logs
+  // before Gatekeeper kills the process on a subsequent launch.
+  if (process.platform === 'darwin' && app.isPackaged) {
+    try {
+      const { execSync } = await import('node:child_process');
+      const appPath = app.getAppPath(); // .../ClawX.app/Contents/Resources/app.asar
+      const appBundlePath = appPath.replace(/\/Contents\/Resources\/app(\.asar)?$/, '');
+      if (appBundlePath.endsWith('.app')) {
+        execSync(`codesign --verify --quiet "${appBundlePath}"`, { timeout: 10_000 });
+        logger.debug('[Startup] macOS code signature verification passed');
+      }
+    } catch (error) {
+      // Log but don't block — the app is already running, and the user should
+      // see the UI. The warning helps diagnose "can't be opened" reports.
+      logger.warn(
+        '[Startup] ⚠️  macOS code signature verification FAILED. ' +
+        'The app may have been corrupted by a partial update or external modification. ' +
+        'If you see "应用程序已不能再打开" on next launch, please reinstall ClawX.',
+        error,
+      );
+    }
+  }
+
   if (!isE2EMode) {
     // Warm up network optimization (non-blocking)
     void warmupNetworkOptimization();

--- a/electron/main/updater.ts
+++ b/electron/main/updater.ts
@@ -226,6 +226,15 @@ export class AppUpdater extends EventEmitter {
    */
   quitAndInstall(): void {
     logger.info('[Updater] quitAndInstall called');
+
+    // Log update details so post-mortem debugging is possible if the update
+    // produces a corrupted install ("已不能再打开" / "can't be opened").
+    const updateVersion = this.status.info?.version ?? 'unknown';
+    logger.info(`[Updater] Installing update: ${app.getVersion()} → ${updateVersion}`);
+    if (process.platform === 'darwin') {
+      logger.info('[Updater] macOS: delegating to Squirrel.Mac (ShipIt) for atomic app replacement');
+    }
+
     setQuitting();
     autoUpdater.quitAndInstall();
   }

--- a/scripts/after-pack.cjs
+++ b/scripts/after-pack.cjs
@@ -799,4 +799,89 @@ exports.default = async function afterPack(context) {
       }
     }
   }
+
+  // ── Final integrity summary ────────────────────────────────────────────────
+  // Log file count and total size of the Resources directory so CI can detect
+  // unexpected growth or shrinkage between releases.  Also verify that
+  // critical patched files contain the expected content (catch silent write
+  // failures or encoding corruption).
+
+  function countFilesRecursive(dir) {
+    let count = 0;
+    let entries;
+    try { entries = readdirSync(normWin(dir), { withFileTypes: true }); } catch { return 0; }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory() || (entry.isSymbolicLink?.() && (() => { try { return statSync(normWin(full)).isDirectory(); } catch { return false; } })())) {
+        count += countFilesRecursive(full);
+      } else {
+        count++;
+      }
+    }
+    return count;
+  }
+
+  function getDirSizeRecursive(dir) {
+    let total = 0;
+    let entries;
+    try { entries = readdirSync(normWin(dir), { withFileTypes: true }); } catch { return 0; }
+    for (const entry of entries) {
+      const full = join(dir, entry.name);
+      if (entry.isDirectory()) {
+        total += getDirSizeRecursive(full);
+      } else if (entry.isFile()) {
+        try { total += statSync(normWin(full)).size; } catch { /* skip */ }
+      }
+    }
+    return total;
+  }
+
+  function formatSizeHuman(bytes) {
+    if (bytes >= 1024 * 1024 * 1024) return `${(bytes / 1024 / 1024 / 1024).toFixed(1)}G`;
+    if (bytes >= 1024 * 1024) return `${(bytes / 1024 / 1024).toFixed(1)}M`;
+    if (bytes >= 1024) return `${(bytes / 1024).toFixed(1)}K`;
+    return `${bytes}B`;
+  }
+
+  const totalFiles = countFilesRecursive(resourcesDir);
+  const totalSize = getDirSizeRecursive(resourcesDir);
+  console.log(`[after-pack] 📊 Final Resources: ${totalFiles} files, ${formatSizeHuman(totalSize)} in ${resourcesDir}`);
+
+  // Verify critical patched modules contain the expected marker strings.
+  // If a write was silently truncated or encoding-corrupted, this catches it
+  // before the app is signed and shipped.
+  const { readFileSync: verifyReadFS } = require('fs');
+  const criticalChecks = [
+    { path: join(dest, 'node-domexception', 'index.js'), marker: 'module.exports = dom', label: 'node-domexception' },
+  ];
+
+  // Check lru-cache patches if the dest exists
+  const lruCacheIndex = join(dest, 'lru-cache', 'index.js');
+  if (existsSync(normWin(lruCacheIndex))) {
+    criticalChecks.push({ path: lruCacheIndex, marker: 'exports.LRUCache', label: 'lru-cache (top-level)' });
+  }
+
+  let integrityOk = true;
+  for (const check of criticalChecks) {
+    if (!existsSync(normWin(check.path))) continue;
+    try {
+      const content = verifyReadFS(normWin(check.path), 'utf8');
+      if (!content.includes(check.marker)) {
+        console.error(`[after-pack] ❌ Integrity check FAILED for ${check.label}: marker "${check.marker}" not found in ${check.path}`);
+        integrityOk = false;
+      }
+    } catch (err) {
+      console.error(`[after-pack] ❌ Integrity check FAILED for ${check.label}: ${err.message}`);
+      integrityOk = false;
+    }
+  }
+
+  if (integrityOk) {
+    console.log(`[after-pack] ✅ Integrity checks passed for ${criticalChecks.length} patched module(s)`);
+  } else {
+    console.error('[after-pack] ❌ One or more integrity checks FAILED — the build may produce a broken app');
+    process.exit(1);
+  }
+
+  console.log(`[after-pack] ✅ afterPack completed for ${platform}/${arch}`);
 };


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses recurring macOS installation stability issues ("应用程序'ClawX'已不能再打开" / "文件已损坏") through a 5-phase improvement plan based on deep analysis of the ClawX build pipeline, CI logs, and best practices from VSCode, ClashParty/Mihomo Party, and the electron-builder ecosystem.

### Root Causes Identified

1. **No post-build signature verification** — CI only checks that electron-builder doesn't throw; broken signatures ship silently
2. **No explicit timestamp server** — Missing secure timestamps can cause Gatekeeper rejection after cert expiry
3. **No startup integrity check** — Corrupted installs from failed auto-updates go undetected
4. **No afterPack integrity verification** — 10,000+ file operations in after-pack.cjs with no validation
5. **Insufficient user guidance** — No Chinese-language troubleshooting for common macOS errors

### Changes

#### Phase 1: CI Post-Build Verification (CRITICAL)
- Added `Verify macOS code signature and notarization` step to `release.yml`
- Runs `codesign --verify --deep --strict` (same as VSCode CI)
- Validates secure timestamp presence
- Runs `spctl --assess` (Gatekeeper acceptance test)
- Runs `xcrun stapler validate` (notarization staple verification)
- Covers both x64 and arm64 builds, plus DMG artifacts

#### Phase 2: Explicit Timestamp Server
- Added `timestamp: "http://timestamp.apple.com/ts01"` to `electron-builder.yml`
- Ensures secure timestamp is always embedded even in network-constrained CI

#### Phase 3: Startup Signature Self-Check + Updater Logging
- Added macOS code signature verification at app startup (diagnostic only, non-blocking)
- Logs a warning if the running .app bundle has a broken signature
- Added update version logging to `quitAndInstall()` for post-mortem debugging

#### Phase 4: afterPack Integrity Verification
- Added final file count and total size logging to `after-pack.cjs`
- Added integrity verification of critical patched modules (node-domexception, lru-cache)
- Build fails immediately if any integrity check fails

#### Phase 5: macOS Troubleshooting in Release Notes
- Added detailed Chinese + English troubleshooting for:
  - "已损坏" (damaged) error → `xattr -cr` fix
  - "已不能再打开" (can't be opened) → reinstall steps
  - First-launch Gatekeeper bypass → right-click → Open
- Restructured installation notes by platform

## Related Issue(s)

Addresses recurring macOS "file is damaged" and "can't be opened" installation reports.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation
- [ ] Refactor
- [ ] Other

## Validation

- `pnpm run lint` — passes cleanly
- `pnpm run typecheck` — pre-existing failure (unrelated `use-stick-to-bottom` module)
- `pnpm test` — pre-existing 5 test failures (unrelated `plugin-install.test.ts` mock issue)
- `node -c scripts/after-pack.cjs` — syntax check passes
- CI verification step is self-testing: it runs on every release build and fails the pipeline if signatures are invalid
- The afterPack integrity check will surface any file corruption on the next build

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a16c20de-71d7-43e4-992b-b4ac5939d0a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a16c20de-71d7-43e4-992b-b4ac5939d0a3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

