### PR TITLE
fix(gateway): stop flagging RPC timeouts while gateway is starting/restarting

### DIFF
--- a/electron/api/routes/channels.ts
+++ b/electron/api/routes/channels.ts
@@ -258,6 +258,13 @@ const FORCE_RESTART_CHANNELS = new Set([
   'discord', 'telegram', 'signal', 'imessage', 'matrix', 'line', 'msteams', 'googlechat', 'mattermost',
 ]);
 
+// Increased from 150ms to 2000ms to coalesce typical setup flows where the UI
+// saves a provider, sets a default, binds an account, and saves a channel
+// config within ~1s of each other.  Before this change every step could
+// trigger a separate full Gateway restart on Windows (where reload=restart),
+// stacking cold-start latency and producing cascading "RPC timeout" banners.
+const CHANNEL_SAVE_RESTART_DEBOUNCE_MS = 2000;
+
 function scheduleGatewayChannelSaveRefresh(
   ctx: HostApiContext,
   channelType: string,
@@ -268,11 +275,11 @@ function scheduleGatewayChannelSaveRefresh(
     return;
   }
   if (FORCE_RESTART_CHANNELS.has(storedChannelType)) {
-    ctx.gatewayManager.debouncedRestart(150);
+    ctx.gatewayManager.debouncedRestart(CHANNEL_SAVE_RESTART_DEBOUNCE_MS);
     void reason;
     return;
   }
-  ctx.gatewayManager.debouncedReload(150);
+  ctx.gatewayManager.debouncedReload(CHANNEL_SAVE_RESTART_DEBOUNCE_MS);
   void reason;
 }
 
@@ -528,7 +535,18 @@ export async function buildChannelAccountsView(
   ]);
 
   let gatewayStatus: GatewayChannelStatusPayload | null = null;
-  if (!skipRuntime) {
+  // Skip the runtime RPC entirely while the gateway is still booting or
+  // reconnecting.  The old behaviour fired `channels.status` anyway, which
+  // — especially on Windows where cold-start can take 30s to 2min —
+  // immediately rejected with "Gateway not connected" or timed out.  Those
+  // failures then polluted the health summary and surfaced as the
+  // "网关状态异常 · 最近的网关 RPC 调用发生超时" red banner during normal
+  // startup.  The config-only path provides a complete view for the UI in
+  // the meantime.
+  const gatewayLifecycle = ctx.gatewayManager.getStatus();
+  const gatewayReadyForRpc =
+    gatewayLifecycle.state === 'running' && gatewayLifecycle.gatewayReady === true;
+  if (!skipRuntime && gatewayReadyForRpc) {
     try {
       // probe=false uses cached runtime state (lighter); probe=true forces
       // adapter-level connectivity checks for faster post-restart convergence.
@@ -552,6 +570,10 @@ export async function buildChannelAccountsView(
       );
       gatewayStatus = null;
     }
+  } else if (!skipRuntime) {
+    logger.info(
+      `[channels.accounts] channels.status skipped (state=${gatewayLifecycle.state}, gatewayReady=${gatewayLifecycle.gatewayReady === true ? '1' : '0'})`
+    );
   }
 
   const gatewayDiagnostics = ctx.gatewayManager.getDiagnostics?.() ?? {

--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -91,12 +91,24 @@ export interface GatewayDiagnosticsSnapshot {
   consecutiveRpcFailures: number;
 }
 
+/**
+ * Classify whether an RPC failure is a "transport" failure that should count
+ * against the gateway health summary's `consecutiveRpcFailures`.
+ *
+ * Historically this treated `Gateway not connected` and `Gateway stopped` as
+ * transport failures, but those are *expected* while the gateway is booting
+ * or being restarted — counting them caused the "最近的网关 RPC 调用发生超时"
+ * red banner to flash on Windows every time the gateway cold-started or the
+ * user saved a provider/channel config (which forces a full Windows restart).
+ *
+ * Only true RPC timeouts (WS is OPEN, request sent, gateway did not respond
+ * within `timeoutMs`) genuinely indicate the gateway is degraded.  The other
+ * cases are handled by the existing `status.state` lifecycle reasons
+ * (`gateway_not_running` / `gateway_error`).
+ */
 function isTransportRpcFailure(error: unknown): boolean {
   const message = error instanceof Error ? error.message : String(error);
-  return message.includes('RPC timeout:')
-    || message.includes('Gateway not connected')
-    || message.includes('Gateway stopped')
-    || message.includes('Failed to send RPC request:');
+  return message.includes('RPC timeout:');
 }
 
 /**
@@ -154,6 +166,12 @@ export class GatewayManager extends EventEmitter {
   private static readonly HEARTBEAT_INTERVAL_MS_WIN = 60_000;
   private static readonly HEARTBEAT_TIMEOUT_MS_WIN = 25_000;
   private static readonly HEARTBEAT_MAX_MISSES_WIN = 5;
+  // Minimum silence (no heartbeat pong AND no inbound message) before we are
+  // willing to restart the Gateway on Windows from a heartbeat-only signal.
+  // Short Defender / system stalls recover within a few minutes; genuine
+  // dead-locks never emit another message.  5 * 60s heartbeat interval ==
+  // 5 minutes of silence before we take action on Windows.
+  private static readonly WINDOWS_RECOVERY_SILENCE_MS = 5 * 60_000;
   public static readonly RESTART_COOLDOWN_MS = 5_000;
   private static readonly GATEWAY_READY_FALLBACK_MS = 30_000;
   private lastRestartAt = 0;
@@ -841,11 +859,51 @@ export class GatewayManager extends EventEmitter {
   private recordRpcSuccess(): void {
     this.diagnostics.lastRpcSuccessAt = Date.now();
     this.diagnostics.consecutiveRpcFailures = 0;
+    // A successful RPC is the strongest positive signal that the gateway's
+    // subsystems (plugins, channels, skills) are reachable.  Some gateway
+    // builds either never emit the `gateway.ready` event or emit it before
+    // handlers are actually registered, which the 30s fallback masked with
+    // a false "ready" flip.  Promoting the first RPC success to the source
+    // of truth avoids that gap.
+    if (this.status.state === 'running' && !this.status.gatewayReady) {
+      this.clearGatewayReadyFallback();
+      logger.info('Gateway subsystems ready (inferred from first successful RPC)');
+      this.setStatus({ gatewayReady: true });
+    }
   }
+
+  /**
+   * Grace window after WebSocket becomes connected during which we don't
+   * count RPC timeouts against gateway health.  Gateway cold-start on
+   * Windows can push subsystem readiness tens of seconds past the WS
+   * handshake, so early-bird RPCs timing out is expected behavior and
+   * should not surface as a "degraded" banner in the Channels page.
+   *
+   * Value chosen > CHAT_HISTORY_RPC_TIMEOUT_MS (35s) in the renderer so
+   * that the initial `chat.history` startup-retry wave does not poison
+   * the counter even in worst-case cold starts.
+   */
+  private static readonly RPC_FAILURE_STARTUP_GRACE_MS = 45_000;
 
   private recordRpcFailure(method: string): void {
     this.diagnostics.lastRpcFailureAt = Date.now();
     this.diagnostics.lastRpcFailureMethod = method;
+
+    // Only count the failure against the health summary if the gateway is
+    // supposed to be fully running.  While the gateway is starting, stopping,
+    // reconnecting, or in its startup grace window, timeouts are expected
+    // side-effects of the lifecycle — not a degraded signal.
+    if (this.status.state !== 'running') {
+      return;
+    }
+    if (!this.status.gatewayReady) {
+      return;
+    }
+    const connectedAt = this.status.connectedAt;
+    if (connectedAt != null && Date.now() - connectedAt < GatewayManager.RPC_FAILURE_STARTUP_GRACE_MS) {
+      return;
+    }
+
     this.diagnostics.consecutiveRpcFailures += 1;
   }
 
@@ -1071,17 +1129,35 @@ export class GatewayManager extends EventEmitter {
         this.recordHeartbeatTimeout(consecutiveMisses);
         const pid = this.process?.pid ?? 'unknown';
         const isWindows = process.platform === 'win32';
-        const shouldAttemptRecovery = !isWindows && this.shouldReconnect && this.status.state === 'running';
         logger.warn(
           `Gateway heartbeat: ${consecutiveMisses} consecutive pong misses ` +
             `(timeout=${timeoutMs}ms, pid=${pid}, state=${this.status.state}, autoReconnect=${this.shouldReconnect}).`,
         );
-        if (!shouldAttemptRecovery) {
-          const reason = isWindows
-            ? 'platform=win32'
-            : 'lifecycle is not in auto-recoverable running state';
-          logger.warn(`Gateway heartbeat recovery skipped (${reason})`);
+        const lifecycleRecoverable = this.shouldReconnect && this.status.state === 'running';
+        if (!lifecycleRecoverable) {
+          logger.warn('Gateway heartbeat recovery skipped (lifecycle is not in auto-recoverable running state)');
           return;
+        }
+        // On Windows we previously disabled heartbeat-driven recovery entirely
+        // because Defender scans and transient OS stalls would produce false
+        // positives.  That left users with a permanently hung Gateway whenever
+        // the process actually deadlocked (see issue: 网关 RPC 调用超时 on
+        // Windows/0.3.10).  We now re-enable recovery but require an
+        // additional "truly silent" guard: no successful alive signal for
+        // at least WINDOWS_RECOVERY_SILENCE_MS so short scan-induced blips
+        // still do not trigger a restart.
+        if (isWindows) {
+          const lastAliveAt = this.diagnostics.lastAliveAt ?? 0;
+          const silenceMs = lastAliveAt === 0
+            ? Number.POSITIVE_INFINITY
+            : Date.now() - lastAliveAt;
+          if (silenceMs < GatewayManager.WINDOWS_RECOVERY_SILENCE_MS) {
+            logger.warn(
+              `Gateway heartbeat recovery deferred on Windows: alive signal seen ${silenceMs}ms ago ` +
+                `(require >= ${GatewayManager.WINDOWS_RECOVERY_SILENCE_MS}ms of silence).`,
+            );
+            return;
+          }
         }
         logger.warn('Gateway heartbeat recovery: restarting unresponsive gateway process');
         void this.restart().catch((error) => {

--- a/electron/gateway/ws-client.ts
+++ b/electron/gateway/ws-client.ts
@@ -11,6 +11,33 @@ import { logger } from '../utils/logger';
 export const GATEWAY_CHALLENGE_TIMEOUT_MS = 10_000;
 export const GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS = 20_000;
 
+/**
+ * Windows-specific handshake/challenge ceilings.
+ *
+ * Gateway cold-start on Windows is dominated by Defender scans, npx/plugin
+ * unpacking, and bonjour probing — all of which can stretch the interval
+ * between `WebSocket open` and `connect.challenge` well past 10 s.  The
+ * old defaults fired a false "handshake timeout" during normal cold-starts,
+ * which `startup-orchestrator` then treated as a transient error and
+ * retried up to 3×, stacking >1 min of additional cold-start delay on top
+ * of the real boot time.
+ *
+ * We keep the stricter defaults on macOS/Linux and only relax them on
+ * win32 to avoid changing well-behaved platforms.
+ */
+export const GATEWAY_CHALLENGE_TIMEOUT_MS_WIN = 30_000;
+export const GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN = 45_000;
+
+export function getPlatformChallengeTimeoutMs(platform: NodeJS.Platform | string): number {
+  return platform === 'win32' ? GATEWAY_CHALLENGE_TIMEOUT_MS_WIN : GATEWAY_CHALLENGE_TIMEOUT_MS;
+}
+
+export function getPlatformConnectHandshakeTimeoutMs(platform: NodeJS.Platform | string): number {
+  return platform === 'win32'
+    ? GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN
+    : GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS;
+}
+
 export async function probeGatewayReady(
   port: number,
   timeoutMs = 1500,
@@ -179,8 +206,10 @@ export async function connectGatewaySocket(options: {
   connectTimeoutMs?: number;
 }): Promise<WebSocket> {
   logger.debug(`Connecting Gateway WebSocket (ws://localhost:${options.port}/ws)`);
-  const challengeTimeoutMs = options.challengeTimeoutMs ?? GATEWAY_CHALLENGE_TIMEOUT_MS;
-  const connectTimeoutMs = options.connectTimeoutMs ?? GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS;
+  const challengeTimeoutMs =
+    options.challengeTimeoutMs ?? getPlatformChallengeTimeoutMs(options.platform);
+  const connectTimeoutMs =
+    options.connectTimeoutMs ?? getPlatformConnectHandshakeTimeoutMs(options.platform);
 
   return await new Promise<WebSocket>((resolve, reject) => {
     const wsUrl = `ws://localhost:${options.port}/ws`;

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -1448,11 +1448,14 @@ function registerOpenClawHandlers(gatewayManager: GatewayManager): void {
   // initialize / tear-down plugin connections.  SIGUSR1 in-process reload is
   // not sufficient for channel plugins (see restartGatewayForAgentDeletion).
   const forceRestartChannels = new Set(['dingtalk', 'wecom', 'whatsapp', 'feishu', 'qqbot']);
+  // Debounce window for gateway refreshes triggered by a channel save.
+  // See electron/api/routes/channels.ts for rationale.
+  const CHANNEL_SAVE_RESTART_DEBOUNCE_MS = 2000;
 
   const scheduleGatewayChannelRestart = (reason: string): void => {
     if (gatewayManager.getStatus().state !== 'stopped') {
       logger.info(`Scheduling Gateway restart after ${reason}`);
-      gatewayManager.debouncedRestart(150);
+      gatewayManager.debouncedRestart(CHANNEL_SAVE_RESTART_DEBOUNCE_MS);
     } else {
       logger.info(`Gateway is stopped; skip immediate restart after ${reason}`);
     }
@@ -1465,11 +1468,11 @@ function registerOpenClawHandlers(gatewayManager: GatewayManager): void {
     }
     if (forceRestartChannels.has(channelType)) {
       logger.info(`Scheduling Gateway restart after ${reason}`);
-      gatewayManager.debouncedRestart(150);
+      gatewayManager.debouncedRestart(CHANNEL_SAVE_RESTART_DEBOUNCE_MS);
       return;
     }
     logger.info(`Scheduling Gateway reload after ${reason}`);
-    gatewayManager.debouncedReload(150);
+    gatewayManager.debouncedReload(CHANNEL_SAVE_RESTART_DEBOUNCE_MS);
   };
 
   // Get OpenClaw package status

--- a/src/pages/Channels/index.tsx
+++ b/src/pages/Channels/index.tsx
@@ -130,6 +130,7 @@ export function Channels() {
   const { t } = useTranslation('channels');
   const gatewayStatus = useGatewayStore((state) => state.status);
   const lastGatewayStateRef = useRef(gatewayStatus.state);
+  const lastGatewayReadyRef = useRef(gatewayStatus.gatewayReady === true);
 
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -286,6 +287,12 @@ export function Channels() {
     // Channel adapters can take time to reconnect after gateway restart.
     // First few rounds use probe=true to force runtime connectivity checks,
     // then fall back to cached pulls to reduce load.
+    //
+    // We still schedule all five timers up-front, but each invocation now
+    // re-reads the latest gatewayStatus before firing.  If the gateway is
+    // not yet running+ready (which is the common case on Windows cold-start),
+    // fetchPageData is skipped for this tick so we don't flood the main
+    // process with channels.status RPCs that are guaranteed to be no-ops.
     [
       { delay: 1200, probe: true },
       { delay: 2600, probe: false },
@@ -294,6 +301,13 @@ export function Channels() {
       { delay: 10500, probe: false },
     ].forEach(({ delay, probe }) => {
       const timerId = window.setTimeout(() => {
+        const status = useGatewayStore.getState().status;
+        if (status.state !== 'running' || status.gatewayReady !== true) {
+          console.info(
+            `[channels-ui] convergence tick skipped (state=${status.state}, gatewayReady=${status.gatewayReady === true ? '1' : '0'})`,
+          );
+          return;
+        }
         void fetchPageData({ probe });
       }, delay);
       convergenceRefreshTimersRef.current.push(timerId);
@@ -342,13 +356,30 @@ export function Channels() {
 
   useEffect(() => {
     const previousGatewayState = lastGatewayStateRef.current;
+    const previousGatewayReady = lastGatewayReadyRef.current;
+    const currentGatewayReady = gatewayStatus.gatewayReady === true;
     lastGatewayStateRef.current = gatewayStatus.state;
+    lastGatewayReadyRef.current = currentGatewayReady;
 
-    if (previousGatewayState !== 'running' && gatewayStatus.state === 'running') {
+    const stateJustTransitionedToRunning =
+      previousGatewayState !== 'running' && gatewayStatus.state === 'running';
+    // Also re-sync when the gateway was already running but only just
+    // finished booting its subsystems.  Without this, a page that loaded
+    // during `starting` and then transitioned via `gateway.ready` (without
+    // ever changing status.state) would never refresh runtime data.
+    const readyJustFlippedOnWhileRunning =
+      gatewayStatus.state === 'running' && !previousGatewayReady && currentGatewayReady;
+
+    if (stateJustTransitionedToRunning || readyJustFlippedOnWhileRunning) {
       void fetchPageData();
       scheduleConvergenceRefresh();
     }
-  }, [fetchPageData, gatewayStatus.state, scheduleConvergenceRefresh]);
+  }, [
+    fetchPageData,
+    gatewayStatus.state,
+    gatewayStatus.gatewayReady,
+    scheduleConvergenceRefresh,
+  ]);
 
   const configuredTypes = useMemo(
     () => visibleChannelGroups.map((group) => group.channelType),

--- a/tests/unit/channel-routes.test.ts
+++ b/tests/unit/channel-routes.test.ts
@@ -174,7 +174,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc,
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           getDiagnostics: () => ({ consecutiveHeartbeatMisses: 0, consecutiveRpcFailures: 0 }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
@@ -218,7 +218,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -258,7 +258,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -292,7 +292,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -325,7 +325,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -353,7 +353,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -387,7 +387,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -407,7 +407,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -447,7 +447,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -492,7 +492,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -535,7 +535,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -577,7 +577,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -615,7 +615,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -666,7 +666,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -709,7 +709,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -746,7 +746,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -817,7 +817,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc,
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -895,7 +895,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc,
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -948,7 +948,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc,
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           getDiagnostics: () => ({ consecutiveHeartbeatMisses: 0, consecutiveRpcFailures: 0 }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
@@ -1035,7 +1035,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc,
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           getDiagnostics: () => ({ consecutiveHeartbeatMisses: 1, consecutiveRpcFailures: 0 }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
@@ -1090,7 +1090,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -1204,7 +1204,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -1263,7 +1263,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -1313,7 +1313,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },
@@ -1365,7 +1365,7 @@ describe('handleChannelRoutes', () => {
       {
         gatewayManager: {
           rpc: vi.fn(),
-          getStatus: () => ({ state: 'running' }),
+          getStatus: () => ({ state: 'running', gatewayReady: true }),
           debouncedReload: vi.fn(),
           debouncedRestart: vi.fn(),
         },

--- a/tests/unit/gateway-manager-diagnostics.test.ts
+++ b/tests/unit/gateway-manager-diagnostics.test.ts
@@ -48,6 +48,14 @@ describe('GatewayManager diagnostics', () => {
     };
 
     (manager as unknown as { ws: typeof ws }).ws = ws;
+    // recordRpcFailure() only counts while the gateway is running, ready,
+    // and outside the 45s startup grace — mirror that in the test.
+    (manager as unknown as { status: { state: string; port: number; connectedAt: number; gatewayReady: boolean } }).status = {
+      state: 'running',
+      port: 18789,
+      connectedAt: Date.now() - 60_000,
+      gatewayReady: true,
+    };
 
     (manager as unknown as { handleMessage: (message: unknown) => void }).handleMessage({
       type: 'event',
@@ -98,9 +106,11 @@ describe('GatewayManager diagnostics', () => {
     };
 
     (manager as unknown as { ws: typeof ws }).ws = ws;
-    (manager as unknown as { status: { state: string; port: number } }).status = {
+    (manager as unknown as { status: { state: string; port: number; connectedAt: number; gatewayReady: boolean } }).status = {
       state: 'running',
       port: 18789,
+      connectedAt: Date.now() - 60_000,
+      gatewayReady: true,
     };
 
     const failurePromise = manager.rpc('channels.status', {}, 1000);
@@ -125,7 +135,109 @@ describe('GatewayManager diagnostics', () => {
     expect(health.reasons).not.toContain('rpc_timeout');
   });
 
-  it('keeps windows heartbeat recovery disabled while diagnostics degrade', async () => {
+  it('does not count RPC timeouts against health while gateway is still starting', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const { buildGatewayHealthSummary } = await import('@electron/utils/gateway-health');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      send: vi.fn(),
+      ping: vi.fn(),
+      terminate: vi.fn(),
+      on: vi.fn(),
+    };
+
+    (manager as unknown as { ws: typeof ws }).ws = ws;
+    // Simulate the gateway still coming up: state=starting, no gatewayReady.
+    (manager as unknown as { status: { state: string; port: number; gatewayReady?: boolean } }).status = {
+      state: 'starting',
+      port: 18789,
+      gatewayReady: false,
+    };
+
+    const failurePromise = manager.rpc('channels.status', {}, 1000);
+    vi.advanceTimersByTime(1001);
+    await expect(failurePromise).rejects.toThrow('RPC timeout: channels.status');
+
+    // Timeout must be recorded (lastRpcFailureAt) but NOT counted toward
+    // consecutiveRpcFailures, because the gateway was not yet running.
+    const diagnostics = manager.getDiagnostics();
+    expect(diagnostics.lastRpcFailureAt).toBe(Date.now());
+    expect(diagnostics.consecutiveRpcFailures).toBe(0);
+
+    const health = buildGatewayHealthSummary({
+      status: manager.getStatus(),
+      diagnostics: manager.getDiagnostics(),
+      platform: process.platform,
+    });
+    expect(health.reasons).not.toContain('rpc_timeout');
+  });
+
+  it('does not count RPC timeouts within the 45s post-connect grace window', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      send: vi.fn(),
+      ping: vi.fn(),
+      terminate: vi.fn(),
+      on: vi.fn(),
+    };
+
+    (manager as unknown as { ws: typeof ws }).ws = ws;
+    // Freshly connected gateway — within the 45s grace window.
+    (manager as unknown as { status: { state: string; port: number; gatewayReady?: boolean; connectedAt: number } }).status = {
+      state: 'running',
+      port: 18789,
+      gatewayReady: true,
+      connectedAt: Date.now() - 10_000,
+    };
+
+    const failurePromise = manager.rpc('channels.status', {}, 1000);
+    vi.advanceTimersByTime(1001);
+    await expect(failurePromise).rejects.toThrow('RPC timeout: channels.status');
+
+    // Within the startup grace window — counter should stay at zero.
+    expect(manager.getDiagnostics().consecutiveRpcFailures).toBe(0);
+  });
+
+  it('infers gatewayReady=true on first successful RPC', async () => {
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      send: vi.fn(),
+      ping: vi.fn(),
+      terminate: vi.fn(),
+      on: vi.fn(),
+    };
+
+    (manager as unknown as { ws: typeof ws }).ws = ws;
+    (manager as unknown as { status: { state: string; port: number; gatewayReady?: boolean } }).status = {
+      state: 'running',
+      port: 18789,
+      gatewayReady: false,
+    };
+
+    const successPromise = manager.rpc<{ ok: boolean }>('sessions.list', {}, 1000);
+    const id = Array.from(
+      (manager as unknown as { pendingRequests: Map<string, unknown> }).pendingRequests.keys(),
+    )[0];
+    (manager as unknown as { handleMessage: (message: unknown) => void }).handleMessage({
+      type: 'res',
+      id,
+      ok: true,
+      payload: { ok: true },
+    });
+    await expect(successPromise).resolves.toEqual({ ok: true });
+
+    expect(manager.getStatus().gatewayReady).toBe(true);
+  });
+
+  it('defers windows heartbeat recovery during short stalls but restarts after prolonged silence', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
     const { GatewayManager } = await import('@electron/gateway/manager');
@@ -146,12 +258,26 @@ describe('GatewayManager diagnostics', () => {
       state: 'running',
       port: 18789,
     };
+    // Simulate a recent alive signal so the first heartbeat-timeout threshold
+    // does *not* breach the 5-minute silence guard.
+    (manager as unknown as { diagnostics: { lastAliveAt: number; consecutiveHeartbeatMisses: number; consecutiveRpcFailures: number } }).diagnostics = {
+      lastAliveAt: Date.now(),
+      consecutiveHeartbeatMisses: 0,
+      consecutiveRpcFailures: 0,
+    };
     const restartSpy = vi.spyOn(manager, 'restart').mockResolvedValue();
 
     (manager as unknown as { startPing: () => void }).startPing();
-    vi.advanceTimersByTime(400_000);
 
+    // First 5 misses occur over ~5 * 60s == 300s; all but the last tick still
+    // land inside the 5-minute silence window so recovery should defer.
+    vi.advanceTimersByTime(5 * 60_000);
     expect(restartSpy).not.toHaveBeenCalled();
+
+    // Continue running without any inbound message: silence now clearly
+    // exceeds 5 minutes, recovery must fire.
+    vi.advanceTimersByTime(60_000);
+    expect(restartSpy).toHaveBeenCalledTimes(1);
 
     const health = buildGatewayHealthSummary({
       status: manager.getStatus(),

--- a/tests/unit/gateway-manager-heartbeat.test.ts
+++ b/tests/unit/gateway-manager-heartbeat.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('electron', () => ({
   app: {
@@ -119,7 +119,7 @@ describe('GatewayManager heartbeat recovery', () => {
     (manager as unknown as { connectionMonitor: { clear: () => void } }).connectionMonitor.clear();
   });
 
-  it('keeps heartbeat recovery disabled on windows', async () => {
+  it('defers heartbeat recovery on windows while inside the 5-minute silence guard', async () => {
     Object.defineProperty(process, 'platform', { value: 'win32' });
 
     const { GatewayManager } = await import('@electron/gateway/manager');
@@ -138,13 +138,58 @@ describe('GatewayManager heartbeat recovery', () => {
       state: 'running',
       port: 18789,
     };
+    // Recent alive signal → first threshold breach should defer (<5 min silence).
+    (manager as unknown as { diagnostics: { lastAliveAt: number; consecutiveHeartbeatMisses: number; consecutiveRpcFailures: number } }).diagnostics = {
+      lastAliveAt: Date.now(),
+      consecutiveHeartbeatMisses: 0,
+      consecutiveRpcFailures: 0,
+    };
     const restartSpy = vi.spyOn(manager, 'restart').mockResolvedValue();
 
     (manager as unknown as { startPing: () => void }).startPing();
 
-    vi.advanceTimersByTime(400_000);
+    // Windows interval=60s, timeout=25s, max=5 misses: threshold fires around
+    // ~5 * 60s == 300s.  Advance only that far so the silence-window guard
+    // is still inside the 5-minute quiet requirement → restart should defer.
+    vi.advanceTimersByTime(5 * 60_000);
 
     expect(restartSpy).not.toHaveBeenCalled();
+
+    (manager as unknown as { connectionMonitor: { clear: () => void } }).connectionMonitor.clear();
+  });
+
+  it('triggers heartbeat recovery on windows after prolonged silence', async () => {
+    Object.defineProperty(process, 'platform', { value: 'win32' });
+
+    const { GatewayManager } = await import('@electron/gateway/manager');
+    const manager = new GatewayManager();
+
+    const ws = {
+      readyState: 1,
+      ping: vi.fn(),
+      terminate: vi.fn(),
+      on: vi.fn(),
+    };
+
+    (manager as unknown as { ws: typeof ws }).ws = ws;
+    (manager as unknown as { shouldReconnect: boolean }).shouldReconnect = true;
+    (manager as unknown as { status: { state: string; port: number } }).status = {
+      state: 'running',
+      port: 18789,
+    };
+    // Alive signal from 10 minutes ago → guard is satisfied at first breach.
+    (manager as unknown as { diagnostics: { lastAliveAt: number; consecutiveHeartbeatMisses: number; consecutiveRpcFailures: number } }).diagnostics = {
+      lastAliveAt: Date.now() - 10 * 60_000,
+      consecutiveHeartbeatMisses: 0,
+      consecutiveRpcFailures: 0,
+    };
+    const restartSpy = vi.spyOn(manager, 'restart').mockResolvedValue();
+
+    (manager as unknown as { startPing: () => void }).startPing();
+
+    vi.advanceTimersByTime(6 * 60_000);
+
+    expect(restartSpy).toHaveBeenCalledTimes(1);
 
     (manager as unknown as { connectionMonitor: { clear: () => void } }).connectionMonitor.clear();
   });

--- a/tests/unit/gateway-ws-client.test.ts
+++ b/tests/unit/gateway-ws-client.test.ts
@@ -62,8 +62,13 @@ vi.mock('@electron/utils/logger', () => ({
 }));
 
 import {
+  GATEWAY_CHALLENGE_TIMEOUT_MS,
+  GATEWAY_CHALLENGE_TIMEOUT_MS_WIN,
   GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS,
+  GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN,
   connectGatewaySocket,
+  getPlatformChallengeTimeoutMs,
+  getPlatformConnectHandshakeTimeoutMs,
   probeGatewayReady,
 } from '@electron/gateway/ws-client';
 
@@ -146,6 +151,71 @@ describe('connectGatewaySocket', () => {
     await expect(connectionPromise).resolves.toBe(socket);
     expect(onHandshakeComplete).toHaveBeenCalledWith(socket);
     expect(pendingRequests.size).toBe(0);
+  });
+
+  it('uses the Windows-specific handshake/challenge timeouts by default on win32', async () => {
+    // Pure helper test — no socket construction required.
+    expect(getPlatformChallengeTimeoutMs('win32')).toBe(GATEWAY_CHALLENGE_TIMEOUT_MS_WIN);
+    expect(getPlatformChallengeTimeoutMs('darwin')).toBe(GATEWAY_CHALLENGE_TIMEOUT_MS);
+    expect(getPlatformChallengeTimeoutMs('linux')).toBe(GATEWAY_CHALLENGE_TIMEOUT_MS);
+    expect(getPlatformConnectHandshakeTimeoutMs('win32')).toBe(GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN);
+    expect(getPlatformConnectHandshakeTimeoutMs('darwin')).toBe(GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS);
+    // Windows ceilings must be wider than the defaults — otherwise there is
+    // no reason for the helper to exist.
+    expect(GATEWAY_CHALLENGE_TIMEOUT_MS_WIN).toBeGreaterThan(GATEWAY_CHALLENGE_TIMEOUT_MS);
+    expect(GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN).toBeGreaterThan(GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS);
+  });
+
+  it('does not time out on win32 within the default non-windows handshake window', async () => {
+    const pendingRequests = new Map();
+    const onHandshakeComplete = vi.fn();
+
+    const connectionPromise = connectGatewaySocket({
+      port: 18789,
+      deviceIdentity: null,
+      platform: 'win32',
+      pendingRequests,
+      getToken: vi.fn().mockResolvedValue('token-123'),
+      onHandshakeComplete,
+      onMessage: (message) => {
+        if (typeof message !== 'object' || message === null) return;
+        const msg = message as { type?: string; id?: string; ok?: boolean; payload?: unknown; error?: unknown };
+        if (msg.type !== 'res' || typeof msg.id !== 'string') return;
+        const pending = pendingRequests.get(msg.id);
+        if (!pending) return;
+        if (msg.ok === false || msg.error) {
+          pending.reject(new Error(String(msg.error ?? 'Gateway request failed')));
+          return;
+        }
+        pending.resolve(msg.payload ?? msg);
+      },
+      onCloseAfterHandshake: vi.fn(),
+    });
+
+    const socket = getLatestSocket();
+    socket.emitOpen();
+    socket.emitJsonMessage({
+      type: 'event',
+      event: 'connect.challenge',
+      payload: { nonce: 'nonce-win-123' },
+    });
+    await flushMicrotasks();
+
+    // Jump well past the non-windows default — handshake must still be alive
+    // because win32 now uses GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN (45s).
+    await vi.advanceTimersByTimeAsync(GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS + 5_000);
+    expect(onHandshakeComplete).not.toHaveBeenCalled();
+
+    const connectFrame = JSON.parse(socket.sentFrames[0]) as { id: string };
+    socket.emitJsonMessage({
+      type: 'res',
+      id: connectFrame.id,
+      ok: true,
+      payload: { protocol: 3 },
+    });
+
+    await expect(connectionPromise).resolves.toBe(socket);
+    expect(onHandshakeComplete).toHaveBeenCalledWith(socket);
   });
 
   it('still fails when the connect response exceeds the configured timeout', async () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

On Windows + ClawX 0.3.10, many users see a persistent red banner on the Channels page:

> 网关状态异常 · 最近的网关 RPC 调用发生超时

This analysis of user-submitted logs (captured `spawnToReadyMs` of 50–130 seconds on Windows) showed the banner is **not a single bug**, but the product of several Windows-specific lifecycle choices combining against a UI judgement with no cooldown:

1. **Cold-start dwarfs RPC timeouts.** On Windows, Gateway bootstrap (uv python download, Defender scans, bonjour probing, model-pricing fetch, plugin init) routinely takes 30 s to 2 min. The first `channels.status` (5–8 s timeout) and `chat.history` (30–35 s timeout) fire long before the gateway is actually ready, rejecting with `Gateway not connected` / `Gateway stopped` / `RPC timeout`.
2. **Windows `reload` is forced into `restart`.** `SIGUSR1` is not supported, so every provider + channel save triggers a full cold-start, cascading the previous problem.
3. **Windows heartbeat recovery was disabled outright.** Once the Gateway deadlocked (Defender / plugin / IO stall), the manager logged `Gateway heartbeat recovery skipped (platform=win32)` and did nothing until the user manually clicked "重启网关".
4. **Handshake / challenge ceilings were platform-agnostic** (10 s / 20 s). On Windows those were shorter than real cold-starts, producing a false `Connect handshake timeout`, which `startup-orchestrator` treated as a transient error and retried up to 3× — stacking another >1 min of delay.
5. **Health judgement was too hot.** `consecutiveRpcFailures > 0` → `rpc_timeout` reason without any cooldown. A single transport failure while the gateway was still booting stuck the banner until the next successful RPC.
6. **Channels page re-fired 5 refresh ticks on page load** (1.2 / 2.6 / 4.5 / 7 / 10.5 s), compounding the counter during cold-start.

Log evidence (abridged, from attached session transcripts):

```
[metric] gateway.startup { spawnToReadyMs: 128245, totalMs: 128866 }
[channels.accounts] channels.status probe=0 failed after 8013ms
[gateway:rpc] chat.history failed (timeoutMs=35000): Error: Gateway stopped
[ERROR] Gateway connect handshake timed out
[WARN ] Transient start error: Error: Connect handshake timeout. Retrying... (1/3)
Gateway heartbeat: 5 consecutive pong misses … autoReconnect=true
Gateway heartbeat recovery skipped (platform=win32)
```

## Fix

`electron/gateway/manager.ts`
- `isTransportRpcFailure()` narrowed to only `"RPC timeout:"`. `Gateway not connected` / `Gateway stopped` / send failures are expected during lifecycle transitions and are already surfaced via `status.state` (`gateway_not_running` / `gateway_error` reasons).
- `recordRpcFailure()` gates incrementing `consecutiveRpcFailures` on `status.state === 'running'`, `gatewayReady === true`, AND 45 s elapsed since `connectedAt` — matching the renderer-side `chat.history` startup retry window.
- `recordRpcSuccess()` now infers `gatewayReady = true` on the first successful RPC, so builds that never emit (or emit too-early) `gateway.ready` no longer wait on the 30 s fallback.
- Windows heartbeat recovery is re-enabled but behind a **5-minute silence guard** (`WINDOWS_RECOVERY_SILENCE_MS`). Short Defender-induced blips (which emit another message within a minute or two) keep the existing deferral; genuine deadlocks now self-heal after 5 min.

`electron/gateway/ws-client.ts`
- New `GATEWAY_CHALLENGE_TIMEOUT_MS_WIN = 30_000` and `GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS_WIN = 45_000`, selected automatically via `getPlatformChallenge/ConnectHandshakeTimeoutMs()` based on the caller's `platform`. Linux / macOS retain the stricter 10 s / 20 s defaults.
- Prevents the retry loop that previously stacked three 20 s handshake-timeout failures on top of a legitimate Windows cold-start.

`electron/api/routes/channels.ts`
- `buildChannelAccountsView()` short-circuits the runtime `channels.status` RPC unless the gateway is truly `running && gatewayReady`. Startup renders now rely on the config view (already fully populated) instead of firing requests that are guaranteed to fail.
- Channel save debounce raised from **150 ms → 2000 ms** (`CHANNEL_SAVE_RESTART_DEBOUNCE_MS`). A typical provider + channel setup flow (which can trigger 3–5 saves within 1 s of each other) now coalesces into a single Gateway restart instead of stacking several cold-starts on Windows.

`electron/main/ipc-handlers.ts`
- Same 2000 ms debounce applied to the legacy IPC code path that also drives channel-save refreshes.

`src/pages/Channels/index.tsx`
- `scheduleConvergenceRefresh()` timers re-read the live gateway status before firing. Ticks are skipped (with a clear info log) while the gateway is not yet `running + gatewayReady`.
- Added a second trigger so that when `gatewayReady` flips true while `status.state` is already `'running'`, the page re-fetches runtime data and re-schedules convergence. This covers the case where a page loaded during `'starting'` and transitioned via `gateway.ready` without ever changing `status.state`.

## Non-fix decisions documented

- **UtilityProcess IPC reload (PLAN item #4)**: declined after code audit of `node_modules/openclaw/dist`. OpenClaw only handles reload via in-process `SIGUSR1` (`process.listenerCount('SIGUSR1') > 0 ? emit : kill`) and does not listen for parent `process.on('message')` IPC. There is no `gateway.reload` / `admin.reload` RPC; `secrets.reload` and `config.apply` both funnel back into the same SIGUSR1 path. Even if implemented, the SIGUSR1 in-process reload re-runs the same plugin/bonjour/model-pricing init that causes the cost we see anyway. The debounce bump from 150 ms → 2 s (above) captures the much larger win — one restart per typical setup flow instead of 3-5.

## Tests

- `tests/unit/gateway-manager-diagnostics.test.ts` (now 6 tests):
  - **new:** RPC timeout during `state: 'starting'` does NOT pollute `consecutiveRpcFailures` / `rpc_timeout` reason.
  - **new:** RPC timeout within the 45 s post-connect grace window does NOT count.
  - **new:** First successful RPC flips `gatewayReady = true`.
  - Existing cases updated to set `connectedAt` / `gatewayReady` so `recordRpcFailure` still fires where intended.
- `tests/unit/gateway-manager-heartbeat.test.ts` (now 5 tests):
  - Windows case split into "deferred while <5 min silence guard" + "fires after prolonged silence".
- `tests/unit/gateway-ws-client.test.ts` (now 12 tests):
  - **new:** `getPlatformChallenge/ConnectHandshakeTimeoutMs` returns the Windows constants on win32 and defaults elsewhere.
  - **new:** A win32 handshake still succeeds after advancing past the non-windows default (+5 s) because the Windows ceiling is in effect.
- `tests/unit/channel-routes.test.ts`:
  - 25 `getStatus` mocks extended with `gatewayReady: true` so `channels.status` still dispatches in tests.

### Verification

| Check | Result |
| --- | --- |
| `pnpm test` | 84 files, **542 tests passed** |
| `pnpm typecheck` | clean |
| `pnpm run lint` | clean |
| `pnpm run comms:replay` + `comms:compare` | all metrics **PASS** (rpc_timeout_rate, duplicate_event_rate, event_fanout_ratio, history_inflight_max, rpc_p95_ms 0% delta vs baseline) |

## Notes for reviewers

- No change to the banner UI itself or to user-facing copy.
- The startup-grace change intentionally keeps `lastRpcFailureAt` / `lastRpcFailureMethod` diagnostics populated for debugging — only the health summary is gated.
- No renderer-side change needed for history path: `src/stores/chat/history-startup-retry.ts` already classifies these failures and retries for up to ~45 s, so timeouts that used to poison the banner now retry transparently.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-57556ba2-1de1-4a93-a7e0-ff41c0a880c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-57556ba2-1de1-4a93-a7e0-ff41c0a880c4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

