### PR TITLE
fix(chat): dedupe optimistic user message against Gateway-prefixed echo

### DIFF
--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -230,8 +230,31 @@ function normalizeStreamingMessage(message: unknown): unknown {
     : rawMessage;
 }
 
+/**
+ * Strip Gateway-injected metadata that does NOT exist on the renderer's
+ * optimistic user message but is echoed back when the Gateway persists it:
+ *   - leading timestamp `[Wed 2026-04-22 10:30 GMT+8] `
+ *   - `[message_id: uuid]` tags sprinkled throughout the text
+ *   - `[media attached: path (mime) | path]` references appended when the
+ *     renderer sends attachments via `chat:sendWithMedia`
+ *   - Gateway-injected "Conversation info (untrusted metadata): ..." blocks
+ *
+ * Keeping this aligned with `cleanUserText` in `pages/Chat/message-utils.ts`
+ * is important: the user bubble renders the cleaned text, so the comparison
+ * used to dedupe optimistic vs server echoes must operate on the same
+ * cleaned form — otherwise the same visible message renders twice.
+ */
+function stripGatewayUserMetadata(text: string): string {
+  return text
+    .replace(/^\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+[^\]]+\]\s*/i, '')
+    .replace(/\s*\[media attached:[^\]]*\]/g, '')
+    .replace(/\s*\[message_id:\s*[^\]]+\]/g, '')
+    .replace(/^Conversation info\s*\([^)]*\):\s*```[a-z]*\n[\s\S]*?```\s*/i, '')
+    .replace(/^Conversation info\s*\([^)]*\):\s*\{[\s\S]*?\}\s*/i, '');
+}
+
 function normalizeComparableUserText(content: unknown): string {
-  return getMessageText(content)
+  return stripGatewayUserMetadata(getMessageText(content))
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/src/stores/chat/helpers.ts
+++ b/src/stores/chat/helpers.ts
@@ -128,8 +128,31 @@ function normalizeStreamingMessage(message: unknown): unknown {
     : rawMessage;
 }
 
+/**
+ * Strip Gateway-injected metadata that does NOT exist on the renderer's
+ * optimistic user message but is echoed back when the Gateway persists it:
+ *   - leading timestamp `[Wed 2026-04-22 10:30 GMT+8] `
+ *   - `[message_id: uuid]` tags sprinkled throughout the text
+ *   - `[media attached: path (mime) | path]` references appended when the
+ *     renderer sends attachments via `chat:sendWithMedia`
+ *   - Gateway-injected "Conversation info (untrusted metadata): ..." blocks
+ *
+ * Keeping this aligned with `cleanUserText` in `pages/Chat/message-utils.ts`
+ * is important: the user bubble renders the cleaned text, so the comparison
+ * used to dedupe optimistic vs server echoes must operate on the same
+ * cleaned form — otherwise the same visible message renders twice.
+ */
+function stripGatewayUserMetadata(text: string): string {
+  return text
+    .replace(/^\s*\[(?:Mon|Tue|Wed|Thu|Fri|Sat|Sun)\s+\d{4}-\d{2}-\d{2}\s+\d{2}:\d{2}\s+[^\]]+\]\s*/i, '')
+    .replace(/\s*\[media attached:[^\]]*\]/g, '')
+    .replace(/\s*\[message_id:\s*[^\]]+\]/g, '')
+    .replace(/^Conversation info\s*\([^)]*\):\s*```[a-z]*\n[\s\S]*?```\s*/i, '')
+    .replace(/^Conversation info\s*\([^)]*\):\s*\{[\s\S]*?\}\s*/i, '');
+}
+
 function normalizeComparableUserText(content: unknown): string {
-  return getMessageText(content)
+  return stripGatewayUserMetadata(getMessageText(content))
     .replace(/\s+/g, ' ')
     .trim();
 }

--- a/tests/unit/chat-optimistic-match.test.ts
+++ b/tests/unit/chat-optimistic-match.test.ts
@@ -2,14 +2,14 @@ import { describe, expect, it } from 'vitest';
 import { matchesOptimisticUserMessage } from '@/stores/chat/helpers';
 
 describe('matchesOptimisticUserMessage', () => {
-  it('matches when text is identical', () => {
+  it('文本完全一致时应匹配', () => {
     const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
     const candidate = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('matches when Gateway prefixes a weekday/timestamp prefix on the echoed user message', () => {
+  it('服务端回显包含 Gateway 注入的星期/时间前缀时应匹配', () => {
     const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
@@ -20,10 +20,10 @@ describe('matchesOptimisticUserMessage', () => {
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('matches when the server appends [media attached: ...] to the echoed user message', () => {
+  it('服务端追加 [media attached: ...] 引用时应匹配', () => {
     const optimistic = {
       role: 'user',
-      content: 'Describe this image',
+      content: '描述这张图片',
       timestamp: 1_700_000_000,
       _attachedFiles: [
         {
@@ -37,29 +37,29 @@ describe('matchesOptimisticUserMessage', () => {
     } as const;
     const candidate = {
       role: 'user',
-      content: 'Describe this image\n\n[media attached: /tmp/shot.png (image/png) | /tmp/shot.png]',
+      content: '描述这张图片\n\n[media attached: /tmp/shot.png (image/png) | /tmp/shot.png]',
       timestamp: 1_700_000_000,
     } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('matches when the server strips a [message_id: ...] tag from the user message', () => {
-    const optimistic = { role: 'user', content: 'hello world', timestamp: 1_700_000_000 } as const;
+  it('服务端在用户消息中混入 [message_id: ...] 标签时应匹配', () => {
+    const optimistic = { role: 'user', content: '你好世界', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
-      content: 'hello world [message_id: 11111111-2222-3333-4444-555555555555]',
+      content: '你好世界 [message_id: 11111111-2222-3333-4444-555555555555]',
       timestamp: 1_700_000_000,
     } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('still rejects unrelated user messages', () => {
+  it('对完全不相关的用户消息仍应返回 false', () => {
     const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
-      content: '[Wed 2026-04-22 10:30 GMT+8] completely different text',
+      content: '[Wed 2026-04-22 10:30 GMT+8] 完全不同的内容',
       timestamp: 1_700_000_000,
     } as const;
 

--- a/tests/unit/chat-optimistic-match.test.ts
+++ b/tests/unit/chat-optimistic-match.test.ts
@@ -1,0 +1,68 @@
+import { describe, expect, it } from 'vitest';
+import { matchesOptimisticUserMessage } from '@/stores/chat/helpers';
+
+describe('matchesOptimisticUserMessage', () => {
+  it('matches when text is identical', () => {
+    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+    const candidate = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+
+    expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
+  });
+
+  it('matches when Gateway prefixes a weekday/timestamp prefix on the echoed user message', () => {
+    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+    const candidate = {
+      role: 'user',
+      content: '[Wed 2026-04-22 10:30 GMT+8] 执行github1',
+      timestamp: 1_700_000_000,
+    } as const;
+
+    expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
+  });
+
+  it('matches when the server appends [media attached: ...] to the echoed user message', () => {
+    const optimistic = {
+      role: 'user',
+      content: 'Describe this image',
+      timestamp: 1_700_000_000,
+      _attachedFiles: [
+        {
+          fileName: 'shot.png',
+          mimeType: 'image/png',
+          fileSize: 123,
+          preview: null,
+          filePath: '/tmp/shot.png',
+        },
+      ],
+    } as const;
+    const candidate = {
+      role: 'user',
+      content: 'Describe this image\n\n[media attached: /tmp/shot.png (image/png) | /tmp/shot.png]',
+      timestamp: 1_700_000_000,
+    } as const;
+
+    expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
+  });
+
+  it('matches when the server strips a [message_id: ...] tag from the user message', () => {
+    const optimistic = { role: 'user', content: 'hello world', timestamp: 1_700_000_000 } as const;
+    const candidate = {
+      role: 'user',
+      content: 'hello world [message_id: 11111111-2222-3333-4444-555555555555]',
+      timestamp: 1_700_000_000,
+    } as const;
+
+    expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
+  });
+
+  it('still rejects unrelated user messages', () => {
+    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+    const candidate = {
+      role: 'user',
+      content: '[Wed 2026-04-22 10:30 GMT+8] completely different text',
+      timestamp: 1_700_000_000,
+    } as const;
+
+    expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(false);
+  });
+});

--- a/tests/unit/chat-optimistic-match.test.ts
+++ b/tests/unit/chat-optimistic-match.test.ts
@@ -2,28 +2,28 @@ import { describe, expect, it } from 'vitest';
 import { matchesOptimisticUserMessage } from '@/stores/chat/helpers';
 
 describe('matchesOptimisticUserMessage', () => {
-  it('文本完全一致时应匹配', () => {
-    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
-    const candidate = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+  it('matches when text is identical', () => {
+    const optimistic = { role: 'user', content: 'run github1', timestamp: 1_700_000_000 } as const;
+    const candidate = { role: 'user', content: 'run github1', timestamp: 1_700_000_000 } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('服务端回显包含 Gateway 注入的星期/时间前缀时应匹配', () => {
-    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+  it('matches when Gateway prefixes a weekday/timestamp prefix on the echoed user message', () => {
+    const optimistic = { role: 'user', content: 'run github1', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
-      content: '[Wed 2026-04-22 10:30 GMT+8] 执行github1',
+      content: '[Wed 2026-04-22 10:30 GMT+8] run github1',
       timestamp: 1_700_000_000,
     } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('服务端追加 [media attached: ...] 引用时应匹配', () => {
+  it('matches when the server appends [media attached: ...] to the echoed user message', () => {
     const optimistic = {
       role: 'user',
-      content: '描述这张图片',
+      content: 'Describe this image',
       timestamp: 1_700_000_000,
       _attachedFiles: [
         {
@@ -37,29 +37,29 @@ describe('matchesOptimisticUserMessage', () => {
     } as const;
     const candidate = {
       role: 'user',
-      content: '描述这张图片\n\n[media attached: /tmp/shot.png (image/png) | /tmp/shot.png]',
+      content: 'Describe this image\n\n[media attached: /tmp/shot.png (image/png) | /tmp/shot.png]',
       timestamp: 1_700_000_000,
     } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('服务端在用户消息中混入 [message_id: ...] 标签时应匹配', () => {
-    const optimistic = { role: 'user', content: '你好世界', timestamp: 1_700_000_000 } as const;
+  it('matches when the server strips a [message_id: ...] tag from the user message', () => {
+    const optimistic = { role: 'user', content: 'hello world', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
-      content: '你好世界 [message_id: 11111111-2222-3333-4444-555555555555]',
+      content: 'hello world [message_id: 11111111-2222-3333-4444-555555555555]',
       timestamp: 1_700_000_000,
     } as const;
 
     expect(matchesOptimisticUserMessage(candidate, optimistic, 1_700_000_000_000)).toBe(true);
   });
 
-  it('对完全不相关的用户消息仍应返回 false', () => {
-    const optimistic = { role: 'user', content: '执行github1', timestamp: 1_700_000_000 } as const;
+  it('still rejects unrelated user messages', () => {
+    const optimistic = { role: 'user', content: 'run github1', timestamp: 1_700_000_000 } as const;
     const candidate = {
       role: 'user',
-      content: '[Wed 2026-04-22 10:30 GMT+8] 完全不同的内容',
+      content: '[Wed 2026-04-22 10:30 GMT+8] completely different text',
       timestamp: 1_700_000_000,
     } as const;
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fix a regression where asking one question made the same user bubble render twice in the chat stream.

### Root cause (lifecycle walkthrough)

1. `ChatInput.handleSend` calls `useChatStore.sendMessage(text, attachments, targetAgentId)`.
2. `runtime-send-actions.ts::sendMessage` appends an **optimistic** user `RawMessage` (plain trimmed text, `timestamp = Date.now()/1000`, random `id`) to `state.messages`, sets `sending: true`, and records `lastUserMessageAt`.
3. It then kicks off the history poll (`POLL_START_DELAY = 3s`, `POLL_INTERVAL = 4s`). Each tick calls `loadHistory(true)` while `sending === true`.
4. In `history-actions.ts::loadHistory` (and the legacy `chat.ts::loadHistory`), the server transcript is re-filtered and reduced to `enrichedMessages`. When `sending` is still `true`, it tries to preserve the optimistic entry by checking `matchesOptimisticUserMessage(candidate, optimistic, userMsMs)` against the server echo:
   - If a match is found, the optimistic entry is dropped and `state.messages` becomes the server view only.
   - If no match is found, `finalMessages = [...enrichedMessages, optimistic]` — the optimistic entry is appended on top of the server echo, and the chat stream renders **two** user bubbles.
5. `matchesOptimisticUserMessage` normalizes text via `normalizeComparableUserText`, which only collapses whitespace. The OpenClaw Gateway, however, rewrites every persisted user message with metadata that does not exist on the optimistic copy:
   - a leading timestamp prefix like `[Wed 2026-04-22 10:30 GMT+8] `
   - `[message_id: uuid]` tags
   - `[media attached: path (mime) | path]` refs injected by `chat:sendWithMedia`
   - a `Conversation info (untrusted metadata): ...` block
6. With the prefix attached, `sameText` is `false`, neither `sameAttachments` branch covers the plain-text case, so the matcher returns `false` — exactly the bug state in the screenshot.

The existing test mock in `tests/unit/chat-history-actions.test.ts` already **stripped the weekday prefix before comparing** (lines 60–63 of that file), so the history-actions tests continued to pass while production drifted away from the intended behavior.

### The fix

Introduce `stripGatewayUserMetadata` and plug it into `normalizeComparableUserText` in both the modular `src/stores/chat/helpers.ts` and the legacy `src/stores/chat.ts`. The stripping rules mirror `cleanUserText` in `src/pages/Chat/message-utils.ts`, so the comparator now operates on the same cleaned text the user sees in the bubble — the echo now consistently matches the optimistic copy regardless of which metadata the Gateway prepends.

## Related Issue(s)

Fixes the duplicate user-message render shown in the reporter's screenshot.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

- Added `tests/unit/chat-optimistic-match.test.ts` covering identical text, weekday/timestamp prefix, appended `[media attached: ...]`, inline `[message_id: ...]`, and a negative case. Tests fail on `main` and pass with the fix.
- `pnpm exec vitest run tests/unit/chat-*.test.*` → all 42 chat-scoped tests pass.
- `pnpm run typecheck` → clean after running `node scripts/generate-ext-bridge.mjs` (the generated stub file is required before typecheck in a fresh clone, unrelated to this change).
- `pnpm run lint` → clean (one pre-existing unrelated warning in `src/pages/Chat/index.tsx`).
- The 22 remaining test failures in `pnpm test` (gateway-manager / plugin-install suites) also fail on `main` before this change — see the pre/post diff captured during review.

GUI manual testing was not performed because this is a data-layer fix in the zustand store, and the repro requires a real Gateway round-trip that injects the `[Day YYYY-MM-DD HH:MM GMT±X]` prefix. The unit coverage targets the exact comparator used on the hot path, and the UI rendering logic in `src/pages/Chat/index.tsx` is unchanged.

## Checklist

- [x] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a108b326-848f-4f93-8967-edddc3095c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a108b326-848f-4f93-8967-edddc3095c84"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

