### PR TITLE
fix(validation): fall back to completions probe for custom providers returning 401/403 on /models

### DIFF
--- a/electron/services/providers/provider-validation.ts
+++ b/electron/services/providers/provider-validation.ts
@@ -216,6 +216,27 @@ async function validateOpenAiCompatibleKey(
     return await performChatCompletionsProbe(providerType, probeUrl, headers);
   }
 
+  // For custom providers, some implementations return 401/403 on GET /models even with a
+  // valid key because they don't implement the OpenAI models listing endpoint. Use the
+  // completions probe as a secondary check: if the server accepts the auth token there,
+  // the key is valid. If the probe also returns an auth failure, the key is genuinely wrong.
+  // Note: 400 auth errors (with explicit error messages) are not retried — those indicate
+  // the server understood the request but rejected the credentials explicitly.
+  if (
+    (modelsResult.status === 401 || modelsResult.status === 403) &&
+    providerType === 'custom'
+  ) {
+    console.log(
+      `[clawx-validate] ${providerType} /models returned auth failure (${modelsResult.status}), ` +
+      `trying ${apiProtocol} probe as secondary check for custom provider`,
+    );
+    const probeResult = apiProtocol === 'openai-responses'
+      ? await performResponsesProbe(providerType, probeUrl, headers)
+      : await performChatCompletionsProbe(providerType, probeUrl, headers);
+    if (probeResult.valid) return probeResult;
+    // Probe also failed — return the original /models auth error
+  }
+
   return modelsResult;
 }
 

--- a/tests/unit/provider-validation.test.ts
+++ b/tests/unit/provider-validation.test.ts
@@ -373,6 +373,111 @@ describe('validateApiKeyWithProvider', () => {
     );
   });
 
+  it('falls back to /chat/completions for custom provider when /models returns 401', async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unknown model: validation-probe' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-custom-valid', {
+      baseUrl: 'https://custom.example.com/v1',
+      apiProtocol: 'openai-completions',
+    });
+
+    expect(result).toMatchObject({ valid: true });
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(proxyAwareFetch).toHaveBeenNthCalledWith(
+      1,
+      'https://custom.example.com/v1/models?limit=1',
+      expect.anything(),
+    );
+    expect(proxyAwareFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://custom.example.com/v1/chat/completions',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('falls back to /responses for custom provider when /models returns 403', async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Forbidden' } }), {
+          status: 403,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unknown model: validation-probe' } }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-custom-valid-responses', {
+      baseUrl: 'https://custom.example.com/v1',
+      apiProtocol: 'openai-responses',
+    });
+
+    expect(result).toMatchObject({ valid: true });
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+    expect(proxyAwareFetch).toHaveBeenNthCalledWith(
+      2,
+      'https://custom.example.com/v1/responses',
+      expect.objectContaining({ method: 'POST' }),
+    );
+  });
+
+  it('reports invalid key for custom provider when /models returns 401 and probe also returns auth failure', async () => {
+    proxyAwareFetch
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      )
+      .mockResolvedValueOnce(
+        new Response(JSON.stringify({ error: { message: 'Invalid API key' } }), {
+          status: 401,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('custom', 'sk-custom-bad-key', {
+      baseUrl: 'https://custom.example.com/v1',
+      apiProtocol: 'openai-completions',
+    });
+
+    expect(result).toMatchObject({ valid: false });
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not apply auth-probe fallback for non-custom provider types returning 401 on /models', async () => {
+    proxyAwareFetch.mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: { message: 'Unauthorized' } }), {
+        status: 401,
+        headers: { 'Content-Type': 'application/json' },
+      })
+    );
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('openai', 'sk-bad-openai-key');
+
+    expect(result).toMatchObject({ valid: false, error: 'Invalid API key' });
+    expect(proxyAwareFetch).toHaveBeenCalledTimes(1);
+  });
+
   it('treats localized auth-like 400 probe responses as invalid after fallback', async () => {
     proxyAwareFetch
       .mockResolvedValueOnce(


### PR DESCRIPTION
Fixes #882

## Problem

Some custom AI provider implementations (e.g. opencode-go) return **401 or 403** on the `GET /models` endpoint even when the API key is valid, because they don't expose the standard OpenAI model listing endpoint. Previously, ClawX would immediately interpret these responses as "Invalid API key" and block the user from saving the custom provider — even though the key itself is correct.

## Solution

For the `custom` provider type, when `GET /models` returns 401 or 403, ClawX now runs a secondary validation probe against `POST /chat/completions` (or `/responses` for `openai-responses` protocol) using the same API key:

- **If the completions probe returns a non-auth error** (e.g. `400 "unknown model: validation-probe"`), it means the server accepted the auth token — the key is valid and the user's provider is saved.
- **If the probe also returns an auth failure**, the original error is returned unchanged — the key is genuinely wrong.

This fallback only applies to the `custom` provider type. Well-known providers (openai, anthropic, etc.) use dedicated validation profiles and are unaffected.

> **Note:** `400` responses with explicit auth-error messages from `/models` (e.g. `"Invalid API key provided"`, `"无效密钥"`) are **not** retried — those already contain a clear rejection from the server and should be surfaced directly.

## Testing

Added 4 new unit tests covering:
1. Custom provider where `/models` returns 401 → fallback probe returns 400 (valid model error) → key accepted
2. Custom provider where `/models` returns 403 → fallback to `/responses` → key accepted
3. Custom provider where `/models` returns 401 → probe also returns 401 → key correctly rejected
4. Non-custom provider (e.g. openai) where `/models` returns 401 → no secondary probe (single call, rejected immediately)

All 19 tests in `provider-validation.test.ts` pass.

```
pnpm exec vitest run tests/unit/provider-validation.test.ts
# Tests  19 passed (19)
```