### PR TITLE
style(channels): align status indicator with Models card style

### DIFF
--- a/src/pages/Channels/index.tsx
+++ b/src/pages/Channels/index.tsx
@@ -616,19 +616,24 @@ export function Channels() {
                           <h3 className="text-[16px] font-semibold text-foreground truncate">
                             {CHANNEL_NAMES[group.channelType as ChannelType] || group.channelType}
                           </h3>
-                          <p className="text-[12px] text-muted-foreground">{group.channelType}</p>
+                          <div className="flex items-center gap-2 text-[12px] text-muted-foreground">
+                            <span>{group.channelType}</span>
+                            <span className="w-1 h-1 rounded-full bg-black/20 dark:bg-white/20" />
+                            <span className="flex items-center gap-1">
+                              <span
+                                className={cn(
+                                  'inline-block h-1.5 w-1.5 rounded-full shrink-0',
+                                  group.status === 'connected' && 'bg-green-500',
+                                  group.status === 'connecting' && 'bg-sky-500 animate-pulse',
+                                  group.status === 'degraded' && 'bg-yellow-500',
+                                  group.status === 'error' && 'bg-red-500',
+                                  group.status === 'disconnected' && 'bg-gray-400',
+                                )}
+                              />
+                              {statusLabel(group.status)}
+                            </span>
+                          </div>
                         </div>
-                        <span
-                          className={cn(
-                            'inline-block h-2.5 w-2.5 rounded-full shrink-0',
-                            group.status === 'connected' && 'bg-green-500',
-                            group.status === 'connecting' && 'bg-sky-500 animate-pulse',
-                            group.status === 'degraded' && 'bg-yellow-500',
-                            group.status === 'error' && 'bg-red-500',
-                            group.status === 'disconnected' && 'bg-gray-400',
-                          )}
-                          title={statusLabel(group.status)}
-                        />
                       </div>
 
                       <div className="flex items-center gap-2">

--- a/tests/e2e/channels-binding-regression.spec.ts
+++ b/tests/e2e/channels-binding-regression.spec.ts
@@ -98,6 +98,9 @@ test.describe('Channels binding regression', () => {
     await expect(page.getByTestId('channels-page')).toBeVisible();
     await expect(page.getByText('Feishu / Lark')).toBeVisible();
 
+    const feishuGroupHeader = page.locator('div.rounded-2xl').filter({ hasText: 'Feishu / Lark' }).first();
+    await expect(feishuGroupHeader).toContainText(/Connected|已连接|接続済み|Подключён/);
+
     await page.getByRole('button', { name: /Add Account|添加账号|アカウントを追加/ }).click();
     await expect(page.getByText(/Configure Feishu \/ Lark|dialog\.configureTitle/)).toBeVisible();
 

--- a/tests/e2e/channels-health-diagnostics.spec.ts
+++ b/tests/e2e/channels-health-diagnostics.spec.ts
@@ -138,7 +138,7 @@ test.describe('Channels health diagnostics', () => {
     await expect(page.getByTestId('channels-page')).toBeVisible();
     await expect(page.getByTestId('channels-health-banner')).toBeVisible();
     await expect(page.getByText(/Gateway degraded|网关状态异常|ゲートウェイ劣化/)).toBeVisible();
-    await expect(page.locator('div.rounded-2xl').getByTitle(/Degraded|异常降级|劣化中/).first()).toBeVisible();
+    await expect(page.locator('div.rounded-2xl').getByText(/Degraded|异常降级|劣化中/).first()).toBeVisible();
 
     await page.getByTestId('channels-restart-gateway').click();
     await page.getByTestId('channels-copy-diagnostics').click();


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the configured-channel card status indicator with the Models / AI Providers card style:

- Moves the green status dot from beside the channel title (first line) into the subtitle row (second line), alongside the channel type slug.
- Appends the localized status label next to the dot (e.g. `Connected` / `已连接` / `接続済み`), reusing the existing `channels.account.connectionStatus.*` keys.
- Uses the same small dot size (`h-1.5 w-1.5`) and bullet separator (`w-1 h-1 rounded-full bg-black/20 dark:bg-white/20`) as the AI Providers card so the two pages read consistently.

Because the status dot no longer carries a `title` attribute (the label is rendered as adjacent text), two Playwright specs were updated to query the status by its localized text:

- `tests/e2e/channels-health-diagnostics.spec.ts` (previously broke CI — `getByTitle(/Degraded|…/)` → `getByText(/Degraded|…/)`)
- `tests/e2e/channels-binding-regression.spec.ts` (added assertion that the `Connected` label is rendered inside the Feishu group card)

No behavior changes, only presentation.

## Walkthrough

<img src="/opt/cursor/artifacts/channels_status_zoom.png" alt="Close-up of Telegram channel card showing `telegram • • Disconnected` on the subtitle row" />

Channel card now follows the same pattern used on the Models page.

[Messaging Channels page after the change](https://cursor.com/agents/bc-4766b6af-9f33-4886-a1dd-22273dcc95fd/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchannels_status_after.png)
<img src="/opt/cursor/artifacts/models_reference.png" alt="Models page reference with `• Configured` label" />

## Testing

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm test -- tests/unit/channels-page.test.tsx`
- `pnpm run test:e2e -- tests/e2e/channels-health-diagnostics.spec.ts tests/e2e/channels-binding-regression.spec.ts tests/e2e/channels-account-id-validation.spec.ts tests/e2e/channels-account-id-persistence.spec.ts`  ← all four pass locally after the selector fix.
- Manual smoke test in the Electron dev build (see screenshots above).

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4766b6af-9f33-4886-a1dd-22273dcc95fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4766b6af-9f33-4886-a1dd-22273dcc95fd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

