### PR TITLE
[codex] stabilize external gateway attach and dingtalk account mirroring

### DIFF
--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -404,7 +404,8 @@ export class GatewayManager extends EventEmitter {
   /**
    * Stop Gateway process
    */
-  async stop(): Promise<void> {
+  async stop(options?: { shutdownExternal?: boolean }): Promise<void> {
+    const shutdownExternal = options?.shutdownExternal ?? false;
     logger.info('Gateway stop requested');
     this.lifecycleController.bump('stop');
     // Disable auto-reconnect
@@ -413,9 +414,14 @@ export class GatewayManager extends EventEmitter {
     // Clear all timers
     this.clearAllTimers();
 
-    // If this manager is attached to an external gateway process, ask it to shut down
-    // over protocol before closing the socket.
-    if (!this.ownsProcess && this.ws?.readyState === WebSocket.OPEN && this.externalShutdownSupported !== false) {
+    // Only explicit restart flows should request shutdown for an externally
+    // managed Gateway. App close / disconnect should leave foreign processes alone.
+    if (
+      shutdownExternal
+      && !this.ownsProcess
+      && this.ws?.readyState === WebSocket.OPEN
+      && this.externalShutdownSupported !== false
+    ) {
       try {
         await this.rpc('shutdown', undefined, 5000);
         this.externalShutdownSupported = true;
@@ -521,7 +527,7 @@ export class GatewayManager extends EventEmitter {
     const pidBefore = this.status.pid;
     logger.info(`[gateway-refresh] mode=restart requested pidBefore=${pidBefore ?? 'n/a'}`);
     this.restartInFlight = (async () => {
-      await this.stop();
+      await this.stop({ shutdownExternal: true });
       try {
         await this.start();
       } catch (err) {

--- a/electron/gateway/startup-recovery.ts
+++ b/electron/gateway/startup-recovery.ts
@@ -20,6 +20,8 @@ const TRANSIENT_START_ERROR_PATTERNS: RegExp[] = [
   /Connect handshake timeout/i,
   // Port occupied after orphan kill: transient, worth retrying with backoff
   /Port \d+ still occupied after \d+ms/i,
+  // External gateway may still be booting or shutting down during attach/restart.
+  /Port \d+ is already in use by another process/i,
 ];
 
 function normalizeLogLine(value: string): string {
@@ -98,4 +100,3 @@ export function getGatewayStartupRecoveryAction(options: {
 
   return 'fail';
 }
-

--- a/electron/gateway/supervisor.ts
+++ b/electron/gateway/supervisor.ts
@@ -194,72 +194,47 @@ async function getListeningProcessIds(port: number): Promise<string[]> {
   return [...new Set(stdout.trim().split(/\r?\n/).map((value) => value.trim()).filter(Boolean))];
 }
 
-async function terminateOrphanedProcessIds(port: number, pids: string[]): Promise<void> {
-  logger.info(`Found orphaned process listening on port ${port} (PIDs: ${pids.join(', ')}), attempting to kill...`);
-
-  if (process.platform === 'darwin') {
-    await unloadLaunchctlGatewayService();
-  }
-
-  for (const pid of pids) {
-    try {
-      if (process.platform === 'win32') {
-        const cp = await import('child_process');
-        await new Promise<void>((resolve) => {
-          cp.exec(
-            `taskkill /F /PID ${pid} /T`,
-            { timeout: 5000, windowsHide: true },
-            () => resolve(),
-          );
-        });
-      } else {
-        process.kill(parseInt(pid, 10), 'SIGTERM');
-      }
-    } catch {
-      // Ignore processes that have already exited.
-    }
-  }
-
-  await new Promise((resolve) => setTimeout(resolve, process.platform === 'win32' ? 2000 : 3000));
-
-  if (process.platform !== 'win32') {
-    for (const pid of pids) {
-      try {
-        process.kill(parseInt(pid, 10), 0);
-        process.kill(parseInt(pid, 10), 'SIGKILL');
-      } catch {
-        // Already exited.
-      }
-    }
-    await new Promise((resolve) => setTimeout(resolve, 1000));
-  }
-}
-
 export async function findExistingGatewayProcess(options: {
   port: number;
   ownedPid?: number;
 }): Promise<{ port: number; externalToken?: string } | null> {
   const { port, ownedPid } = options;
+  let foreignPids: string[] = [];
 
   try {
-    try {
-      const pids = await getListeningProcessIds(port);
-      if (pids.length > 0 && (!ownedPid || !pids.includes(String(ownedPid)))) {
-        await terminateOrphanedProcessIds(port, pids);
-        if (process.platform === 'win32') {
-          await waitForPortFree(port, 10000);
-        }
-        return null;
-      }
-    } catch (err) {
-      logger.warn('Error checking for existing process on port:', err);
+    const pids = await getListeningProcessIds(port);
+    foreignPids = ownedPid
+      ? pids.filter((pid) => pid !== String(ownedPid))
+      : pids;
+    if (foreignPids.length > 0) {
+      logger.info(
+        `Found external process listening on port ${port} (PIDs: ${foreignPids.join(', ')}); probing for attachable Gateway`,
+      );
     }
-
-    const ready = await probeGatewayReady(port, 5000);
-    return ready ? { port } : null;
-  } catch {
-    return null;
+  } catch (err) {
+    logger.warn('Error checking for existing process on port:', err);
   }
+
+  try {
+    const ready = await probeGatewayReady(port, 5000);
+    if (ready) {
+      return { port };
+    }
+  } catch {
+    if (foreignPids.length > 0) {
+      throw new Error(
+        `Port ${port} is already in use by another process (PIDs: ${foreignPids.join(', ')})`,
+      );
+    }
+  }
+
+  if (foreignPids.length > 0) {
+    throw new Error(
+      `Port ${port} is already in use by another process (PIDs: ${foreignPids.join(', ')})`,
+    );
+  }
+
+  return null;
 }
 
 export async function runOpenClawDoctorRepair(): Promise<boolean> {

--- a/electron/utils/channel-config.ts
+++ b/electron/utils/channel-config.ts
@@ -26,11 +26,10 @@ const WECOM_PLUGIN_ID = 'wecom';
 const WECHAT_PLUGIN_ID = OPENCLAW_WECHAT_CHANNEL_TYPE;
 const FEISHU_PLUGIN_ID_CANDIDATES = ['openclaw-lark', 'feishu-openclaw-plugin'] as const;
 const DEFAULT_ACCOUNT_ID = 'default';
-// Channels whose plugin schema uses additionalProperties:false, meaning
-// credential keys MUST NOT appear at the top level of `channels.<type>`.
-// All other channels get the default account mirrored to the top level
-// so their runtime/plugin can discover the credentials.
-const CHANNELS_EXCLUDING_TOP_LEVEL_MIRROR = new Set(['dingtalk']);
+// Channels whose runtime truly rejects account maps would be listed here.
+// The current bundled channel set, including DingTalk 3.5.3, supports
+// `accounts` plus top-level default-account mirroring.
+const CHANNELS_EXCLUDING_TOP_LEVEL_MIRROR = new Set<string>();
 const CHANNEL_TOP_LEVEL_KEYS_TO_KEEP = new Set(['accounts', 'defaultAccount', 'enabled']);
 const WECHAT_STATE_DIR = join(OPENCLAW_DIR, WECHAT_PLUGIN_ID);
 const WECHAT_ACCOUNT_INDEX_FILE = join(WECHAT_STATE_DIR, 'accounts.json');
@@ -635,6 +634,10 @@ function migrateLegacyChannelConfigToAccounts(
     const legacyKeys = Object.keys(legacyPayload);
     const existingAccounts = getChannelAccountsMap(channelSection);
     const hasAccounts = Boolean(existingAccounts) && Object.keys(existingAccounts).length > 0;
+    const resolvedDefaultAccountId =
+        typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim()
+            ? channelSection.defaultAccount
+            : defaultAccountId;
 
     if (legacyKeys.length === 0) {
         if (hasAccounts && typeof channelSection.defaultAccount !== 'string') {
@@ -644,9 +647,9 @@ function migrateLegacyChannelConfigToAccounts(
     }
 
     const accounts = ensureChannelAccountsMap(channelSection);
-    const existingDefaultAccount = accounts[defaultAccountId] ?? {};
+    const existingDefaultAccount = accounts[resolvedDefaultAccountId] ?? {};
 
-    accounts[defaultAccountId] = {
+    accounts[resolvedDefaultAccountId] = {
         ...(channelSection.enabled !== undefined ? { enabled: channelSection.enabled } : {}),
         ...legacyPayload,
         ...existingDefaultAccount,
@@ -655,10 +658,59 @@ function migrateLegacyChannelConfigToAccounts(
     channelSection.defaultAccount =
         typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim()
             ? channelSection.defaultAccount
-            : defaultAccountId;
+            : resolvedDefaultAccountId;
 
     for (const key of legacyKeys) {
         delete channelSection[key];
+    }
+}
+
+function getMirroredAccountKeys(
+    channelSection: ChannelConfigData,
+): string[] {
+    const accounts = getChannelAccountsMap(channelSection);
+    if (!accounts) return [];
+
+    const keys = new Set<string>();
+    for (const accountConfig of Object.values(accounts)) {
+        if (!accountConfig || typeof accountConfig !== 'object') continue;
+        for (const key of Object.keys(accountConfig)) {
+            if (CHANNEL_TOP_LEVEL_KEYS_TO_KEEP.has(key)) continue;
+            keys.add(key);
+        }
+    }
+    return Array.from(keys);
+}
+
+function remirrorDefaultAccountToTopLevel(
+    channelSection: ChannelConfigData,
+    fallbackAccountId: string = DEFAULT_ACCOUNT_ID,
+    extraKeysToClear: Iterable<string> = [],
+): void {
+    const accounts = getChannelAccountsMap(channelSection);
+    if (!accounts) return;
+
+    const keysToClear = new Set([
+        ...getMirroredAccountKeys(channelSection),
+        ...Array.from(extraKeysToClear),
+    ]);
+
+    for (const key of keysToClear) {
+        delete channelSection[key];
+    }
+
+    const mirroredAccountId =
+        typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim()
+            ? channelSection.defaultAccount
+            : fallbackAccountId;
+    const defaultAccountData = accounts[mirroredAccountId] ?? accounts[fallbackAccountId];
+    if (!defaultAccountData || typeof defaultAccountData !== 'object') {
+        return;
+    }
+
+    for (const [key, value] of Object.entries(defaultAccountData)) {
+        if (CHANNEL_TOP_LEVEL_KEYS_TO_KEEP.has(key)) continue;
+        channelSection[key] = value;
     }
 }
 
@@ -767,7 +819,7 @@ export async function saveChannelConfig(
             }
         }
 
-        // ── Strict-schema channels (e.g. dingtalk) ──────────────────────
+        // ── Strict-schema channels ──────────────────────────────────────
         // These plugins declare additionalProperties:false and do NOT
         // recognise `accounts` / `defaultAccount`.  Write credentials
         // flat to the channel root and strip the multi-account keys.
@@ -801,16 +853,7 @@ export async function saveChannelConfig(
             // account's credentials from the top level of `channels.<type>`
             // (e.g. channels.feishu.appId).  Mirror them there so the
             // runtime can discover them.
-            const mirroredAccountId =
-                typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim()
-                    ? channelSection.defaultAccount
-                    : resolvedAccountId;
-            const defaultAccountData = accounts[mirroredAccountId] ?? accounts[resolvedAccountId] ?? accounts[DEFAULT_ACCOUNT_ID];
-            if (defaultAccountData) {
-                for (const [key, value] of Object.entries(defaultAccountData)) {
-                    channelSection[key] = value;
-                }
-            }
+            remirrorDefaultAccountToTopLevel(channelSection, resolvedAccountId);
         }
 
         await writeOpenClawConfig(currentConfig);
@@ -923,16 +966,11 @@ export async function deleteChannelAccountConfig(channelType: string, accountId:
         const accounts = getChannelAccountsMap(channelSection);
         if (!accounts?.[accountId]) {
             // Account not found; just ensure top-level mirror is consistent
-            const mirroredAccountId = typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim() ? channelSection.defaultAccount : DEFAULT_ACCOUNT_ID;
-            const defaultAccountData = accounts?.[mirroredAccountId] ?? accounts?.[DEFAULT_ACCOUNT_ID];
-            if (defaultAccountData) {
-                for (const [key, value] of Object.entries(defaultAccountData)) {
-                    channelSection[key] = value;
-                }
-            }
+            remirrorDefaultAccountToTopLevel(channelSection, DEFAULT_ACCOUNT_ID);
             return;
         }
 
+        const mirroredKeysBeforeDelete = getMirroredAccountKeys(channelSection);
         delete accounts[accountId];
 
         if (Object.keys(accounts).length === 0) {
@@ -954,16 +992,7 @@ export async function deleteChannelAccountConfig(channelType: string, accountId:
             // Re-mirror default account credentials to top level after migration
             // stripped them (same rationale as saveChannelConfig).
             // (Strict-schema channels already returned above, so this is safe.)
-            const mirroredAccountId =
-                typeof channelSection.defaultAccount === 'string' && channelSection.defaultAccount.trim()
-                    ? channelSection.defaultAccount
-                    : DEFAULT_ACCOUNT_ID;
-            const defaultAccountData = accounts[mirroredAccountId] ?? accounts[DEFAULT_ACCOUNT_ID];
-            if (defaultAccountData) {
-                for (const [key, value] of Object.entries(defaultAccountData)) {
-                    channelSection[key] = value;
-                }
-            }
+            remirrorDefaultAccountToTopLevel(channelSection, DEFAULT_ACCOUNT_ID, mirroredKeysBeforeDelete);
         }
 
         syncBuiltinChannelsWithPluginAllowlist(currentConfig);
@@ -1153,11 +1182,9 @@ export async function setChannelDefaultAccount(channelType: string, accountId: s
 
         channelSection.defaultAccount = trimmedAccountId;
 
-        // Strict-schema channels don't use defaultAccount — always mirror for others
-        const defaultAccountData = accounts[trimmedAccountId];
-        for (const [key, value] of Object.entries(defaultAccountData)) {
-            channelSection[key] = value;
-        }
+        // Mirror the chosen default account to top-level channel keys so the
+        // runtime can resolve the active account without losing named accounts.
+        remirrorDefaultAccountToTopLevel(channelSection, trimmedAccountId);
 
         await writeOpenClawConfig(currentConfig);
         logger.info('Set channel default account', { channelType: resolvedChannelType, accountId: trimmedAccountId });
@@ -1180,17 +1207,12 @@ export async function deleteAgentChannelAccounts(agentId: string, ownedChannelAc
                 // Strict-schema channels have no accounts map; skip them.
                 // For normal channels, ensure top-level mirror is consistent.
                 if (!CHANNELS_EXCLUDING_TOP_LEVEL_MIRROR.has(channelType)) {
-                    const mirroredAccountId = typeof section.defaultAccount === 'string' && section.defaultAccount.trim() ? section.defaultAccount : DEFAULT_ACCOUNT_ID;
-                    const defaultAccountData = accounts?.[mirroredAccountId] ?? accounts?.[DEFAULT_ACCOUNT_ID];
-                    if (defaultAccountData) {
-                        for (const [key, value] of Object.entries(defaultAccountData)) {
-                            section[key] = value;
-                        }
-                    }
+                    remirrorDefaultAccountToTopLevel(section, DEFAULT_ACCOUNT_ID);
                 }
                 continue;
             }
 
+            const mirroredKeysBeforeDelete = getMirroredAccountKeys(section);
             delete accounts[accountId];
             if (Object.keys(accounts).length === 0) {
                 delete currentConfig.channels[channelType];
@@ -1207,16 +1229,7 @@ export async function deleteAgentChannelAccounts(agentId: string, ownedChannelAc
                 }
                 // Re-mirror default account credentials to top level after migration
                 // stripped them (same rationale as saveChannelConfig).
-                const mirroredAccountId =
-                    typeof section.defaultAccount === 'string' && section.defaultAccount.trim()
-                        ? section.defaultAccount
-                        : DEFAULT_ACCOUNT_ID;
-                const defaultAccountData = accounts[mirroredAccountId] ?? accounts[DEFAULT_ACCOUNT_ID];
-                if (defaultAccountData) {
-                    for (const [key, value] of Object.entries(defaultAccountData)) {
-                        section[key] = value;
-                    }
-                }
+                remirrorDefaultAccountToTopLevel(section, DEFAULT_ACCOUNT_ID, mirroredKeysBeforeDelete);
             }
             modified = true;
         }

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -1946,11 +1946,10 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
     // credentials from the top level of `channels.<type>`.  Mirror them
     // there so the runtime can discover them.
     //
-    // Strict-schema channels (e.g. dingtalk, additionalProperties:false)
-    // reject the `accounts` / `defaultAccount` keys entirely — strip them
-    // so the Gateway doesn't crash on startup.
+    // Some channels may require flat-only config, but the current bundled set,
+    // including DingTalk 3.5.3, supports preserving named `accounts`.
     const channelsObj = config.channels as Record<string, Record<string, unknown>> | undefined;
-    const CHANNELS_EXCLUDING_TOP_LEVEL_MIRROR = new Set(['dingtalk']);
+    const CHANNELS_EXCLUDING_TOP_LEVEL_MIRROR = new Set<string>();
 
     if (channelsObj && typeof channelsObj === 'object') {
       for (const [channelType, section] of Object.entries(channelsObj)) {
@@ -1978,8 +1977,20 @@ export async function sanitizeOpenClawConfig(): Promise<void> {
                 : 'default';
           const defaultAccountData = accounts?.[defaultAccountId] ?? accounts?.['default'];
           if (!defaultAccountData || typeof defaultAccountData !== 'object') continue;
+          const mirroredKeys = new Set<string>();
+          for (const accountConfig of Object.values(accounts ?? {})) {
+            if (!accountConfig || typeof accountConfig !== 'object') continue;
+            for (const key of Object.keys(accountConfig)) {
+              if (key === 'accounts' || key === 'defaultAccount' || key === 'enabled') continue;
+              mirroredKeys.add(key);
+            }
+          }
+          for (const key of mirroredKeys) {
+            delete section[key];
+          }
           let mirrored = false;
           for (const [key, value] of Object.entries(defaultAccountData)) {
+            if (key === 'accounts' || key === 'defaultAccount' || key === 'enabled') continue;
             if (!(key in section)) {
               section[key] = value;
               mirrored = true;

--- a/tests/e2e/channels-dingtalk-multi-account.spec.ts
+++ b/tests/e2e/channels-dingtalk-multi-account.spec.ts
@@ -1,0 +1,84 @@
+import { completeSetup, expect, test } from './fixtures/electron';
+
+test.describe('DingTalk multi-account lifecycle', () => {
+  test('persists a second dingtalk account without replacing the existing one', async ({ electronApp, page }) => {
+    await electronApp.evaluate(async () => {
+      const { mkdir, writeFile } = process.mainModule!.require('fs/promises') as typeof import('fs/promises');
+      const { join } = process.mainModule!.require('path') as typeof import('path');
+
+      const openclawDir = join(process.env.HOME!, '.openclaw');
+      await mkdir(openclawDir, { recursive: true });
+      await writeFile(join(openclawDir, 'openclaw.json'), JSON.stringify({
+        channels: {
+          dingtalk: {
+            enabled: true,
+            defaultAccount: 'default',
+            clientId: 'dt-main',
+            clientSecret: 'secret-main',
+            accounts: {
+              default: {
+                clientId: 'dt-main',
+                clientSecret: 'secret-main',
+                enabled: true,
+              },
+            },
+          },
+        },
+      }, null, 2), 'utf8');
+    });
+
+    await completeSetup(page);
+
+    await page.getByTestId('sidebar-nav-channels').click();
+    await expect(page.getByTestId('channels-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'DingTalk' })).toBeVisible();
+
+    const dingtalkCard = page.locator('div.rounded-2xl').filter({
+      has: page.getByRole('heading', { name: 'DingTalk' }),
+    }).first();
+    await expect(dingtalkCard.locator('button').first()).toBeVisible();
+
+    await dingtalkCard.locator('button').first().click();
+    await expect(page.locator('#account-id')).toBeVisible();
+
+    await page.locator('#account-id').fill('sales');
+    await page.locator('#clientId').fill('dt-sales');
+    await page.locator('#clientSecret').fill('secret-sales');
+    await page.locator('div.fixed.inset-0 button').last().click();
+
+    await expect(page.locator('#account-id')).toHaveCount(0);
+    await expect(page.getByText('sales')).toBeVisible();
+
+    const persisted = await electronApp.evaluate(async () => {
+      const { readFile } = process.mainModule!.require('fs/promises') as typeof import('fs/promises');
+      const { join } = process.mainModule!.require('path') as typeof import('path');
+      const raw = await readFile(join(process.env.HOME!, '.openclaw', 'openclaw.json'), 'utf8');
+      return JSON.parse(raw) as {
+        channels?: {
+          dingtalk?: {
+            defaultAccount?: string;
+            clientId?: string;
+            clientSecret?: string;
+            accounts?: Record<string, { clientId?: string; clientSecret?: string; enabled?: boolean }>;
+          };
+        };
+      };
+    });
+
+    expect(persisted.channels?.dingtalk?.defaultAccount).toBe('default');
+    expect(persisted.channels?.dingtalk?.clientId).toBe('dt-main');
+    expect(persisted.channels?.dingtalk?.clientSecret).toBe('secret-main');
+    expect(persisted.channels?.dingtalk?.accounts).toEqual({
+      default: {
+        clientId: 'dt-main',
+        clientSecret: 'secret-main',
+        enabled: true,
+      },
+      sales: {
+        clientId: 'dt-sales',
+        clientSecret: 'secret-sales',
+        enabled: true,
+      },
+    });
+  });
+});

--- a/tests/unit/channel-config.test.ts
+++ b/tests/unit/channel-config.test.ts
@@ -214,6 +214,127 @@ describe('WeCom plugin configuration', () => {
       expect(plugins.entries['qqbot']).toBeUndefined();
     }
   });
+
+  it('preserves multiple dingtalk accounts and mirrors the default account to top level', async () => {
+    const { saveChannelConfig, setChannelDefaultAccount } = await import('@electron/utils/channel-config');
+
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-main',
+      clientSecret: 'secret-main',
+    }, 'default');
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-sales',
+      clientSecret: 'secret-sales',
+    }, 'sales');
+    await setChannelDefaultAccount('dingtalk', 'sales');
+
+    const config = await readOpenClawJson();
+    const channels = config.channels as Record<string, {
+      defaultAccount?: string;
+      clientId?: string;
+      clientSecret?: string;
+      accounts?: Record<string, { clientId?: string; clientSecret?: string }>;
+    }>;
+
+    expect(channels.dingtalk.defaultAccount).toBe('sales');
+    expect(channels.dingtalk.accounts).toEqual({
+      default: {
+        clientId: 'dt-main',
+        clientSecret: 'secret-main',
+        enabled: true,
+      },
+      sales: {
+        clientId: 'dt-sales',
+        clientSecret: 'secret-sales',
+        enabled: true,
+      },
+    });
+    expect(channels.dingtalk.clientId).toBe('dt-sales');
+    expect(channels.dingtalk.clientSecret).toBe('secret-sales');
+  });
+
+  it('deletes only the targeted dingtalk account when multiple accounts exist', async () => {
+    const { deleteChannelAccountConfig, saveChannelConfig } = await import('@electron/utils/channel-config');
+
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-main',
+      clientSecret: 'secret-main',
+    }, 'default');
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-sales',
+      clientSecret: 'secret-sales',
+    }, 'sales');
+
+    await deleteChannelAccountConfig('dingtalk', 'sales');
+
+    const config = await readOpenClawJson();
+    const channels = config.channels as Record<string, {
+      defaultAccount?: string;
+      accounts?: Record<string, { clientId?: string }>;
+    }>;
+
+    expect(channels.dingtalk.defaultAccount).toBe('default');
+    expect(channels.dingtalk.accounts).toEqual({
+      default: {
+        clientId: 'dt-main',
+        clientSecret: 'secret-main',
+        enabled: true,
+      },
+    });
+  });
+
+  it('clears stale top-level dingtalk fields when switching the default account', async () => {
+    const { saveChannelConfig, setChannelDefaultAccount } = await import('@electron/utils/channel-config');
+
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-main',
+      clientSecret: 'secret-main',
+      robotCode: 'robot-main',
+      corpId: 'corp-main',
+    }, 'default');
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-sales',
+      clientSecret: 'secret-sales',
+    }, 'sales');
+
+    await setChannelDefaultAccount('dingtalk', 'sales');
+
+    const config = await readOpenClawJson();
+    const channels = config.channels as Record<string, Record<string, unknown>>;
+
+    expect(channels.dingtalk.defaultAccount).toBe('sales');
+    expect(channels.dingtalk.clientId).toBe('dt-sales');
+    expect(channels.dingtalk.clientSecret).toBe('secret-sales');
+    expect(channels.dingtalk.robotCode).toBeUndefined();
+    expect(channels.dingtalk.corpId).toBeUndefined();
+  });
+
+  it('clears stale top-level dingtalk fields when deleting the current default account', async () => {
+    const { deleteChannelAccountConfig, saveChannelConfig, setChannelDefaultAccount } = await import('@electron/utils/channel-config');
+
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-main',
+      clientSecret: 'secret-main',
+    }, 'default');
+    await saveChannelConfig('dingtalk', {
+      clientId: 'dt-sales',
+      clientSecret: 'secret-sales',
+      agentId: 'agent-sales',
+      robotCode: 'robot-sales',
+    }, 'sales');
+    await setChannelDefaultAccount('dingtalk', 'sales');
+
+    await deleteChannelAccountConfig('dingtalk', 'sales');
+
+    const config = await readOpenClawJson();
+    const channels = config.channels as Record<string, Record<string, unknown>>;
+
+    expect(channels.dingtalk.defaultAccount).toBe('default');
+    expect(channels.dingtalk.clientId).toBe('dt-main');
+    expect(channels.dingtalk.clientSecret).toBe('secret-main');
+    expect(channels.dingtalk.agentId).toBeUndefined();
+    expect(channels.dingtalk.robotCode).toBeUndefined();
+  });
 });
 
 describe('WeChat dangling plugin cleanup', () => {

--- a/tests/unit/gateway-manager-external-stop.test.ts
+++ b/tests/unit/gateway-manager-external-stop.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp',
+    isPackaged: false,
+  },
+  utilityProcess: {
+    fork: vi.fn(),
+  },
+}));
+
+describe('GatewayManager external stop behavior', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('disconnects from an external gateway without sending shutdown by default', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      terminate: vi.fn(),
+    };
+
+    Object.assign(manager as object, {
+      ownsProcess: false,
+      ws,
+      externalShutdownSupported: null,
+      status: { state: 'running', port: 18789 },
+    });
+
+    const rpcSpy = vi.spyOn(manager, 'rpc').mockResolvedValue(undefined as never);
+
+    await manager.stop();
+
+    expect(rpcSpy).not.toHaveBeenCalled();
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
+  });
+
+  it('can explicitly request external shutdown when asked by restart flows', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      terminate: vi.fn(),
+    };
+
+    Object.assign(manager as object, {
+      ownsProcess: false,
+      ws,
+      externalShutdownSupported: null,
+      status: { state: 'running', port: 18789 },
+    });
+
+    const rpcSpy = vi.spyOn(manager, 'rpc').mockResolvedValue(undefined as never);
+
+    await manager.stop({ shutdownExternal: true });
+
+    expect(rpcSpy).toHaveBeenCalledWith('shutdown', undefined, 5000);
+    expect(ws.terminate).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/unit/gateway-manager-restart-recovery.test.ts
+++ b/tests/unit/gateway-manager-restart-recovery.test.ts
@@ -119,4 +119,26 @@ describe('GatewayManager restart recovery', () => {
     // (it may be called from other paths, but not the restart-recovery catch)
     expect(scheduleReconnectSpy).not.toHaveBeenCalled();
   });
+
+  it('requests external shutdown semantics during restart stop phase', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const internals = manager as unknown as {
+      shouldReconnect: boolean;
+      status: { state: string; port: number };
+      startLock: boolean;
+    };
+
+    internals.status = { state: 'running', port: 18789 };
+    internals.startLock = false;
+    internals.shouldReconnect = true;
+
+    const stopSpy = vi.spyOn(manager, 'stop').mockResolvedValue();
+    vi.spyOn(manager, 'start').mockResolvedValue();
+
+    await manager.restart();
+
+    expect(stopSpy).toHaveBeenCalledWith({ shutdownExternal: true });
+  });
 });

--- a/tests/unit/gateway-startup-orchestrator.test.ts
+++ b/tests/unit/gateway-startup-orchestrator.test.ts
@@ -148,6 +148,27 @@ describe('runGatewayStartupSequence', () => {
     expect(hooks.onConnectedToManagedGateway).toHaveBeenCalledTimes(1);
   });
 
+  it('retries when a foreign process still owns the port during external attach/restart windows', async () => {
+    let calls = 0;
+    const hooks = createMockHooks({
+      findExistingGateway: vi.fn().mockImplementation(async () => {
+        calls++;
+        if (calls === 1) {
+          throw new Error('Port 18789 is already in use by another process (PIDs: 4321)');
+        }
+        return { port: 18789 };
+      }),
+      maxStartAttempts: 3,
+    });
+
+    await runGatewayStartupSequence(hooks);
+
+    expect(hooks.findExistingGateway).toHaveBeenCalledTimes(2);
+    expect(hooks.delay).toHaveBeenCalledWith(1000);
+    expect(hooks.connect).toHaveBeenCalledWith(18789, undefined);
+    expect(hooks.onConnectedToExistingGateway).toHaveBeenCalledTimes(1);
+  });
+
   it('runs doctor repair on config-invalid stderr signal', async () => {
     let attemptNumber = 0;
     const hooks = createMockHooks({

--- a/tests/unit/gateway-startup-recovery.test.ts
+++ b/tests/unit/gateway-startup-recovery.test.ts
@@ -3,6 +3,7 @@ import {
   getGatewayStartupRecoveryAction,
   hasInvalidConfigFailureSignal,
   isInvalidConfigSignal,
+  isTransientGatewayStartError,
   shouldAttemptConfigAutoRepair,
 } from '@electron/gateway/startup-recovery';
 
@@ -48,6 +49,14 @@ describe('gateway startup recovery heuristics', () => {
     expect(isInvalidConfigSignal('skills: Unrecognized key: "enabled"')).toBe(true);
     expect(isInvalidConfigSignal('Run: openclaw doctor --fix')).toBe(true);
     expect(isInvalidConfigSignal('Gateway ready after 3 attempts')).toBe(false);
+  });
+
+  it('treats external port-conflict attach windows as transient startup errors', () => {
+    expect(
+      isTransientGatewayStartError(
+        new Error('Port 18789 is already in use by another process (PIDs: 4321)'),
+      ),
+    ).toBe(true);
   });
 });
 

--- a/tests/unit/gateway-supervisor.test.ts
+++ b/tests/unit/gateway-supervisor.test.ts
@@ -6,9 +6,11 @@ const originalPlatform = process.platform;
 const {
   mockExec,
   mockCreateServer,
+  mockProbeGatewayReady,
 } = vi.hoisted(() => ({
   mockExec: vi.fn(),
   mockCreateServer: vi.fn(),
+  mockProbeGatewayReady: vi.fn(),
 }));
 
 vi.mock('electron', () => ({
@@ -34,6 +36,10 @@ vi.mock('net', () => ({
   createServer: mockCreateServer,
 }));
 
+vi.mock('@electron/gateway/ws-client', () => ({
+  probeGatewayReady: (...args: unknown[]) => mockProbeGatewayReady(...args),
+}));
+
 class MockUtilityChild extends EventEmitter {
   pid?: number;
   kill = vi.fn();
@@ -52,6 +58,7 @@ describe('gateway supervisor process cleanup', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockProbeGatewayReady.mockResolvedValue(false);
 
     mockExec.mockImplementation((_cmd: string, _opts: object, cb: (err: Error | null, stdout: string) => void) => {
       cb(null, '');
@@ -111,9 +118,10 @@ describe('gateway supervisor process cleanup', () => {
     expect(child.kill).toHaveBeenCalledTimes(1);
   });
 
-  it('waits for port release after orphan cleanup on Windows', async () => {
+  it('attaches to a ready external gateway instead of killing it on Windows', async () => {
     setPlatform('win32');
     const { findExistingGatewayProcess } = await import('@electron/gateway/supervisor');
+    mockProbeGatewayReady.mockResolvedValue(true);
 
     mockExec.mockImplementation((cmd: string, _opts: object, cb: (err: Error | null, stdout: string) => void) => {
       if (cmd.includes('netstat -ano')) {
@@ -125,13 +133,40 @@ describe('gateway supervisor process cleanup', () => {
     });
 
     const result = await findExistingGatewayProcess({ port: 18789 });
-    expect(result).toBeNull();
+    expect(result).toEqual({ port: 18789 });
 
-    expect(mockExec).toHaveBeenCalledWith(
+    expect(mockProbeGatewayReady).toHaveBeenCalledWith(18789, 5000);
+    expect(mockExec).not.toHaveBeenCalledWith(
       expect.stringContaining('taskkill /F /PID 4321 /T'),
-      expect.objectContaining({ timeout: 5000, windowsHide: true }),
+      expect.anything(),
       expect.any(Function),
     );
-    expect(mockCreateServer).toHaveBeenCalled();
+    expect(mockCreateServer).not.toHaveBeenCalled();
+  });
+
+  it('reports port conflicts for foreign non-gateway processes without killing them', async () => {
+    setPlatform('linux');
+    const { findExistingGatewayProcess } = await import('@electron/gateway/supervisor');
+    mockProbeGatewayReady.mockResolvedValue(false);
+
+    mockExec.mockImplementation((cmd: string, _opts: object, cb: (err: Error | null, stdout: string) => void) => {
+      if (cmd.includes('lsof -i :18789')) {
+        cb(null, '4321\n');
+        return {} as never;
+      }
+      cb(null, '');
+      return {} as never;
+    });
+
+    await expect(findExistingGatewayProcess({ port: 18789 })).rejects.toThrow(
+      'Port 18789 is already in use by another process (PIDs: 4321)',
+    );
+
+    expect(mockProbeGatewayReady).toHaveBeenCalledWith(18789, 5000);
+    expect(mockExec).not.toHaveBeenCalledWith(
+      expect.stringContaining('taskkill /F /PID 4321 /T'),
+      expect.anything(),
+      expect.any(Function),
+    );
   });
 });

--- a/tests/unit/openclaw-auth.test.ts
+++ b/tests/unit/openclaw-auth.test.ts
@@ -455,21 +455,24 @@ describe('sanitizeOpenClawConfig', () => {
     expect(telegram.botToken).toBe('telegram-token');
   });
 
-  it('strips accounts/defaultAccount from dingtalk (strict-schema channel) during sanitize', async () => {
+  it('preserves dingtalk named accounts during sanitize and mirrors default credentials to top level', async () => {
     await writeOpenClawJson({
       channels: {
         dingtalk: {
           enabled: true,
-          defaultAccount: 'default',
+          defaultAccount: 'sales',
           accounts: {
             default: {
-              clientId: 'dt-client-id-nested',
-              clientSecret: 'dt-secret-nested',
+              clientId: 'dt-client-id-default',
+              clientSecret: 'dt-secret-default',
+              enabled: true,
+            },
+            sales: {
+              clientId: 'dt-client-id-sales',
+              clientSecret: 'dt-secret-sales',
               enabled: true,
             },
           },
-          clientId: 'dt-client-id',
-          clientSecret: 'dt-secret',
         },
       },
     });
@@ -480,13 +483,22 @@ describe('sanitizeOpenClawConfig', () => {
     const result = await readOpenClawJson();
     const channels = result.channels as Record<string, Record<string, unknown>>;
     const dingtalk = channels.dingtalk;
-    // dingtalk's strict schema rejects accounts/defaultAccount — they must be stripped
     expect(dingtalk.enabled).toBe(true);
-    expect(dingtalk.accounts).toBeUndefined();
-    expect(dingtalk.defaultAccount).toBeUndefined();
-    // Top-level credentials must be preserved
-    expect(dingtalk.clientId).toBe('dt-client-id');
-    expect(dingtalk.clientSecret).toBe('dt-secret');
+    expect(dingtalk.defaultAccount).toBe('sales');
+    expect(dingtalk.accounts).toEqual({
+      default: {
+        clientId: 'dt-client-id-default',
+        clientSecret: 'dt-secret-default',
+        enabled: true,
+      },
+      sales: {
+        clientId: 'dt-client-id-sales',
+        clientSecret: 'dt-secret-sales',
+        enabled: true,
+      },
+    });
+    expect(dingtalk.clientId).toBe('dt-client-id-sales');
+    expect(dingtalk.clientSecret).toBe('dt-secret-sales');
   });
 });
 


### PR DESCRIPTION
## What changed

This PR fixes two regressions in the recent gateway / DingTalk multi-account work:

- external gateway attach and restart now tolerate the booting / shutting-down window instead of failing hard on a transient port conflict
- DingTalk default-account remirroring now clears stale top-level fields before rebuilding the mirror from the current default account

It also strengthens the regression coverage around those flows.

## Why

The previous patch still had three issues:

1. externally managed gateways could fail to attach during startup or shutdown races because `Port ... is already in use by another process` was treated as fatal instead of transient
2. switching or deleting the current DingTalk default account could leave stale top-level fields like `robotCode`, `corpId`, or `agentId`
3. the new DingTalk E2E covered only UI state and could pass even if backend persistence was still broken

## User impact

- ClawX is less likely to break when OpenClaw Gateway is managed by systemd or another external supervisor
- DingTalk multi-account configs keep the correct top-level default mirror when changing or deleting the default account
- CI now checks the actual persistence path for DingTalk multi-account saves

## Validation

- `pnpm exec vitest run tests/unit/gateway-startup-recovery.test.ts tests/unit/gateway-startup-orchestrator.test.ts tests/unit/channel-config.test.ts tests/unit/openclaw-auth.test.ts tests/unit/gateway-supervisor.test.ts tests/unit/gateway-manager-external-stop.test.ts tests/unit/gateway-manager-restart-recovery.test.ts`
- `pnpm exec playwright test tests/e2e/channels-dingtalk-multi-account.spec.ts`
- `pnpm run typecheck`
