### PR TITLE
Improve first-load latency for Skills and Channels

### DIFF
--- a/electron/gateway/clawhub.ts
+++ b/electron/gateway/clawhub.ts
@@ -53,6 +53,11 @@ export class ClawHubService {
     private useNodeRunner: boolean;
     private ansiRegex: RegExp;
     private marketplaceProvider: MarketplaceProvider | null = null;
+    private listInstalledCache:
+        | { expiresAt: number; results: ClawHubInstalledSkillResult[] }
+        | null = null;
+    private listInstalledInFlight: Promise<ClawHubInstalledSkillResult[]> | null = null;
+    private readonly listInstalledCacheTtlMs = 15_000;
 
     setMarketplaceProvider(provider: MarketplaceProvider): void {
         this.marketplaceProvider = provider;
@@ -338,6 +343,7 @@ export class ClawHubService {
         }
 
         await this.runCommand(args);
+        this.invalidateInstalledListCache();
     }
 
     /**
@@ -367,20 +373,28 @@ export class ClawHubService {
                 console.error('Failed to update ClawHub lock file:', err);
             }
         }
+        this.invalidateInstalledListCache();
     }
 
     /**
      * List installed skills
      */
     async listInstalled(): Promise<ClawHubInstalledSkillResult[]> {
+        const now = Date.now();
+        if (this.listInstalledCache && this.listInstalledCache.expiresAt > now) {
+            return this.listInstalledCache.results;
+        }
+        if (this.listInstalledInFlight) {
+            return await this.listInstalledInFlight;
+        }
+
+        this.listInstalledInFlight = (async () => {
         try {
             const output = await this.runCommand(['list']);
-            if (!output || output.includes('No installed skills')) {
-                return [];
-            }
-
-            const lines = output.split('\n').filter(l => l.trim());
-            return lines.map(line => {
+            let results: ClawHubInstalledSkillResult[] = [];
+            if (output && !output.includes('No installed skills')) {
+                const lines = output.split('\n').filter(l => l.trim());
+                results = lines.map(line => {
                 const cleanLine = this.stripAnsi(line);
                 const match = cleanLine.match(/^(\S+)\s+v?(\d+\.\S+)/);
                 if (match) {
@@ -394,10 +408,26 @@ export class ClawHubService {
                 }
                 return null;
             }).filter((s): s is ClawHubInstalledSkillResult => s !== null);
+            }
+            this.listInstalledCache = {
+                expiresAt: Date.now() + this.listInstalledCacheTtlMs,
+                results,
+            };
+            return results;
         } catch (error) {
             console.error('ClawHub list error:', error);
             return [];
+        } finally {
+            this.listInstalledInFlight = null;
         }
+        })();
+
+        return await this.listInstalledInFlight;
+    }
+
+    private invalidateInstalledListCache(): void {
+        this.listInstalledCache = null;
+        this.listInstalledInFlight = null;
     }
 
     private resolveSkillDir(skillKeyOrSlug: string, fallbackSlug?: string, preferredBaseDir?: string): string | null {

--- a/src/pages/Channels/index.tsx
+++ b/src/pages/Channels/index.tsx
@@ -301,9 +301,12 @@ export function Channels() {
   }, [clearConvergenceRefreshTimers, fetchPageData]);
 
   useEffect(() => {
+    if (gatewayStatus.state === 'running') {
+      void fetchPageData();
+      return;
+    }
     void fetchPageData({ configOnly: true });
-    void fetchPageData();
-  }, [fetchPageData]);
+  }, [fetchPageData, gatewayStatus.state]);
 
   useEffect(() => {
     return () => {

--- a/src/stores/skills.ts
+++ b/src/stores/skills.ts
@@ -8,6 +8,8 @@ import { AppError, normalizeAppError } from '@/lib/error-model';
 import { useGatewayStore } from './gateway';
 import type { Skill, MarketplaceSkill } from '../types/skill';
 
+let latestFetchSkillsRequestId = 0;
+
 type GatewaySkillStatus = {
   skillKey: string;
   slug?: string;
@@ -35,6 +37,87 @@ type ClawHubListResult = {
   source?: string;
   baseDir?: string;
 };
+
+function buildSkillsFromGatewayAndConfig(
+  gatewayData: GatewaySkillsStatusResult,
+  configResult: Record<string, { apiKey?: string; env?: Record<string, string> }>,
+  currentSkills: Skill[],
+): Skill[] {
+  if (gatewayData.skills) {
+    return gatewayData.skills.map((s: GatewaySkillStatus) => {
+      const directConfig = configResult[s.skillKey] || {};
+
+      return {
+        id: s.skillKey,
+        slug: s.slug || s.skillKey,
+        name: s.name || s.skillKey,
+        description: s.description || '',
+        enabled: !s.disabled,
+        icon: s.emoji || '📦',
+        version: s.version || '1.0.0',
+        author: s.author,
+        config: {
+          ...(s.config || {}),
+          ...directConfig,
+        },
+        isCore: s.bundled && s.always,
+        isBundled: s.bundled,
+        source: s.source,
+        baseDir: s.baseDir,
+        filePath: s.filePath,
+      };
+    });
+  }
+
+  if (currentSkills.length > 0) {
+    return [...currentSkills];
+  }
+
+  return [];
+}
+
+function mergeClawHubSkills(
+  baseSkills: Skill[],
+  clawhubResult: { success: boolean; results?: ClawHubListResult[]; error?: string },
+  configResult: Record<string, { apiKey?: string; env?: Record<string, string> }>,
+): Skill[] {
+  if (!clawhubResult.success || !clawhubResult.results) {
+    return baseSkills;
+  }
+
+  const mergedSkills = [...baseSkills];
+  clawhubResult.results.forEach((cs: ClawHubListResult) => {
+    const existing = mergedSkills.find(s => s.id === cs.slug);
+    if (existing) {
+      if (!existing.baseDir && cs.baseDir) {
+        existing.baseDir = cs.baseDir;
+      }
+      if (!existing.source && cs.source) {
+        existing.source = cs.source;
+      }
+      return;
+    }
+
+    const directConfig = configResult[cs.slug] || {};
+    mergedSkills.push({
+      id: cs.slug,
+      slug: cs.slug,
+      name: cs.slug,
+      description: 'Recently installed, initializing...',
+      enabled: false,
+      icon: '⌛',
+      version: cs.version || 'unknown',
+      author: undefined,
+      config: directConfig,
+      isCore: false,
+      isBundled: false,
+      source: cs.source || 'openclaw-managed',
+      baseDir: cs.baseDir,
+    });
+  });
+
+  return mergedSkills;
+}
 
 function mapErrorCodeToSkillErrorKey(
   code: AppError['code'],
@@ -87,88 +170,39 @@ export const useSkillsStore = create<SkillsState>((set, get) => ({
   error: null,
 
   fetchSkills: async () => {
+    const requestId = ++latestFetchSkillsRequestId;
     // Only show loading state if we have no skills yet (initial load)
     if (get().skills.length === 0) {
       set({ loading: true, error: null });
     }
     try {
-      // Fetch all skill sources in parallel to reduce first-load latency.
+      // Start all sources immediately, but do not block first paint on the
+      // slower ClawHub CLI listing used only for enrichment.
       const gatewayDataPromise = useGatewayStore.getState().rpc<GatewaySkillsStatusResult>('skills.status');
       const clawhubResultPromise = hostApiFetch<{ success: boolean; results?: ClawHubListResult[]; error?: string }>('/api/clawhub/list');
       const configResultPromise = hostApiFetch<Record<string, { apiKey?: string; env?: Record<string, string> }>>('/api/skills/configs');
-      const [gatewayData, clawhubResult, configResult] = await Promise.all([
+      const [gatewayData, configResult] = await Promise.all([
         gatewayDataPromise,
-        clawhubResultPromise,
         configResultPromise,
       ]);
 
-      let combinedSkills: Skill[] = [];
-      const currentSkills = get().skills;
-
-      // Map gateway skills info
-      if (gatewayData.skills) {
-        combinedSkills = gatewayData.skills.map((s: GatewaySkillStatus) => {
-          // Merge with direct config if available
-          const directConfig = configResult[s.skillKey] || {};
-
-          return {
-            id: s.skillKey,
-            slug: s.slug || s.skillKey,
-            name: s.name || s.skillKey,
-            description: s.description || '',
-            enabled: !s.disabled,
-            icon: s.emoji || '📦',
-            version: s.version || '1.0.0',
-            author: s.author,
-            config: {
-              ...(s.config || {}),
-              ...directConfig,
-            },
-            isCore: s.bundled && s.always,
-            isBundled: s.bundled,
-            source: s.source,
-            baseDir: s.baseDir,
-            filePath: s.filePath,
-          };
-        });
-      } else if (currentSkills.length > 0) {
-        // ... if gateway down ...
-        combinedSkills = [...currentSkills];
+      const combinedSkills = buildSkillsFromGatewayAndConfig(gatewayData, configResult, get().skills);
+      if (requestId === latestFetchSkillsRequestId) {
+        set({ skills: combinedSkills, loading: false, error: null });
       }
 
-      // Merge with ClawHub results
-      if (clawhubResult.success && clawhubResult.results) {
-        clawhubResult.results.forEach((cs: ClawHubListResult) => {
-          const existing = combinedSkills.find(s => s.id === cs.slug);
-          if (existing) {
-            if (!existing.baseDir && cs.baseDir) {
-              existing.baseDir = cs.baseDir;
-            }
-            if (!existing.source && cs.source) {
-              existing.source = cs.source;
-            }
+      void clawhubResultPromise
+        .then((clawhubResult) => {
+          if (requestId !== latestFetchSkillsRequestId) {
             return;
           }
-          const directConfig = configResult[cs.slug] || {};
-          combinedSkills.push({
-            id: cs.slug,
-            slug: cs.slug,
-            name: cs.slug,
-            description: 'Recently installed, initializing...',
-            enabled: false,
-            icon: '⌛',
-            version: cs.version || 'unknown',
-            author: undefined,
-            config: directConfig,
-            isCore: false,
-            isBundled: false,
-            source: cs.source || 'openclaw-managed',
-            baseDir: cs.baseDir,
-          });
+          set((state) => ({
+            skills: mergeClawHubSkills(state.skills, clawhubResult, configResult),
+          }));
+        })
+        .catch((error) => {
+          console.warn('Failed to enrich skills from ClawHub list:', error);
         });
-      }
-
-      set({ skills: combinedSkills, loading: false });
     } catch (error) {
       console.error('Failed to fetch skills:', error);
       const appError = normalizeAppError(error, { module: 'skills', operation: 'fetch' });

--- a/tests/e2e/skills-and-channels-first-load.spec.ts
+++ b/tests/e2e/skills-and-channels-first-load.spec.ts
@@ -1,0 +1,143 @@
+import { completeSetup, expect, test } from './fixtures/electron';
+
+test.describe('Skills and Channels first-load responsiveness', () => {
+  test('renders channels immediately and keeps skills navigation responsive while clawhub list is slow', async ({ electronApp, page }) => {
+    await electronApp.evaluate(({ ipcMain }) => {
+      ipcMain.removeHandler('hostapi:fetch');
+      ipcMain.handle('hostapi:fetch', async (_event, request: { path?: string; method?: string }) => {
+        const method = request?.method ?? 'GET';
+        const path = request?.path ?? '';
+
+        if (path === '/api/gateway/status' && method === 'GET') {
+          return {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { state: 'running', port: 18789 },
+            },
+          };
+        }
+
+        if (path === '/api/agents' && method === 'GET') {
+          return {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { success: true, agents: [] },
+            },
+          };
+        }
+
+        if (path === '/api/channels/accounts' && method === 'GET') {
+          return {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: {
+                success: true,
+                gatewayHealth: {
+                  state: 'healthy',
+                  reasons: [],
+                  consecutiveHeartbeatMisses: 0,
+                },
+                channels: [
+                  {
+                    channelType: 'feishu',
+                    defaultAccountId: 'default',
+                    status: 'connected',
+                    accounts: [
+                      {
+                        accountId: 'default',
+                        name: 'Primary Account',
+                        configured: true,
+                        status: 'connected',
+                        isDefault: true,
+                      },
+                    ],
+                  },
+                ],
+              },
+            },
+          };
+        }
+
+        if (path === '/api/skills/configs' && method === 'GET') {
+          return {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: {},
+            },
+          };
+        }
+
+        if (path === '/api/clawhub/list' && method === 'GET') {
+          await new Promise((resolve) => setTimeout(resolve, 1_500));
+          return {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: {
+                success: true,
+                results: [
+                  {
+                    slug: 'market-skill',
+                    version: '1.2.3',
+                    source: 'openclaw-managed',
+                    baseDir: '/tmp/market-skill',
+                  },
+                ],
+              },
+            },
+          };
+        }
+
+        return {
+          ok: false,
+          error: { message: `Unexpected hostapi:fetch request: ${method} ${path}` },
+        };
+      });
+
+      ipcMain.removeHandler('gateway:rpc');
+      ipcMain.handle('gateway:rpc', async (_event, method: string) => {
+        if (method === 'skills.status') {
+          return {
+            success: true,
+            result: {
+              skills: [
+                {
+                  skillKey: 'demo-skill',
+                  slug: 'demo-skill',
+                  name: 'Demo Skill',
+                  description: 'Gateway-backed skill',
+                  disabled: false,
+                  version: '1.0.0',
+                  source: 'openclaw-bundled',
+                },
+              ],
+            },
+          };
+        }
+
+        return {
+          success: true,
+          result: {},
+        };
+      });
+    });
+
+    await completeSetup(page);
+
+    await page.getByTestId('sidebar-nav-channels').click();
+    await expect(page.getByTestId('channels-page')).toBeVisible();
+    await expect(page.getByText('Feishu / Lark')).toBeVisible();
+
+    await page.getByTestId('sidebar-nav-skills').click();
+    await expect(page.getByText('Demo Skill')).toBeVisible();
+  });
+});

--- a/tests/unit/channels-page.test.tsx
+++ b/tests/unit/channels-page.test.tsx
@@ -214,13 +214,28 @@ describe('Channels page status refresh', () => {
     });
   });
 
+  it('skips config-only prefetch on mount when gateway is already running', async () => {
+    subscribeHostEventMock.mockImplementation(() => vi.fn());
+
+    render(<Channels />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Feishu / Lark')).toBeInTheDocument();
+    });
+
+    const configFetchCalls = hostApiFetchMock.mock.calls.filter(([path]) => path === '/api/channels/accounts?mode=config');
+    const runtimeFetchCalls = hostApiFetchMock.mock.calls.filter(([path]) => path === '/api/channels/accounts');
+    expect(configFetchCalls).toHaveLength(0);
+    expect(runtimeFetchCalls).toHaveLength(1);
+  });
+
   it('refetches when the gateway transitions to running after mount', async () => {
     gatewayState.status = { state: 'starting', port: 18789 };
 
     const { rerender } = render(<Channels />);
 
     await waitFor(() => {
-      expect(hostApiFetchMock).toHaveBeenCalledWith('/api/channels/accounts');
+      expect(hostApiFetchMock).toHaveBeenCalledWith('/api/channels/accounts?mode=config');
       expect(hostApiFetchMock).toHaveBeenCalledWith('/api/agents');
     });
 

--- a/tests/unit/clawhub-service.test.ts
+++ b/tests/unit/clawhub-service.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const spawnMock = vi.fn();
+const existsSyncMock = vi.fn();
+const ensureDirMock = vi.fn();
+
+vi.mock('child_process', () => ({
+  spawn: (...args: unknown[]) => spawnMock(...args),
+  default: {
+    spawn: (...args: unknown[]) => spawnMock(...args),
+  },
+}));
+
+vi.mock('fs', () => ({
+  default: {
+    existsSync: (...args: unknown[]) => existsSyncMock(...args),
+    readFileSync: vi.fn(),
+    readdirSync: vi.fn(),
+    promises: {
+      rm: vi.fn(),
+      writeFile: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: true,
+  },
+  shell: {
+    openPath: vi.fn(),
+  },
+}));
+
+vi.mock('@electron/utils/paths', () => ({
+  getOpenClawConfigDir: () => '/tmp/openclaw',
+  ensureDir: (...args: unknown[]) => ensureDirMock(...args),
+  getClawHubCliBinPath: () => '/tmp/clawhub',
+  getClawHubCliEntryPath: () => '/tmp/clawhub-entry.js',
+  quoteForCmd: (value: string) => value,
+}));
+
+function createChildProcessMock() {
+  const stdoutHandlers: Array<(chunk: Buffer) => void> = [];
+  const closeHandlers: Array<(code: number | null) => void> = [];
+  const errorHandlers: Array<(error: Error) => void> = [];
+
+  return {
+    stdout: {
+      on: (event: string, handler: (chunk: Buffer) => void) => {
+        if (event === 'data') stdoutHandlers.push(handler);
+      },
+    },
+    stderr: {
+      on: (event: string, handler: (chunk: Buffer) => void) => {
+        if (event === 'data') void handler;
+      },
+    },
+    on: (event: string, handler: ((code: number | null) => void) | ((error: Error) => void)) => {
+      if (event === 'close') {
+        closeHandlers.push(handler as (code: number | null) => void);
+      }
+      if (event === 'error') {
+        errorHandlers.push(handler as (error: Error) => void);
+      }
+    },
+    emitStdoutAndClose: (stdoutChunks: string[], code: number | null = 0) => {
+      stdoutChunks.forEach((chunk) => {
+        stdoutHandlers.forEach((handler) => handler(Buffer.from(chunk)));
+      });
+      closeHandlers.forEach((handler) => handler(code));
+    },
+    emitError: (error: Error) => {
+      errorHandlers.forEach((handler) => handler(error));
+    },
+  };
+}
+
+describe('ClawHubService listInstalled cache', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    existsSyncMock.mockReturnValue(true);
+  });
+
+  it('deduplicates in-flight listInstalled calls and reuses cached results', async () => {
+    const child = createChildProcessMock();
+    spawnMock.mockReturnValue(child);
+
+    const { ClawHubService } = await import('@electron/gateway/clawhub');
+    const service = new ClawHubService();
+
+    const pending = Promise.all([
+      service.listInstalled(),
+      service.listInstalled(),
+    ]);
+    child.emitStdoutAndClose(['demo-skill v1.2.3\n']);
+    const [first, second] = await pending;
+
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(first).toEqual(second);
+    expect(first).toEqual([
+      {
+        slug: 'demo-skill',
+        version: '1.2.3',
+        source: 'openclaw-managed',
+        baseDir: '/tmp/openclaw/skills/demo-skill',
+      },
+    ]);
+
+    const cached = await service.listInstalled();
+    expect(spawnMock).toHaveBeenCalledTimes(1);
+    expect(cached).toEqual(first);
+  });
+
+  it('invalidates the installed-skills cache after install and uninstall', async () => {
+    const firstList = createChildProcessMock();
+    const installRun = createChildProcessMock();
+    const secondList = createChildProcessMock();
+    const thirdList = createChildProcessMock();
+    spawnMock
+      .mockReturnValueOnce(firstList)
+      .mockReturnValueOnce(installRun)
+      .mockReturnValueOnce(secondList)
+      .mockReturnValueOnce(thirdList);
+
+    const { ClawHubService } = await import('@electron/gateway/clawhub');
+    const service = new ClawHubService();
+
+    const initialListPromise = service.listInstalled();
+    firstList.emitStdoutAndClose(['demo-skill v1.2.3\n']);
+    await initialListPromise;
+
+    const installPromise = service.install({ slug: 'demo-skill' });
+    installRun.emitStdoutAndClose([]);
+    await installPromise;
+
+    const secondListPromise = service.listInstalled();
+    secondList.emitStdoutAndClose(['demo-skill v1.2.3\n']);
+    await secondListPromise;
+
+    await service.uninstall({ slug: 'demo-skill' });
+    const thirdListPromise = service.listInstalled();
+    thirdList.emitStdoutAndClose(['demo-skill v1.2.3\n']);
+    await thirdListPromise;
+
+    expect(spawnMock).toHaveBeenCalledTimes(4);
+  });
+});

--- a/tests/unit/skills-store-fetch-parallel.test.ts
+++ b/tests/unit/skills-store-fetch-parallel.test.ts
@@ -53,4 +53,64 @@ describe('skills store fetch parallelization', () => {
     gatewayDeferred.resolve({ skills: [] });
     await fetchPromise;
   });
+
+  it('does not block initial skills state on slow clawhub list', async () => {
+    const clawhubDeferred = deferred<{ success: boolean; results: Array<{ slug: string; version: string; source: string; baseDir: string }> }>();
+    rpcMock.mockResolvedValueOnce({
+      skills: [
+        {
+          skillKey: 'demo-skill',
+          slug: 'demo-skill',
+          name: 'Demo Skill',
+          description: 'Gateway skill',
+          disabled: false,
+          version: '1.0.0',
+          source: 'openclaw-bundled',
+        },
+      ],
+    });
+    hostApiFetchMock.mockImplementation((path: unknown) => {
+      if (path === '/api/clawhub/list') return clawhubDeferred.promise;
+      if (path === '/api/skills/configs') return Promise.resolve({});
+      return Promise.reject(new Error(`Unexpected path: ${String(path)}`));
+    });
+
+    const { useSkillsStore } = await import('@/stores/skills');
+    useSkillsStore.setState({ skills: [], loading: false, error: null });
+
+    await useSkillsStore.getState().fetchSkills();
+
+    expect(useSkillsStore.getState().loading).toBe(false);
+    expect(useSkillsStore.getState().skills).toEqual([
+      expect.objectContaining({
+        id: 'demo-skill',
+        name: 'Demo Skill',
+        source: 'openclaw-bundled',
+      }),
+    ]);
+
+    clawhubDeferred.resolve({
+      success: true,
+      results: [
+        {
+          slug: 'later-skill',
+          version: '2.0.0',
+          source: 'openclaw-managed',
+          baseDir: '/tmp/later-skill',
+        },
+      ],
+    });
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(useSkillsStore.getState().skills).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'demo-skill',
+      }),
+      expect.objectContaining({
+        id: 'later-skill',
+        baseDir: '/tmp/later-skill',
+      }),
+    ]));
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- stop the Skills page from blocking first render on the slower `clawhub list` enrichment path
- cache and dedupe `clawhub list` results in the main process to avoid repeated cold subprocess launches
- skip the redundant config-only Channels fetch when the gateway is already running
- add focused unit coverage and an Electron E2E regression for the first-load responsiveness path

## Related Issue(s)

- addresses Windows first-install slowness when opening Skills / Channels while the gateway is already up

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

- `pnpm test tests/unit/skills-store-fetch-parallel.test.ts tests/unit/channels-page.test.tsx tests/unit/clawhub-service.test.ts`
- `node scripts/generate-ext-bridge.mjs && pnpm run build:vite`
- `xvfb-run -a pnpm exec playwright test tests/e2e/skills-and-channels-first-load.spec.ts`
- manual walkthrough on the running app covering Channels then Skills first navigation

[skills_channels_first_load_walkthrough.mp4](https://cursor.com/agents/bc-c26ed8af-f2d7-409b-bc2d-121298ad2a09/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskills_channels_first_load_walkthrough.mp4)
[Channels first load](https://cursor.com/agents/bc-c26ed8af-f2d7-409b-bc2d-121298ad2a09/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fchannels_first_load.png)
[Skills first load](https://cursor.com/agents/bc-c26ed8af-f2d7-409b-bc2d-121298ad2a09/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fskills_first_load.png)

## Checklist

- [x] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-c26ed8af-f2d7-409b-bc2d-121298ad2a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c26ed8af-f2d7-409b-bc2d-121298ad2a09"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

