### PR TITLE
feat(skills): add MiniMax-AI/cli as default skill tap

### DIFF
--- a/resources/skills/preinstalled-manifest.json
+++ b/resources/skills/preinstalled-manifest.json
@@ -63,6 +63,14 @@
       "ref": "main",
       "version": "main",
       "autoEnable": true
+    },
+    {
+      "slug": "mmx-cli",
+      "repo": "MiniMax-AI/cli",
+      "repoPath": "skill",
+      "ref": "main",
+      "version": "main",
+      "autoEnable": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

- Add `MiniMax-AI/cli` (`skill/` path) to `resources/skills/preinstalled-manifest.json` so the mmx-cli skill is pre-installed out of the box
- Users can install via `clawhub install mmx-cli` — the SKILL.md is fetched directly from [MiniMax-AI/cli](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md)
- Skill updates are fully decoupled: MiniMax maintains the upstream SKILL.md, no changes needed in this project

**8 lines added, 0 new files.**

## What is mmx-cli?

[mmx-cli](https://github.com/MiniMax-AI/cli) is a CLI tool for the MiniMax AI platform, providing:
- **Text generation** (MiniMax-M2.7 model)
- **Image generation** (image-01)
- **Video generation** (Hailuo-2.3)
- **Speech synthesis** (speech-2.8-hd, 300+ voices)
- **Music generation** (music-2.6, with lyrics, cover, and instrumental)
- **Web search**

The [SKILL.md](https://github.com/MiniMax-AI/cli/blob/main/skill/SKILL.md) follows the [agentskills.io](https://agentskills.io) standard and includes agent-specific flags (`--non-interactive`, `--quiet`, `--output json`).

## Test plan

- ClawX preinstalls mmx-cli skill on first launch
- `clawhub install mmx-cli` installs successfully
- Ask agent "generate a jazz instrumental" — agent invokes `mmx music generate` via terminal