### PR TITLE
style(chat): make reply bubble table headers transparent + bold in light theme

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -149,6 +149,11 @@
 }
 
 .prose th {
+  background: transparent;
+  font-weight: 700;
+}
+
+.dark .prose th {
   background: hsl(var(--muted));
 }
 

--- a/tests/e2e/chat-table-header-light.spec.ts
+++ b/tests/e2e/chat-table-header-light.spec.ts
@@ -1,3 +1,6 @@
+import { mkdirSync, copyFileSync } from 'node:fs';
+import { dirname } from 'node:path';
+
 import { closeElectronApp, expect, getStableWindow, installIpcMocks, test } from './fixtures/electron';
 
 const SESSION_KEY = 'agent:main:main';
@@ -12,21 +15,21 @@ function stableStringify(value: unknown): string {
 }
 
 const tableMarkdown = [
-  '| 账号 | 内容 | 热度 |',
-  '|------|------|------|',
-  '| @OpenAI | ChatGPT 推出 Workspace Agents（共享智能体），可跨团队处理复杂工作流 | 15K 2.2K转 4.4M浏览 |',
-  '| @oran_ge | GPT Images 2 限时免费一周，每人100张，Labnana平台 | 68 |',
-  '| @caiyue5 | X平台能自动识别"由AI生成"的图片，GPT Images 2引发讨论 | 74 |',
-  '| @fkysly | "GPT Image2团队全是华人？" 引发热议 | 482 |',
-  '| @binghe | 分析Claude封号的可能原因 | 620 |',
-  '| @turingou | "GPT Images 2水平完全可以替代Claude design" | 187 |',
-  '| @DashHuang | "OpenAI也开始KYC了" 截图引发讨论 | — |',
+  '| Account | Content | Heat |',
+  '|---------|---------|------|',
+  '| @OpenAI | ChatGPT launches Workspace Agents (shared agents) for cross-team complex workflows | 15K 2.2K RT 4.4M views |',
+  '| @oran_ge | GPT Images 2 free for one week, 100 images per user, on the Labnana platform | 68 |',
+  '| @caiyue5 | X now auto-detects "AI-generated" images, sparking GPT Images 2 discussion | 74 |',
+  '| @fkysly | "Is the GPT Image 2 team entirely Chinese?" goes viral | 482 |',
+  '| @binghe | Analyzing the possible reasons behind Claude account bans | 620 |',
+  '| @turingou | "GPT Images 2 can fully replace Claude for design work" | 187 |',
+  '| @DashHuang | "OpenAI is rolling out KYC" screenshot sparks discussion | — |',
 ].join('\n');
 
 const seededHistory = [
   {
     role: 'user',
-    content: [{ type: 'text', text: '请汇总今日 X 上的 AI 新闻。' }],
+    content: [{ type: 'text', text: 'Please summarize today\'s AI news on X.' }],
     timestamp: Date.now(),
   },
   {
@@ -34,25 +37,27 @@ const seededHistory = [
     content: [{
       type: 'text',
       text: [
-        '好，全部都查完了，给你汇总一下 👇',
+        'All done — here is a quick roundup for you:',
         '',
-        '🐦 **X（Twitter）关注列表 AI 新闻**',
+        '**X (Twitter) following list — AI news**',
         '',
-        '点击 **Following（关注）** 标签后，过滤掉了推荐内容，看到了你关注账号的真实动态：',
+        'After clicking the **Following** tab and filtering out recommended content, here is what your followed accounts are actually posting:',
         '',
-        '🔥 **热门 AI 推文**',
+        '**Trending AI tweets**',
         '',
         tableMarkdown,
         '',
-        '**主要趋势：** X上今日AI圈最热的三个话题是 ① GPT Images 2 / GPT Image2 ② Claude账号被封 ③ OpenAI Workspace Agents',
+        '**Key trends:** Today\'s hottest three topics in the AI corner of X are (1) GPT Images 2 / GPT Image2, (2) Claude account bans, and (3) OpenAI Workspace Agents.',
       ].join('\n'),
     }],
     timestamp: Date.now(),
   },
 ];
 
+const CLOUD_ARTIFACT_PATH = '/opt/cursor/artifacts/chat_table_header_light.png';
+
 test.describe('ClawX chat table header styling', () => {
-  test('renders markdown table headers with transparent background and bold text in light theme', async ({ launchElectronApp }) => {
+  test('renders markdown table headers with transparent background and bold text in light theme', async ({ launchElectronApp }, testInfo) => {
     const app = await launchElectronApp({ skipSetup: true });
 
     try {
@@ -127,7 +132,20 @@ test.describe('ClawX chat table header styling', () => {
 
       const tableEl = page.locator('.prose table').first();
       await tableEl.scrollIntoViewIfNeeded();
-      await tableEl.screenshot({ path: '/opt/cursor/artifacts/chat_table_header_light.png' });
+
+      const screenshotPath = testInfo.outputPath('chat_table_header_light.png');
+      await tableEl.screenshot({ path: screenshotPath });
+      await testInfo.attach('chat_table_header_light', {
+        path: screenshotPath,
+        contentType: 'image/png',
+      });
+
+      try {
+        mkdirSync(dirname(CLOUD_ARTIFACT_PATH), { recursive: true });
+        copyFileSync(screenshotPath, CLOUD_ARTIFACT_PATH);
+      } catch {
+        // Cloud artifact directory is optional; ignore when unavailable (e.g. on CI runners).
+      }
     } finally {
       await closeElectronApp(app);
     }

--- a/tests/e2e/chat-table-header-light.spec.ts
+++ b/tests/e2e/chat-table-header-light.spec.ts
@@ -1,0 +1,135 @@
+import { closeElectronApp, expect, getStableWindow, installIpcMocks, test } from './fixtures/electron';
+
+const SESSION_KEY = 'agent:main:main';
+
+function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
+  return `{${entries.join(',')}}`;
+}
+
+const tableMarkdown = [
+  '| 账号 | 内容 | 热度 |',
+  '|------|------|------|',
+  '| @OpenAI | ChatGPT 推出 Workspace Agents（共享智能体），可跨团队处理复杂工作流 | 15K 2.2K转 4.4M浏览 |',
+  '| @oran_ge | GPT Images 2 限时免费一周，每人100张，Labnana平台 | 68 |',
+  '| @caiyue5 | X平台能自动识别"由AI生成"的图片，GPT Images 2引发讨论 | 74 |',
+  '| @fkysly | "GPT Image2团队全是华人？" 引发热议 | 482 |',
+  '| @binghe | 分析Claude封号的可能原因 | 620 |',
+  '| @turingou | "GPT Images 2水平完全可以替代Claude design" | 187 |',
+  '| @DashHuang | "OpenAI也开始KYC了" 截图引发讨论 | — |',
+].join('\n');
+
+const seededHistory = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: '请汇总今日 X 上的 AI 新闻。' }],
+    timestamp: Date.now(),
+  },
+  {
+    role: 'assistant',
+    content: [{
+      type: 'text',
+      text: [
+        '好，全部都查完了，给你汇总一下 👇',
+        '',
+        '🐦 **X（Twitter）关注列表 AI 新闻**',
+        '',
+        '点击 **Following（关注）** 标签后，过滤掉了推荐内容，看到了你关注账号的真实动态：',
+        '',
+        '🔥 **热门 AI 推文**',
+        '',
+        tableMarkdown,
+        '',
+        '**主要趋势：** X上今日AI圈最热的三个话题是 ① GPT Images 2 / GPT Image2 ② Claude账号被封 ③ OpenAI Workspace Agents',
+      ].join('\n'),
+    }],
+    timestamp: Date.now(),
+  },
+];
+
+test.describe('ClawX chat table header styling', () => {
+  test('renders markdown table headers with transparent background and bold text in light theme', async ({ launchElectronApp }) => {
+    const app = await launchElectronApp({ skipSetup: true });
+
+    try {
+      await installIpcMocks(app, {
+        gatewayStatus: { state: 'running', port: 18789, pid: 12345 },
+        gatewayRpc: {
+          [stableStringify(['sessions.list', {}])]: {
+            success: true,
+            result: {
+              sessions: [{ key: SESSION_KEY, displayName: 'main' }],
+            },
+          },
+          [stableStringify(['chat.history', { sessionKey: SESSION_KEY, limit: 200 }])]: {
+            success: true,
+            result: { messages: seededHistory },
+          },
+          [stableStringify(['chat.history', { sessionKey: SESSION_KEY, limit: 1000 }])]: {
+            success: true,
+            result: { messages: seededHistory },
+          },
+        },
+        hostApi: {
+          [stableStringify(['/api/gateway/status', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { state: 'running', port: 18789, pid: 12345 },
+            },
+          },
+          [stableStringify(['/api/agents', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: {
+                success: true,
+                agents: [{ id: 'main', name: 'main' }],
+              },
+            },
+          },
+        },
+      });
+
+      const page = await getStableWindow(app);
+      try {
+        await page.reload();
+      } catch (error) {
+        if (!String(error).includes('ERR_FILE_NOT_FOUND')) {
+          throw error;
+        }
+      }
+
+      await expect(page.getByTestId('main-layout')).toBeVisible();
+
+      await page.evaluate(() => {
+        const root = document.documentElement;
+        root.classList.remove('dark');
+        root.classList.add('light');
+      });
+
+      const header = page.locator('.prose table thead th').first();
+      await expect(header).toBeVisible({ timeout: 30_000 });
+
+      const headerStyles = await header.evaluate((el) => {
+        const style = window.getComputedStyle(el);
+        return { backgroundColor: style.backgroundColor, fontWeight: style.fontWeight };
+      });
+
+      expect(headerStyles.backgroundColor).toBe('rgba(0, 0, 0, 0)');
+      expect(Number(headerStyles.fontWeight)).toBeGreaterThanOrEqual(700);
+
+      const tableEl = page.locator('.prose table').first();
+      await tableEl.scrollIntoViewIfNeeded();
+      await tableEl.screenshot({ path: '/opt/cursor/artifacts/chat_table_header_light.png' });
+    } finally {
+      await closeElectronApp(app);
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Markdown tables rendered inside assistant reply bubbles showed a filled (muted) background on the header row, which looked heavy on the light theme. This PR makes the header background transparent and bumps the font weight to `700` in light mode. Dark theme retains the original muted background so the header row stays visually distinct against the dark bubble.

[Reply bubble markdown table header in light theme (transparent background, bold text)](https://cursor.com/agents/bc-eaba7f48-b27e-4f70-bfb3-ade1fe78f047/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchat_table_header_light.png)

Change is isolated to `.prose th` in `src/styles/globals.css`; no renderer/main IPC changes.

## Related Issue(s)

N/A

## Type of Change

- [ ] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [x] Other (visual style tweak)

## Validation

- `pnpm run lint`
- `pnpm run typecheck`
- `pnpm run build:vite`
- New Electron E2E spec `tests/e2e/chat-table-header-light.spec.ts` seeds a chat session with a markdown table, switches to light theme, asserts computed header styles (`background-color: rgba(0, 0, 0, 0)`, `font-weight >= 700`) and attaches a screenshot of the rendered table to the Playwright report via `testInfo.outputPath(...)` so it works on both Linux (cloud) and macOS runners.
  - `xvfb-run -a pnpm exec playwright test tests/e2e/chat-table-header-light.spec.ts` — passes on Linux.

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed. (N/A — visual-only tweak, no behavior/interface change)
- [x] I verified there are no unrelated changes in this PR.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-eaba7f48-b27e-4f70-bfb3-ade1fe78f047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-eaba7f48-b27e-4f70-bfb3-ade1fe78f047"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

