### PR TITLE
fix(exec): suppress Dock icon bounce for child processes on macOS (fixes #834)

### DIFF
--- a/electron/gateway/process-launcher.ts
+++ b/electron/gateway/process-launcher.ts
@@ -75,6 +75,46 @@ const GATEWAY_FETCH_PRELOAD_SOURCE = `'use strict';
       // ignore
     }
   }
+
+  if (process.platform === 'darwin') {
+    try {
+      var cp = require('child_process');
+      if (!cp.__clawxPatchedMac) {
+        cp.__clawxPatchedMac = true;
+        ['spawn', 'exec', 'execFile', 'fork', 'spawnSync', 'execSync', 'execFileSync'].forEach(function(method) {
+          var original = cp[method];
+          if (typeof original !== 'function') return;
+          cp[method] = function() {
+            var args = Array.prototype.slice.call(arguments);
+            var optIdx = -1;
+            for (var i = 1; i < args.length; i++) {
+              var a = args[i];
+              if (a && typeof a === 'object' && !Array.isArray(a)) {
+                optIdx = i;
+                break;
+              }
+            }
+            if (optIdx >= 0) {
+              if (!args[optIdx].env) {
+                args[optIdx].env = Object.assign({}, process.env);
+              }
+              args[optIdx].env.LSUIElement = '1';
+            } else {
+              var opts = { env: Object.assign({}, process.env, { LSUIElement: '1' }) };
+              if (typeof args[args.length - 1] === 'function') {
+                args.splice(args.length - 1, 0, opts);
+              } else {
+                args.push(opts);
+              }
+            }
+            return original.apply(this, args);
+          };
+        });
+      }
+    } catch (e) {
+      // ignore
+    }
+  }
 })();
 `;
 


### PR DESCRIPTION
## Problem

Every exec tool invocation on macOS shows bouncing Dock icons, cluttering the user's Dock bar (#834).

<img width="906" height="300" alt="Dock icon bounce" src="https://github.com/user-attachments/assets/1dcef944-0712-4133-a6ba-46bb813ae7f1" />

## Root Cause

`child_process.spawn/exec` calls in the gateway inherit the Electron app's GUI context, causing macOS to treat each spawned process as a foreground application.

## Fix

Add a macOS block to the gateway fetch-preload script (mirroring the existing Windows `windowsHide` patch) that injects `LSUIElement=1` into the environment of all `child_process` method calls.

`LSUIElement=1` is a macOS convention that tells the system the process is a background agent — it should not appear in the Dock or receive a menu bar.

### Approach Details

- **Mirrors existing pattern**: The Windows block already patches all 7 `child_process` methods to add `windowsHide: true`. This adds an equivalent macOS block using `LSUIElement`.
- **Non-invasive**: Only affects macOS (`process.platform === 'darwin'`), only affects child processes spawned from the gateway, environment inheritance is preserved (`Object.assign({}, process.env)`).
- **One file changed**: `electron/gateway/process-launcher.ts` (+40 lines)

## Testing

- `npm test`: 454 tests pass (8 pre-existing test file failures from missing `@testing-library/dom` peer dep — unrelated)
- TypeScript: pre-existing type errors in other files, our change is in a template string literal
- Functional verification requires macOS (we're on Linux) — tested that the preload script generates valid JavaScript

Closes #834

Signed-off-by: Kagura <kagura.chen28@gmail.com>