### PR TITLE
feat(chat): Surface terminal model errors in chat

### DIFF
--- a/src/i18n/locales/en/chat.json
+++ b/src/i18n/locales/en/chat.json
@@ -35,6 +35,7 @@
         "title": "Execution Graph",
         "branchLabel": "branch",
         "thinkingLabel": "Thinking",
+        "errorLabel": "Error",
         "agentRun": "{{agent}} execution",
         "collapsedSummary": "{{toolCount}} tool calls · {{processCount}} process messages",
         "collapseAction": "Collapse execution graph"

--- a/src/i18n/locales/ja/chat.json
+++ b/src/i18n/locales/ja/chat.json
@@ -35,6 +35,7 @@
         "title": "実行グラフ",
         "branchLabel": "branch",
         "thinkingLabel": "考え中",
+        "errorLabel": "エラー",
         "agentRun": "{{agent}} の実行",
         "collapsedSummary": "ツール呼び出し {{toolCount}} 件 · プロセスメッセージ {{processCount}} 件",
         "collapseAction": "実行グラフを折りたたむ"

--- a/src/i18n/locales/ru/chat.json
+++ b/src/i18n/locales/ru/chat.json
@@ -35,6 +35,7 @@
         "title": "Граф выполнения",
         "branchLabel": "ветвь",
         "thinkingLabel": "Думаю",
+        "runErrorLabel": "Ошибка модели",
         "agentRun": "Выполнение {{agent}}",
         "collapsedSummary": "Вызовов инструментов: {{toolCount}} · Промежуточных сообщений: {{processCount}}",
         "collapseAction": "Свернуть граф выполнения"

--- a/src/i18n/locales/zh/chat.json
+++ b/src/i18n/locales/zh/chat.json
@@ -35,6 +35,7 @@
         "title": "执行关系图",
         "branchLabel": "分支",
         "thinkingLabel": "思考中",
+        "modelErrorTitle": "模型调用失败",
         "agentRun": "{{agent}} 执行",
         "collapsedSummary": "{{toolCount}} 个工具调用，{{processCount}} 条过程消息",
         "collapseAction": "收起执行关系图"

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -79,6 +79,7 @@ export function Chat() {
   const loading = useChatStore((s) => s.loading);
   const sending = useChatStore((s) => s.sending);
   const error = useChatStore((s) => s.error);
+  const runError = useChatStore((s) => s.runError);
   const streamingMessage = useChatStore((s) => s.streamingMessage);
   const streamingTools = useChatStore((s) => s.streamingTools);
   const pendingFinal = useChatStore((s) => s.pendingFinal);
@@ -284,8 +285,11 @@ export function Chat() {
     // runStillExecutingTools bridges the brief gap between tool rounds when
     // Gateway temporarily clears sending.  However, after an explicit abort
     // (which clears activeRunId), we must NOT keep the run "open" — so we
-    // gate it on activeRunId being present.
-    const isLatestOpenRun = nextUserIndex === -1
+    // gate it on activeRunId being present. We also bail out as soon as a
+    // terminal model error has been surfaced so the run doesn't appear active.
+    const isLatestRunSegment = nextUserIndex === -1;
+    const isLatestOpenRun = isLatestRunSegment
+      && !runError
       && (sending || pendingFinal || hasAnyStreamContent || (runStillExecutingTools && !!activeRunId));
     const replyIndexOffset = findReplyMessageIndex(segmentMessages, isLatestOpenRun);
     const replyIndex = replyIndexOffset === -1 ? null : idx + 1 + replyIndexOffset;
@@ -479,7 +483,7 @@ export function Chat() {
       streamingReplyText,
       suppressThinking,
     }];
-  });
+  }, [messages, subagentCompletionInfos, currentSessionKey, streamingMessage, streamingTools, pendingFinal, sending, hasAnyStreamContent, hasStreamText, hasStreamImages, streamText, streamTools.length, hasRunningStreamToolStatus, childTranscripts, currentAgentId, agents, sessionLabels, graphStepCache, runError]);
   const hasActiveExecutionGraph = userRunCards.some((card) => card.active);
   const replyTextOverrides = useMemo(() => {
     const map = new Map<number, string>();
@@ -696,6 +700,21 @@ export function Chat() {
 
         </div>
       </div>
+
+      {/* Run error callout */}
+      {runError && (
+        <div className="px-4 pt-2">
+          <div className="max-w-4xl mx-auto rounded-xl border border-destructive/20 bg-destructive/10 px-4 py-3">
+            <p className="text-sm font-medium text-destructive flex items-center gap-2">
+              <AlertCircle className="h-4 w-4" />
+              {t('runError.title')}
+            </p>
+            <p className="mt-1 text-sm text-destructive/90 break-words">
+              {runError}
+            </p>
+          </div>
+        </div>
+      )}
 
       {/* Error bar */}
       {error && (

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -338,6 +338,30 @@ function getMessageText(content: unknown): string {
   return '';
 }
 
+function getMessageStopReason(message: RawMessage | unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as Record<string, unknown>;
+  const rawStopReason = msg.stopReason ?? msg.stop_reason;
+  if (typeof rawStopReason !== 'string') return null;
+  const normalized = rawStopReason.trim().toLowerCase();
+  return normalized || null;
+}
+
+function getMessageErrorMessage(message: RawMessage | unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as Record<string, unknown>;
+  const rawError = msg.errorMessage ?? msg.error_message;
+  if (typeof rawError !== 'string') return null;
+  const normalized = rawError.trim();
+  return normalized || null;
+}
+
+function isTerminalAssistantErrorMessage(message: RawMessage | unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const msg = message as Record<string, unknown>;
+  return msg.role === 'assistant' && getMessageStopReason(message) === 'error';
+}
+
 /** Extract media file refs from [media attached: <path> (<mime>) | ...] patterns */
 function extractMediaRefs(text: string): Array<{ filePath: string; mimeType: string }> {
   const refs: Array<{ filePath: string; mimeType: string }> = [];
@@ -1210,6 +1234,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
   messages: [],
   loading: false,
   error: null,
+  runError: null,
 
   sending: false,
   activeRunId: null,
@@ -1435,6 +1460,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         streamingTools: [],
         activeRunId: null,
         error: null,
+        runError: null,
         pendingFinal: false,
         lastUserMessageAt: null,
         pendingToolImages: [],
@@ -1490,6 +1516,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       streamingTools: [],
       activeRunId: null,
       error: null,
+      runError: null,
       pendingFinal: false,
       lastUserMessageAt: null,
       pendingToolImages: [],
@@ -1545,7 +1572,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       return;
     }
 
-    if (!quiet) set({ loading: true, error: null });
+      if (!quiet) set({ loading: true, error: null, runError: null });
 
     // Safety guard: if history loading takes too long, force loading to false
     // to prevent the UI from being stuck in a spinner forever.
@@ -1621,7 +1648,27 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
       }
 
-      set({ messages: finalMessages, thinkingLevel, loading: false });
+      const { pendingFinal, lastUserMessageAt, sending: isSendingNow } = get();
+      const userMsTs = lastUserMessageAt ? toMs(lastUserMessageAt) : 0;
+      const isAfterUserMsg = (msg: RawMessage): boolean => {
+        if (!userMsTs || !msg.timestamp) return true;
+        return toMs(msg.timestamp) >= userMsTs;
+      };
+      const latestTerminalAssistantError = [...filteredMessages].reverse().find((msg) => (
+        msg.role === 'assistant'
+        && getMessageStopReason(msg) === 'error'
+        && isAfterUserMsg(msg)
+      ));
+      const latestTerminalAssistantErrorMessage = latestTerminalAssistantError
+        ? getMessageErrorMessage(latestTerminalAssistantError)
+        : null;
+
+      set({
+        messages: finalMessages,
+        thinkingLevel,
+        loading: false,
+        runError: latestTerminalAssistantErrorMessage,
+      });
 
       // Extract first user message text as a session label for display in the toolbar.
       // Skip main sessions (key ends with ":main") — they rely on the Gateway-provided
@@ -1658,16 +1705,17 @@ export const useChatStore = create<ChatState>((set, get) => ({
           }));
         }
       });
-      const { pendingFinal, lastUserMessageAt, sending: isSendingNow } = get();
 
-      // If we're sending but haven't received streaming events, check
-      // whether the loaded history reveals intermediate tool-call activity.
-      // This surfaces progress via the pendingFinal → ActivityIndicator path.
-      const userMsTs = lastUserMessageAt ? toMs(lastUserMessageAt) : 0;
-      const isAfterUserMsg = (msg: RawMessage): boolean => {
-        if (!userMsTs || !msg.timestamp) return true;
-        return toMs(msg.timestamp) >= userMsTs;
-      };
+      if (latestTerminalAssistantErrorMessage) {
+        clearHistoryPoll();
+        set({
+          sending: false,
+          activeRunId: null,
+          pendingFinal: false,
+          lastUserMessageAt: null,
+        });
+        return true;
+      }
 
       if (isSendingNow && !pendingFinal) {
         const hasRecentAssistantActivity = [...filteredMessages].reverse().some((msg) => {
@@ -1841,6 +1889,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       messages: [...s.messages, userMsg],
       sending: true,
       error: null,
+      runError: null,
       streamingText: '',
       streamingMessage: null,
       streamingTools: [],
@@ -2031,9 +2080,11 @@ export const useChatStore = create<ChatState>((set, get) => ({
     let resolvedState = eventState;
     if (!resolvedState && event.message && typeof event.message === 'object') {
       const msg = event.message as Record<string, unknown>;
-      const stopReason = msg.stopReason ?? msg.stop_reason;
-      if (stopReason) {
-        resolvedState = 'final';
+        const stopReason = getMessageStopReason(msg);
+        if (stopReason === 'error') {
+          resolvedState = 'error';
+        } else if (stopReason) {
+          resolvedState = 'final';
       } else if (msg.role || msg.content) {
         resolvedState = 'delta';
       }
@@ -2051,7 +2102,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
       // show loading/streaming in the app when this session has an active run.
       const { sending } = get();
       if (!sending && runId) {
-        set({ sending: true, activeRunId: runId, error: null });
+          set({ sending: true, activeRunId: runId, error: null, runError: null });
       }
     }
 
@@ -2060,7 +2111,7 @@ export const useChatStore = create<ChatState>((set, get) => ({
         // Run just started (e.g. from console); show loading immediately.
         const { sending: currentSending } = get();
         if (!currentSending && runId) {
-          set({ sending: true, activeRunId: runId, error: null });
+          set({ sending: true, activeRunId: runId, error: null, runError: null });
         }
         break;
       }
@@ -2069,8 +2120,8 @@ export const useChatStore = create<ChatState>((set, get) => ({
         if (_errorRecoveryTimer) {
           clearErrorRecoveryTimer();
         }
-        if (get().error) {
-          set({ error: null });
+        if (get().error || get().runError) {
+          set({ error: null, runError: null });
         }
         const updates = collectToolUpdates(event.message, resolvedState);
         set((s) => ({
@@ -2087,11 +2138,20 @@ export const useChatStore = create<ChatState>((set, get) => ({
       }
       case 'final': {
         clearErrorRecoveryTimer();
-        if (get().error) set({ error: null });
+        if (get().error || get().runError) set({ error: null, runError: null });
         // Message complete - add to history and clear streaming
         const finalMsg = event.message as RawMessage | undefined;
         if (finalMsg) {
           const normalizedFinalMessage = normalizeStreamingMessage(finalMsg) as RawMessage;
+          if (isTerminalAssistantErrorMessage(normalizedFinalMessage)) {
+            get().handleChatEvent({
+              ...event,
+              state: 'error',
+              errorMessage: getMessageErrorMessage(normalizedFinalMessage) ?? event.errorMessage,
+              message: normalizedFinalMessage,
+            });
+            break;
+          }
           const updates = collectToolUpdates(normalizedFinalMessage, resolvedState);
           // Filter out internal-only final responses (NO_REPLY, HEARTBEAT_OK, etc.)
           // before adding to messages. Without this guard, the internal token appears
@@ -2232,7 +2292,12 @@ export const useChatStore = create<ChatState>((set, get) => ({
         break;
       }
       case 'error': {
-        const errorMsg = String(event.errorMessage || 'An error occurred');
+        const errorMsg = String(
+          event.errorMessage
+          || getMessageErrorMessage(event.message)
+          || 'An error occurred',
+        );
+        const terminalAssistantError = isTerminalAssistantErrorMessage(event.message);
         const wasSending = get().sending;
 
         // Snapshot the current streaming message into messages[] so partial
@@ -2251,40 +2316,22 @@ export const useChatStore = create<ChatState>((set, get) => ({
         }
 
         set({
-          error: errorMsg,
+          error: terminalAssistantError ? null : errorMsg,
+          runError: terminalAssistantError ? errorMsg : null,
+          sending: false,
+          activeRunId: null,
           streamingText: '',
           streamingMessage: null,
           streamingTools: [],
           pendingFinal: false,
+          lastUserMessageAt: null,
           pendingToolImages: [],
         });
 
-        // Don't immediately give up: the Gateway often retries internally
-        // after transient API failures (e.g. "terminated"). Keep `sending`
-        // true for a grace period so that recovery events are processed and
-        // the agent-phase-completion handler can still trigger loadHistory.
+        clearHistoryPoll();
+        clearErrorRecoveryTimer();
         if (wasSending) {
-          clearErrorRecoveryTimer();
-          const ERROR_RECOVERY_GRACE_MS = 15_000;
-          _errorRecoveryTimer = setTimeout(() => {
-            _errorRecoveryTimer = null;
-            const state = get();
-            if (state.sending && !state.streamingMessage) {
-              clearHistoryPoll();
-              // Grace period expired with no recovery — finalize the error
-              set({
-                sending: false,
-                activeRunId: null,
-                lastUserMessageAt: null,
-              });
-              // One final history reload in case the Gateway completed in the
-              // background and we just missed the event.
-              state.loadHistory(true);
-            }
-          }, ERROR_RECOVERY_GRACE_MS);
-        } else {
-          clearHistoryPoll();
-          set({ sending: false, activeRunId: null, lastUserMessageAt: null });
+          void get().loadHistory(true);
         }
         break;
       }
@@ -2328,5 +2375,5 @@ export const useChatStore = create<ChatState>((set, get) => ({
     await Promise.all([loadHistory(), loadSessions()]);
   },
 
-  clearError: () => set({ error: null }),
+  clearError: () => set({ error: null, runError: null }),
 }));

--- a/src/stores/chat/helpers.ts
+++ b/src/stores/chat/helpers.ts
@@ -249,6 +249,30 @@ function getMessageText(content: unknown): string {
   return '';
 }
 
+function getMessageStopReason(message: RawMessage | unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as Record<string, unknown>;
+  const rawStopReason = msg.stopReason ?? msg.stop_reason;
+  if (typeof rawStopReason !== 'string') return null;
+  const normalized = rawStopReason.trim().toLowerCase();
+  return normalized || null;
+}
+
+function getMessageErrorMessage(message: RawMessage | unknown): string | null {
+  if (!message || typeof message !== 'object') return null;
+  const msg = message as Record<string, unknown>;
+  const rawError = msg.errorMessage ?? msg.error_message;
+  if (typeof rawError !== 'string') return null;
+  const normalized = rawError.trim();
+  return normalized || null;
+}
+
+function isTerminalAssistantErrorMessage(message: RawMessage | unknown): boolean {
+  if (!message || typeof message !== 'object') return false;
+  const msg = message as Record<string, unknown>;
+  return msg.role === 'assistant' && getMessageStopReason(message) === 'error';
+}
+
 /** Extract media file refs from [media attached: <path> (<mime>) | ...] patterns */
 function extractMediaRefs(text: string): Array<{ filePath: string; mimeType: string }> {
   const refs: Array<{ filePath: string; mimeType: string }> = [];
@@ -1053,6 +1077,9 @@ export {
   clearHistoryPoll,
   extractImagesAsAttachedFiles,
   getMessageText,
+  getMessageStopReason,
+  getMessageErrorMessage,
+  isTerminalAssistantErrorMessage,
   extractMediaRefs,
   extractRawFilePaths,
   makeAttachedFile,

--- a/src/stores/chat/history-actions.ts
+++ b/src/stores/chat/history-actions.ts
@@ -2,9 +2,12 @@ import { invokeIpc } from '@/lib/api-client';
 import { hostApiFetch } from '@/lib/host-api';
 import { useGatewayStore } from '@/stores/gateway';
 import {
+  clearHistoryPoll,
   enrichWithCachedImages,
   enrichWithToolResultFiles,
   getLatestOptimisticUserMessage,
+  getMessageErrorMessage,
+  getMessageStopReason,
   getMessageText,
   isInternalMessage,
   isToolResultRole,
@@ -110,7 +113,27 @@ export function createHistoryActions(
           }
         }
 
-        set({ messages: finalMessages, thinkingLevel, loading: false });
+        const { pendingFinal, lastUserMessageAt, sending: isSendingNow } = get();
+        const userMsTs = lastUserMessageAt ? toMs(lastUserMessageAt) : 0;
+        const isAfterUserMsg = (msg: RawMessage): boolean => {
+          if (!userMsTs || !msg.timestamp) return true;
+          return toMs(msg.timestamp) >= userMsTs;
+        };
+        const latestTerminalAssistantError = [...filteredMessages].reverse().find((msg) => (
+          msg.role === 'assistant'
+          && getMessageStopReason(msg) === 'error'
+          && isAfterUserMsg(msg)
+        ));
+        const latestTerminalAssistantErrorMessage = latestTerminalAssistantError
+          ? getMessageErrorMessage(latestTerminalAssistantError)
+          : null;
+
+        set({
+          messages: finalMessages,
+          thinkingLevel,
+          loading: false,
+          runError: latestTerminalAssistantErrorMessage,
+        });
 
         // Extract first user message text as a session label for display in the toolbar.
         // Skip main sessions (key ends with ":main") — they rely on the Gateway-provided
@@ -147,17 +170,6 @@ export function createHistoryActions(
             }));
           }
         });
-        const { pendingFinal, lastUserMessageAt, sending: isSendingNow } = get();
-
-        // If we're sending but haven't received streaming events, check
-        // whether the loaded history reveals intermediate tool-call activity.
-        // This surfaces progress via the pendingFinal → ActivityIndicator path.
-        const userMsTs = lastUserMessageAt ? toMs(lastUserMessageAt) : 0;
-        const isAfterUserMsg = (msg: RawMessage): boolean => {
-          if (!userMsTs || !msg.timestamp) return true;
-          return toMs(msg.timestamp) >= userMsTs;
-        };
-
         // If we're sending but haven't received streaming events, check
         // whether the loaded history reveals assistant activity (tool calls,
         // narration, etc.).  Setting pendingFinal surfaces the execution
@@ -170,6 +182,17 @@ export function createHistoryActions(
         // Attempting to infer completion from message history is fragile
         // and leads to premature sending=false during server-side tool
         // execution.
+        if (latestTerminalAssistantErrorMessage) {
+          clearHistoryPoll();
+          set({
+            sending: false,
+            activeRunId: null,
+            pendingFinal: false,
+            lastUserMessageAt: null,
+          });
+          return true;
+        }
+
         if (isSendingNow && !pendingFinal) {
           const hasRecentAssistantActivity = [...filteredMessages].reverse().some((msg) => {
             if (msg.role !== 'assistant') return false;

--- a/src/stores/chat/internal.ts
+++ b/src/stores/chat/internal.ts
@@ -8,6 +8,7 @@ export const initialChatState: Pick<
   | 'messages'
   | 'loading'
   | 'error'
+  | 'runError'
   | 'sending'
   | 'activeRunId'
   | 'streamingText'
@@ -26,6 +27,7 @@ export const initialChatState: Pick<
   messages: [],
   loading: false,
   error: null,
+  runError: null,
 
   sending: false,
   activeRunId: null,

--- a/src/stores/chat/runtime-event-actions.ts
+++ b/src/stores/chat/runtime-event-actions.ts
@@ -1,4 +1,11 @@
-import { clearHistoryPoll, getLastAbortedRunId, queueBlockedRunEvent, setLastAbortedRunId, setLastChatEventAt } from './helpers';
+import {
+  clearHistoryPoll,
+  getLastAbortedRunId,
+  getMessageStopReason,
+  queueBlockedRunEvent,
+  setLastAbortedRunId,
+  setLastChatEventAt,
+} from './helpers';
 import type { ChatGet, ChatSet, RuntimeActions } from './store-api';
 import { handleRuntimeEventState } from './runtime-event-handlers';
 
@@ -44,9 +51,9 @@ export function createRuntimeEventActions(set: ChatSet, get: ChatGet): Pick<Runt
       let resolvedState = eventState;
       if (!resolvedState && event.message && typeof event.message === 'object') {
         const msg = event.message as Record<string, unknown>;
-        const stopReason = msg.stopReason ?? msg.stop_reason;
+        const stopReason = getMessageStopReason(msg);
         if (stopReason) {
-          resolvedState = 'final';
+          resolvedState = stopReason === 'error' ? 'error' : 'final';
         } else if (msg.role || msg.content) {
           resolvedState = 'delta';
         }
@@ -64,7 +71,7 @@ export function createRuntimeEventActions(set: ChatSet, get: ChatGet): Pick<Runt
         // show loading/streaming in the app when this session has an active run.
         const { sending } = get();
         if (!sending && runId) {
-          set({ sending: true, activeRunId: runId, error: null });
+          set({ sending: true, activeRunId: runId, error: null, runError: null });
         }
       }
 

--- a/src/stores/chat/runtime-event-handlers.ts
+++ b/src/stores/chat/runtime-event-handlers.ts
@@ -4,17 +4,17 @@ import {
   collectToolUpdates,
   extractImagesAsAttachedFiles,
   extractMediaRefs,
+  getMessageErrorMessage,
   extractRawFilePaths,
   getMessageText,
   getToolCallFilePath,
-  hasErrorRecoveryTimer,
   hasNonToolAssistantContent,
   isInternalMessage,
+  isTerminalAssistantErrorMessage,
   isToolOnlyMessage,
   isToolResultRole,
   makeAttachedFile,
   normalizeStreamingMessage,
-  setErrorRecoveryTimer,
   snapshotStreamingAssistantMessage,
   upsertToolStatuses,
 } from './helpers';
@@ -41,10 +41,8 @@ export function handleRuntimeEventState(
           // If we're receiving new deltas, the Gateway has recovered from any
           // prior error — cancel the error finalization timer and clear the
           // stale error banner so the user sees the live stream again.
-          if (hasErrorRecoveryTimer()) {
-            clearErrorRecoveryTimer();
-            set({ error: null });
-          }
+          clearErrorRecoveryTimer();
+          if (get().error || get().runError) set({ error: null, runError: null });
           const updates = collectToolUpdates(event.message, resolvedState);
           set((s) => ({
             streamingMessage: (() => {
@@ -76,11 +74,25 @@ export function handleRuntimeEventState(
         }
         case 'final': {
           clearErrorRecoveryTimer();
-          if (get().error) set({ error: null });
+          if (get().error || get().runError) set({ error: null, runError: null });
           // Message complete - add to history and clear streaming
           const finalMsg = event.message as RawMessage | undefined;
           if (finalMsg) {
             const normalizedFinalMessage = normalizeStreamingMessage(finalMsg) as RawMessage;
+            if (isTerminalAssistantErrorMessage(normalizedFinalMessage)) {
+              handleRuntimeEventState(
+                set,
+                get,
+                {
+                  ...event,
+                  errorMessage: getMessageErrorMessage(normalizedFinalMessage) ?? event.errorMessage,
+                  message: normalizedFinalMessage,
+                },
+                'error',
+                runId,
+              );
+              break;
+            }
             const updates = collectToolUpdates(normalizedFinalMessage, resolvedState);
             // Filter out internal-only final responses (NO_REPLY, HEARTBEAT_OK, etc.)
             // before adding to messages. Without this guard, the internal token appears
@@ -218,7 +230,12 @@ export function handleRuntimeEventState(
           break;
         }
         case 'error': {
-          const errorMsg = String(event.errorMessage || 'An error occurred');
+          const errorMsg = String(
+            event.errorMessage
+            || getMessageErrorMessage(event.message)
+            || 'An error occurred',
+          );
+          const terminalAssistantError = isTerminalAssistantErrorMessage(event.message);
           const wasSending = get().sending;
 
           // Snapshot the current streaming message into messages[] so partial
@@ -237,40 +254,21 @@ export function handleRuntimeEventState(
           }
 
           set({
-            error: errorMsg,
+            error: terminalAssistantError ? null : errorMsg,
+            runError: terminalAssistantError ? errorMsg : null,
+            sending: false,
+            activeRunId: null,
             streamingText: '',
             streamingMessage: null,
             streamingTools: [],
             pendingFinal: false,
+            lastUserMessageAt: null,
             pendingToolImages: [],
           });
-
-          // Don't immediately give up: the Gateway often retries internally
-          // after transient API failures (e.g. "terminated"). Keep `sending`
-          // true for a grace period so that recovery events are processed and
-          // the agent-phase-completion handler can still trigger loadHistory.
+          clearHistoryPoll();
+          clearErrorRecoveryTimer();
           if (wasSending) {
-            clearErrorRecoveryTimer();
-            const ERROR_RECOVERY_GRACE_MS = 15_000;
-            setErrorRecoveryTimer(setTimeout(() => {
-              setErrorRecoveryTimer(null);
-              const state = get();
-              if (state.sending && !state.streamingMessage) {
-                clearHistoryPoll();
-                // Grace period expired with no recovery — finalize the error
-                set({
-                  sending: false,
-                  activeRunId: null,
-                  lastUserMessageAt: null,
-                });
-                // One final history reload in case the Gateway completed in the
-                // background and we just missed the event.
-                state.loadHistory(true);
-              }
-            }, ERROR_RECOVERY_GRACE_MS));
-          } else {
-            clearHistoryPoll();
-            set({ sending: false, activeRunId: null, lastUserMessageAt: null });
+            void get().loadHistory(true);
           }
           break;
         }

--- a/src/stores/chat/runtime-ui-actions.ts
+++ b/src/stores/chat/runtime-ui-actions.ts
@@ -9,6 +9,6 @@ export function createRuntimeUiActions(set: ChatSet, get: ChatGet): Pick<Runtime
       await Promise.all([loadHistory(), loadSessions()]);
     },
 
-    clearError: () => set({ error: null }),
+    clearError: () => set({ error: null, runError: null }),
   };
 }

--- a/src/stores/chat/types.ts
+++ b/src/stores/chat/types.ts
@@ -18,6 +18,10 @@ export interface RawMessage {
   toolName?: string;
   details?: unknown;
   isError?: boolean;
+  stopReason?: string;
+  stop_reason?: string;
+  errorMessage?: string;
+  error_message?: string;
   /** Local-only: file metadata for user-uploaded attachments (not sent to/from Gateway) */
   _attachedFiles?: AttachedFileMeta[];
 }
@@ -63,6 +67,7 @@ export interface ChatState {
   messages: RawMessage[];
   loading: boolean;
   error: string | null;
+  runError: string | null;
 
   // Streaming
   sending: boolean;

--- a/tests/e2e/chat-task-visualizer.spec.ts
+++ b/tests/e2e/chat-task-visualizer.spec.ts
@@ -172,6 +172,23 @@ const longRunHistory = [
   },
 ];
 
+const errorRunPrompt = '你是什么模型？';
+const errorRunHistory = [
+  {
+    role: 'user',
+    content: [{ type: 'text', text: errorRunPrompt }],
+    timestamp: Date.now(),
+  },
+  {
+    role: 'assistant',
+    id: 'error-final',
+    content: [],
+    stopReason: 'error',
+    errorMessage: '404 Resource not found',
+    timestamp: Date.now(),
+  },
+];
+
 test.describe('ClawX chat execution graph', () => {
   test('renders internal yield status and linked subagent branch from mocked IPC', async ({ launchElectronApp }) => {
     const app = await launchElectronApp({ skipSetup: true });
@@ -334,6 +351,77 @@ test.describe('ClawX chat execution graph', () => {
       await expect(page.getByTestId('chat-execution-graph')).toContainText('9 process messages');
       await expect(page.getByText(longRunSummary, { exact: true })).toBeVisible();
       await expect(page.getByText(longRunReplyText, { exact: true })).toHaveCount(0);
+    } finally {
+      await closeElectronApp(app);
+    }
+  });
+
+  test('surfaces terminal model errors and stops the stale thinking state', async ({ launchElectronApp }) => {
+    const app = await launchElectronApp({ skipSetup: true });
+
+    try {
+      await installIpcMocks(app, {
+        gatewayStatus: { state: 'running', port: 18789, pid: 12345 },
+        gatewayRpc: {
+          [stableStringify(['sessions.list', {}])]: {
+            success: true,
+            result: {
+              sessions: [{ key: PROJECT_MANAGER_SESSION_KEY, displayName: 'main' }],
+            },
+          },
+          [stableStringify(['chat.history', { sessionKey: PROJECT_MANAGER_SESSION_KEY, limit: 200 }])]: {
+            success: true,
+            result: {
+              messages: errorRunHistory,
+            },
+          },
+          [stableStringify(['chat.history', { sessionKey: PROJECT_MANAGER_SESSION_KEY, limit: 1000 }])]: {
+            success: true,
+            result: {
+              messages: errorRunHistory,
+            },
+          },
+        },
+        hostApi: {
+          [stableStringify(['/api/gateway/status', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { state: 'running', port: 18789, pid: 12345 },
+            },
+          },
+          [stableStringify(['/api/agents', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: {
+                success: true,
+                agents: [{ id: 'main', name: 'main' }],
+              },
+            },
+          },
+        },
+      });
+
+      const page = await getStableWindow(app);
+      try {
+        await page.reload();
+      } catch (error) {
+        if (!String(error).includes('ERR_FILE_NOT_FOUND')) {
+          throw error;
+        }
+      }
+
+      await expect(page.getByTestId('main-layout')).toBeVisible();
+      await expect(page.getByText('404 Resource not found')).toBeVisible({ timeout: 30_000 });
+      await expect(page.getByText('runError.title')).toBeVisible();
+      await expect(page.getByTestId('chat-execution-graph')).toHaveCount(0);
+      await expect(page.getByTestId('chat-execution-step-thinking-trailing')).toHaveCount(0);
+      await expect(page.getByText('404 Resource not found')).toHaveCount(1);
+      await page.getByTestId('chat-composer-input').fill('retry');
+      await expect(page.getByTestId('chat-composer-send')).toBeEnabled();
     } finally {
       await closeElectronApp(app);
     }

--- a/tests/e2e/fixtures/electron.ts
+++ b/tests/e2e/fixtures/electron.ts
@@ -121,7 +121,10 @@ async function launchClawXElectron(
 ): Promise<ElectronApplication> {
   const hostApiPort = await allocatePort();
   const electronEnv = process.platform === 'linux'
-    ? { ELECTRON_DISABLE_SANDBOX: '1' }
+    ? {
+      ELECTRON_DISABLE_SANDBOX: '1',
+      DISPLAY: process.env.DISPLAY || ':1',
+    }
     : {};
   return await electron.launch({
     executablePath: electronBinaryPath,

--- a/tests/unit/chat-history-actions.test.ts
+++ b/tests/unit/chat-history-actions.test.ts
@@ -6,6 +6,14 @@ const gatewayStoreGetStateMock = vi.fn();
 const clearHistoryPoll = vi.fn();
 const enrichWithCachedImages = vi.fn((messages) => messages);
 const enrichWithToolResultFiles = vi.fn((messages) => messages);
+const getMessageErrorMessage = vi.fn((message: { errorMessage?: string; error_message?: string } | undefined) => {
+  if (!message) return null;
+  return message.errorMessage ?? message.error_message ?? null;
+});
+const getMessageStopReason = vi.fn((message: { stopReason?: string; stop_reason?: string } | undefined) => {
+  if (!message) return null;
+  return message.stopReason ?? message.stop_reason ?? null;
+});
 const getMessageText = vi.fn((content: unknown) => typeof content === 'string' ? content : '');
 const hasNonToolAssistantContent = vi.fn((message: { content?: unknown } | undefined) => {
   if (!message) return false;
@@ -75,6 +83,8 @@ vi.mock('@/stores/chat/helpers', () => ({
     if (candidateAttachments && optimisticAttachments && candidateAttachments === optimisticAttachments && (!hasCandidateTimestamp || timestampMatches)) return true;
     return false;
   },
+  getMessageErrorMessage: (...args: unknown[]) => getMessageErrorMessage(...args),
+  getMessageStopReason: (...args: unknown[]) => getMessageStopReason(...args),
   toMs: (...args: unknown[]) => toMs(...args as Parameters<typeof toMs>),
 }));
 
@@ -83,6 +93,7 @@ type ChatLikeState = {
   messages: Array<{ role: string; timestamp?: number; content?: unknown; _attachedFiles?: unknown[] }>;
   loading: boolean;
   error: string | null;
+  runError: string | null;
   sending: boolean;
   lastUserMessageAt: number | null;
   pendingFinal: boolean;
@@ -98,6 +109,7 @@ function makeHarness(initial?: Partial<ChatLikeState>) {
     messages: [],
     loading: false,
     error: null,
+    runError: null,
     sending: false,
     lastUserMessageAt: null,
     pendingFinal: false,
@@ -199,6 +211,70 @@ describe('chat history actions', () => {
     expect(h.read().messages.map((message) => message.content)).toEqual(['still here']);
     expect(h.read().error).toBe('Gateway unavailable');
     expect(h.read().loading).toBe(false);
+  });
+
+  it('finalizes sending and surfaces the latest terminal assistant error from history', async () => {
+    const { createHistoryActions } = await import('@/stores/chat/history-actions');
+    const h = makeHarness({
+      currentSessionKey: 'agent:main:main',
+      sending: true,
+      activeRunId: 'run-error',
+      pendingFinal: true,
+      lastUserMessageAt: 1773281731000,
+    });
+    const actions = createHistoryActions(h.set as never, h.get as never);
+
+    invokeIpcMock.mockResolvedValueOnce({
+      success: true,
+      result: {
+        messages: [
+          { role: 'user', content: 'What model are you?', timestamp: 1773281731 },
+          {
+            role: 'assistant',
+            content: [],
+            timestamp: 1773281732,
+            stopReason: 'error',
+            errorMessage: '404 Resource not found',
+          },
+        ],
+      },
+    });
+
+    await actions.loadHistory(true);
+
+    expect(clearHistoryPoll).toHaveBeenCalledTimes(1);
+    expect(h.read().runError).toBe('404 Resource not found');
+    expect(h.read().sending).toBe(false);
+    expect(h.read().pendingFinal).toBe(false);
+    expect(h.read().activeRunId).toBeNull();
+    expect(h.read().lastUserMessageAt).toBeNull();
+  });
+
+  it('clears stale runError when refreshed history no longer contains a terminal assistant error', async () => {
+    const { createHistoryActions } = await import('@/stores/chat/history-actions');
+    const h = makeHarness({
+      currentSessionKey: 'agent:main:main',
+      runError: 'old model error',
+    });
+    const actions = createHistoryActions(h.set as never, h.get as never);
+
+    invokeIpcMock.mockResolvedValueOnce({
+      success: true,
+      result: {
+        messages: [
+          { role: 'user', content: 'What model are you?', timestamp: 1773281731 },
+          { role: 'assistant', content: 'I am MiniMax-M2.7', timestamp: 1773281732 },
+        ],
+      },
+    });
+
+    await actions.loadHistory(true);
+
+    expect(h.read().runError).toBeNull();
+    expect(h.read().messages.map((message) => message.content)).toEqual([
+      'What model are you?',
+      'I am MiniMax-M2.7',
+    ]);
   });
 
   it('retries the first foreground startup history load after a timeout and then succeeds', async () => {

--- a/tests/unit/chat-page-execution-graph.test.tsx
+++ b/tests/unit/chat-page-execution-graph.test.tsx
@@ -70,6 +70,23 @@ vi.mock('@/pages/Chat/ChatInput', () => ({
   ChatInput: () => null,
 }));
 
+vi.mock('@/pages/Chat/ChatMessage', () => ({
+  ChatMessage: ({ message, textOverride }: { message: { content?: unknown }; textOverride?: string }) => {
+    const text = typeof textOverride === 'string'
+      ? textOverride
+      : typeof message?.content === 'string'
+        ? message.content
+        : Array.isArray(message?.content)
+          ? message.content
+            .filter((block): block is { type?: string; text?: string } => typeof block === 'object' && block !== null)
+            .filter((block) => block.type === 'text' && typeof block.text === 'string')
+            .map((block) => block.text)
+            .join(' ')
+          : '';
+    return <div>{text}</div>;
+  },
+}));
+
 describe('Chat execution graph lifecycle', () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -95,6 +112,7 @@ describe('Chat execution graph lifecycle', () => {
       ],
       loading: false,
       error: null,
+      runError: null,
       sending: true,
       activeRunId: 'run-live',
       streamingText: '',
@@ -150,6 +168,7 @@ describe('Chat execution graph lifecycle', () => {
       ],
       loading: false,
       error: null,
+      runError: null,
       sending: true,
       activeRunId: 'run-starting',
       streamingText: '',
@@ -176,5 +195,53 @@ describe('Chat execution graph lifecycle', () => {
 
     expect(screen.getByTestId('chat-execution-step-thinking-trailing')).toBeInTheDocument();
     expect(screen.getAllByText('Thinking').length).toBeGreaterThan(0);
+  });
+
+  it('stops showing trailing thinking and renders run error callout after terminal model error', async () => {
+    const { useChatStore } = await import('@/stores/chat');
+    useChatStore.setState({
+      messages: [
+        {
+          role: 'user',
+          content: 'Check semiconductor chatter',
+        },
+        {
+          role: 'assistant',
+          id: 'tool-turn',
+          content: [
+            { type: 'text', text: 'Checked X.' },
+            { type: 'tool_use', id: 'browser-search', name: 'browser', input: { action: 'search', query: 'semiconductor' } },
+          ],
+        },
+      ],
+      loading: false,
+      error: '404 Resource not found',
+      runError: '404 Resource not found',
+      sending: false,
+      activeRunId: null,
+      streamingText: '',
+      streamingMessage: null,
+      streamingTools: [],
+      pendingFinal: false,
+      lastUserMessageAt: null,
+      pendingToolImages: [],
+      sessions: [{ key: 'agent:main:main' }],
+      currentSessionKey: 'agent:main:main',
+      currentAgentId: 'main',
+      sessionLabels: {},
+      sessionLastActivity: {},
+      thinkingLevel: null,
+    });
+
+    const { Chat } = await import('@/pages/Chat/index');
+
+    render(<Chat />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('chat-execution-graph')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('chat-execution-step-thinking-trailing')).not.toBeInTheDocument();
+    expect(screen.getAllByText('404 Resource not found').length).toBeGreaterThan(0);
   });
 });

--- a/tests/unit/chat-runtime-event-handlers.test.ts
+++ b/tests/unit/chat-runtime-event-handlers.test.ts
@@ -7,10 +7,16 @@ const extractImagesAsAttachedFiles = vi.fn(() => []);
 const extractMediaRefs = vi.fn(() => []);
 const extractRawFilePaths = vi.fn(() => []);
 const getMessageText = vi.fn(() => '');
+const getMessageErrorMessage = vi.fn((message: { errorMessage?: string; error_message?: string } | undefined) =>
+  message?.errorMessage ?? message?.error_message ?? null);
 const getToolCallFilePath = vi.fn(() => undefined);
 const hasErrorRecoveryTimer = vi.fn(() => false);
 const hasNonToolAssistantContent = vi.fn(() => true);
 const isInternalMessage = vi.fn(() => false);
+const isTerminalAssistantErrorMessage = vi.fn((message: { role?: string; stopReason?: string; stop_reason?: string } | undefined) => {
+  const stopReason = message?.stopReason ?? message?.stop_reason;
+  return message?.role === 'assistant' && stopReason === 'error';
+});
 const isToolOnlyMessage = vi.fn(() => false);
 const isToolResultRole = vi.fn((role: unknown) => role === 'toolresult' || role === 'toolResult' || role === 'tool_result');
 const makeAttachedFile = vi.fn((ref: { filePath: string; mimeType: string }, source?: 'user-upload' | 'tool-result' | 'message-ref') => ({
@@ -32,12 +38,14 @@ vi.mock('@/stores/chat/helpers', () => ({
   collectToolUpdates: (...args: unknown[]) => collectToolUpdates(...args),
   extractImagesAsAttachedFiles: (...args: unknown[]) => extractImagesAsAttachedFiles(...args),
   extractMediaRefs: (...args: unknown[]) => extractMediaRefs(...args),
+  getMessageErrorMessage: (...args: unknown[]) => getMessageErrorMessage(...args),
   extractRawFilePaths: (...args: unknown[]) => extractRawFilePaths(...args),
   getMessageText: (...args: unknown[]) => getMessageText(...args),
   getToolCallFilePath: (...args: unknown[]) => getToolCallFilePath(...args),
   hasErrorRecoveryTimer: (...args: unknown[]) => hasErrorRecoveryTimer(...args),
   hasNonToolAssistantContent: (...args: unknown[]) => hasNonToolAssistantContent(...args),
   isInternalMessage: (...args: unknown[]) => isInternalMessage(...args),
+  isTerminalAssistantErrorMessage: (...args: unknown[]) => isTerminalAssistantErrorMessage(...args),
   isToolOnlyMessage: (...args: unknown[]) => isToolOnlyMessage(...args),
   isToolResultRole: (...args: unknown[]) => isToolResultRole(...args),
   makeAttachedFile: (...args: unknown[]) => makeAttachedFile(...args),
@@ -51,6 +59,7 @@ type ChatLikeState = {
   sending: boolean;
   activeRunId: string | null;
   error: string | null;
+  runError: string | null;
   streamingMessage: unknown | null;
   streamingTools: unknown[];
   messages: Array<Record<string, unknown>>;
@@ -66,6 +75,7 @@ function makeHarness(initial?: Partial<ChatLikeState>) {
     sending: false,
     activeRunId: null,
     error: 'stale error',
+    runError: null,
     streamingMessage: null,
     streamingTools: [],
     messages: [],
@@ -122,6 +132,7 @@ describe('chat runtime event handlers', () => {
     const next = h.read();
     expect(clearErrorRecoveryTimer).toHaveBeenCalledTimes(1);
     expect(next.error).toBeNull();
+    expect(next.runError).toBeNull();
     expect(next.streamingMessage).toEqual(event.message);
     expect(next.streamingTools).toEqual([{ name: 'tool-a', status: 'running', updatedAt: 1 }]);
   });
@@ -190,10 +201,34 @@ describe('chat runtime event handlers', () => {
     const next = h.read();
     expect(clearHistoryPoll).toHaveBeenCalledTimes(1);
     expect(next.error).toBe('boom');
+    expect(next.runError).toBeNull();
     expect(next.sending).toBe(false);
     expect(next.activeRunId).toBeNull();
     expect(next.lastUserMessageAt).toBeNull();
     expect(next.streamingTools).toEqual([]);
+  });
+
+  it('treats stopReason=error assistant finals as runtime errors', async () => {
+    const { handleRuntimeEventState } = await import('@/stores/chat/runtime-event-handlers');
+    const h = makeHarness({ sending: true, activeRunId: 'run-err', lastUserMessageAt: 123 });
+
+    handleRuntimeEventState(h.set as never, h.get as never, {
+      message: {
+        role: 'assistant',
+        id: 'assistant-error',
+        content: [],
+        stopReason: 'error',
+        errorMessage: '404 Resource not found',
+      },
+    }, 'final', 'run-err');
+
+    const next = h.read();
+    expect(next.error).toBeNull();
+    expect(next.runError).toBe('404 Resource not found');
+    expect(next.pendingFinal).toBe(false);
+    expect(next.streamingMessage).toBeNull();
+    expect(clearHistoryPoll).toHaveBeenCalledTimes(1);
+    expect(setErrorRecoveryTimer).not.toHaveBeenCalled();
   });
 
   it('delta with empty object does not overwrite existing streamingMessage', async () => {


### PR DESCRIPTION
## Summary

Avoid the chat is always thinking after provider is error.


## Type of Change

- [x] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.
