### PR TITLE
Multi-profile support for provider accounts

### DIFF
--- a/electron/api/routes/providers.ts
+++ b/electron/api/routes/providers.ts
@@ -94,6 +94,75 @@ export async function handleProviderRoutes(
     return true;
   }
 
+  const profileListMatch = url.pathname.match(/^\/api\/provider-accounts\/([^/]+)\/profiles$/);
+  if (profileListMatch && req.method === 'GET') {
+    const accountId = decodeURIComponent(profileListMatch[1]);
+    sendJson(res, 200, await providerService.listProfilesForAccount(accountId));
+    return true;
+  }
+
+  if (profileListMatch && req.method === 'POST') {
+    const accountId = decodeURIComponent(profileListMatch[1]);
+    try {
+      const body = await parseJsonBody<{
+        label: string;
+        apiKey?: string;
+        authMode?: ProviderAccount['authMode'];
+        oauthToken?: { access: string; refresh: string; expires: number; email?: string; projectId?: string };
+      }>(req);
+      const profile = await providerService.addProfileToAccount(
+        accountId,
+        body.label,
+        body.apiKey,
+        body.authMode,
+        body.oauthToken,
+      );
+      sendJson(res, 200, { success: true, profile });
+    } catch (error) {
+      sendJson(res, 500, { success: false, error: String(error) });
+    }
+    return true;
+  }
+
+  const profileOrderMatch = url.pathname.match(/^\/api\/provider-accounts\/([^/]+)\/profiles\/order$/);
+  if (profileOrderMatch && req.method === 'PUT') {
+    const accountId = decodeURIComponent(profileOrderMatch[1]);
+    try {
+      const body = await parseJsonBody<{ orderedProfileIds: string[] }>(req);
+      await providerService.setProfileFallbackOrder(accountId, body.orderedProfileIds ?? []);
+      sendJson(res, 200, { success: true });
+    } catch (error) {
+      sendJson(res, 500, { success: false, error: String(error) });
+    }
+    return true;
+  }
+
+  const setPrimaryMatch = url.pathname.match(/^\/api\/provider-accounts\/([^/]+)\/profiles\/([^/]+)\/primary$/);
+  if (setPrimaryMatch && req.method === 'PUT') {
+    const accountId = decodeURIComponent(setPrimaryMatch[1]);
+    const profileId = decodeURIComponent(setPrimaryMatch[2]);
+    try {
+      await providerService.setPrimaryProfile(accountId, profileId);
+      sendJson(res, 200, { success: true });
+    } catch (error) {
+      sendJson(res, 500, { success: false, error: String(error) });
+    }
+    return true;
+  }
+
+  const removeProfileMatch = url.pathname.match(/^\/api\/provider-accounts\/([^/]+)\/profiles\/([^/]+)$/);
+  if (removeProfileMatch && req.method === 'DELETE') {
+    const accountId = decodeURIComponent(removeProfileMatch[1]);
+    const profileId = decodeURIComponent(removeProfileMatch[2]);
+    try {
+      await providerService.removeProfileFromAccount(accountId, profileId);
+      sendJson(res, 200, { success: true });
+    } catch (error) {
+      sendJson(res, 500, { success: false, error: String(error) });
+    }
+    return true;
+  }
+
   if (url.pathname.startsWith('/api/provider-accounts/') && req.method === 'GET') {
     const accountId = decodeURIComponent(url.pathname.slice('/api/provider-accounts/'.length));
     sendJson(res, 200, await providerService.getAccount(accountId));

--- a/electron/services/providers/provider-service.ts
+++ b/electron/services/providers/provider-service.ts
@@ -4,8 +4,10 @@ import {
 } from '../../shared/providers/registry';
 import type {
   ProviderAccount,
+  ProviderAuthMode,
   ProviderConfig,
   ProviderDefinition,
+  ProviderProfile,
   ProviderType,
 } from '../../shared/providers/types';
 import { BUILTIN_PROVIDER_TYPES } from '../../shared/providers/types';
@@ -32,6 +34,13 @@ import { getActiveOpenClawProviders, getOpenClawProvidersConfig } from '../../ut
 import { getAliasSourceTypes, getOpenClawProviderKeyForType } from '../../utils/provider-keys';
 import type { ProviderWithKeyInfo } from '../../shared/providers/types';
 import { logger } from '../../utils/logger';
+import {
+  listProfilesForProvider,
+  removeProfileById,
+  reorderProviderProfiles,
+  saveOAuthTokenToOpenClaw,
+  saveProviderKeyToOpenClaw,
+} from '../../utils/openclaw-auth';
 
 function maskApiKey(apiKey: string | null): string | null {
   if (!apiKey) return null;
@@ -68,6 +77,19 @@ function inferProviderVendorIdFromOpenClawEntry(
 }
 
 export class ProviderService {
+  private static slugifyProfileLabel(label: string): string {
+    return label.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'profile';
+  }
+
+  private static profileLabelFromId(profileId: string): string {
+    const maybeLabel = profileId.split(':').slice(1).join(':') || 'default';
+    return maybeLabel
+      .split('-')
+      .filter(Boolean)
+      .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+      .join(' ');
+  }
+
   async listVendors(): Promise<ProviderDefinition[]> {
     return PROVIDER_DEFINITIONS;
   }
@@ -394,6 +416,93 @@ export class ProviderService {
 
   getVendorDefinition(vendorId: string): ProviderDefinition | undefined {
     return getProviderDefinition(vendorId);
+  }
+
+  async listProfilesForAccount(accountId: string): Promise<ProviderProfile[]> {
+    const account = await this.getAccount(accountId);
+    if (!account || account.authMode === 'local') {
+      return [];
+    }
+    const profiles = await listProfilesForProvider(account.id);
+    return profiles.map((entry, index) => ({
+      id: entry.id,
+      label: ProviderService.profileLabelFromId(entry.id),
+      authMode: account.authMode,
+      hasCredential: entry.profile.type === 'api_key' ? Boolean(entry.profile.key) : Boolean(entry.profile.access),
+      isDefault: index === 0,
+      order: index,
+    }));
+  }
+
+  async addProfileToAccount(
+    accountId: string,
+    profileLabel: string,
+    apiKey: string | undefined,
+    authMode: ProviderAuthMode = 'api_key',
+    oauthToken?: { access: string; refresh: string; expires: number; email?: string; projectId?: string },
+  ): Promise<ProviderProfile> {
+    const account = await this.getAccount(accountId);
+    if (!account) {
+      throw new Error('Provider account not found');
+    }
+    const effectiveAuthMode = authMode || account.authMode;
+    if (effectiveAuthMode === 'local') {
+      throw new Error('Local providers do not support fallback profiles');
+    }
+    const slug = ProviderService.slugifyProfileLabel(profileLabel);
+    let profileId = `${account.id}:${slug}`;
+    if (effectiveAuthMode === 'api_key') {
+      const trimmedApiKey = apiKey?.trim();
+      if (!trimmedApiKey) {
+        throw new Error('API key is required for api_key profiles');
+      }
+      await saveProviderKeyToOpenClaw(account.id, trimmedApiKey, profileId, true);
+    } else if (effectiveAuthMode === 'oauth_device' || effectiveAuthMode === 'oauth_browser') {
+      if (!oauthToken?.access || !oauthToken.refresh || !oauthToken.expires) {
+        throw new Error('OAuth token is required for oauth profiles');
+      }
+      let appendToOrder = true;
+      if (oauthToken.email) {
+        const existingProfiles = await listProfilesForProvider(account.id);
+        const matchedByEmail = existingProfiles.find(
+          (entry) => entry.profile.type === 'oauth' && entry.profile.email === oauthToken.email,
+        );
+        if (matchedByEmail) {
+          profileId = matchedByEmail.id;
+          appendToOrder = false;
+        }
+      }
+      await saveOAuthTokenToOpenClaw(account.id, oauthToken, profileId, appendToOrder);
+    }
+    const profiles = await this.listProfilesForAccount(accountId);
+    return profiles.find((profile) => profile.id === profileId) ?? {
+      id: profileId,
+      label: ProviderService.profileLabelFromId(profileId),
+      authMode: effectiveAuthMode,
+      hasCredential: true,
+      isDefault: false,
+      order: profiles.length,
+    };
+  }
+
+  async removeProfileFromAccount(accountId: string, profileId: string): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    await removeProfileById(account.id, profileId);
+  }
+
+  async setProfileFallbackOrder(accountId: string, orderedProfileIds: string[]): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    await reorderProviderProfiles(account.id, orderedProfileIds);
+  }
+
+  async setPrimaryProfile(accountId: string, profileId: string): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    const profiles = await listProfilesForProvider(account.id);
+    const reordered = [profileId, ...profiles.map((entry) => entry.id).filter((id) => id !== profileId)];
+    await reorderProviderProfiles(account.id, reordered);
   }
 }
 

--- a/electron/services/providers/provider-service.ts
+++ b/electron/services/providers/provider-service.ts
@@ -4,8 +4,10 @@ import {
 } from '../../shared/providers/registry';
 import type {
   ProviderAccount,
+  ProviderAuthMode,
   ProviderConfig,
   ProviderDefinition,
+  ProviderProfile,
   ProviderType,
 } from '../../shared/providers/types';
 import { BUILTIN_PROVIDER_TYPES } from '../../shared/providers/types';
@@ -32,6 +34,13 @@ import { getActiveOpenClawProviders, getOpenClawProvidersConfig } from '../../ut
 import { getAliasSourceTypes, getOpenClawProviderKeyForType } from '../../utils/provider-keys';
 import type { ProviderWithKeyInfo } from '../../shared/providers/types';
 import { logger } from '../../utils/logger';
+import {
+  listProfilesForProvider,
+  removeProfileById,
+  reorderProviderProfiles,
+  saveOAuthTokenToOpenClaw,
+  saveProviderKeyToOpenClaw,
+} from '../../utils/openclaw-auth';
 
 function maskApiKey(apiKey: string | null): string | null {
   if (!apiKey) return null;
@@ -68,6 +77,31 @@ function inferProviderVendorIdFromOpenClawEntry(
 }
 
 export class ProviderService {
+  private static slugifyProfileLabel(label: string): string {
+    return label.trim().toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '') || 'profile';
+  }
+
+  private static profileLabelFromId(profileId: string): string {
+    const maybeLabel = profileId.split(':').slice(1).join(':') || 'default';
+    return maybeLabel
+      .split('-')
+      .filter(Boolean)
+      .map((chunk) => chunk.charAt(0).toUpperCase() + chunk.slice(1))
+      .join(' ');
+  }
+
+  private static resolveAuthProfileProviderKey(account: ProviderAccount): string {
+    if (account.authMode === 'oauth_browser') {
+      if (account.vendorId === 'google') {
+        return 'google-gemini-cli';
+      }
+      if (account.vendorId === 'openai') {
+        return 'openai-codex';
+      }
+    }
+    return getOpenClawProviderKeyForType(account.vendorId, account.id);
+  }
+
   async listVendors(): Promise<ProviderDefinition[]> {
     return PROVIDER_DEFINITIONS;
   }
@@ -394,6 +428,96 @@ export class ProviderService {
 
   getVendorDefinition(vendorId: string): ProviderDefinition | undefined {
     return getProviderDefinition(vendorId);
+  }
+
+  async listProfilesForAccount(accountId: string): Promise<ProviderProfile[]> {
+    const account = await this.getAccount(accountId);
+    if (!account || account.authMode === 'local') {
+      return [];
+    }
+    const providerKey = ProviderService.resolveAuthProfileProviderKey(account);
+    const profiles = await listProfilesForProvider(providerKey);
+    return profiles.map((entry, index) => ({
+      id: entry.id,
+      label: ProviderService.profileLabelFromId(entry.id),
+      authMode: account.authMode,
+      hasCredential: entry.profile.type === 'api_key' ? Boolean(entry.profile.key) : Boolean(entry.profile.access),
+      isDefault: index === 0,
+      order: index,
+    }));
+  }
+
+  async addProfileToAccount(
+    accountId: string,
+    profileLabel: string,
+    apiKey: string | undefined,
+    authMode: ProviderAuthMode = 'api_key',
+    oauthToken?: { access: string; refresh: string; expires: number; email?: string; projectId?: string },
+  ): Promise<ProviderProfile> {
+    const account = await this.getAccount(accountId);
+    if (!account) {
+      throw new Error('Provider account not found');
+    }
+    const effectiveAuthMode = authMode || account.authMode;
+    if (effectiveAuthMode === 'local') {
+      throw new Error('Local providers do not support fallback profiles');
+    }
+    const providerKey = ProviderService.resolveAuthProfileProviderKey(account);
+    const slug = ProviderService.slugifyProfileLabel(profileLabel);
+    let profileId = `${providerKey}:${slug}`;
+    if (effectiveAuthMode === 'api_key') {
+      const trimmedApiKey = apiKey?.trim();
+      if (!trimmedApiKey) {
+        throw new Error('API key is required for api_key profiles');
+      }
+      await saveProviderKeyToOpenClaw(providerKey, trimmedApiKey, profileId, true);
+    } else if (effectiveAuthMode === 'oauth_device' || effectiveAuthMode === 'oauth_browser') {
+      if (!oauthToken?.access || !oauthToken.refresh || !oauthToken.expires) {
+        throw new Error('OAuth token is required for oauth profiles');
+      }
+      let appendToOrder = true;
+      if (oauthToken.email) {
+        const existingProfiles = await listProfilesForProvider(providerKey);
+        const matchedByEmail = existingProfiles.find(
+          (entry) => entry.profile.type === 'oauth' && entry.profile.email === oauthToken.email,
+        );
+        if (matchedByEmail) {
+          profileId = matchedByEmail.id;
+          appendToOrder = false;
+        }
+      }
+      await saveOAuthTokenToOpenClaw(providerKey, oauthToken, profileId, appendToOrder);
+    }
+    const profiles = await this.listProfilesForAccount(accountId);
+    return profiles.find((profile) => profile.id === profileId) ?? {
+      id: profileId,
+      label: ProviderService.profileLabelFromId(profileId),
+      authMode: effectiveAuthMode,
+      hasCredential: true,
+      isDefault: false,
+      order: profiles.length,
+    };
+  }
+
+  async removeProfileFromAccount(accountId: string, profileId: string): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    await removeProfileById(ProviderService.resolveAuthProfileProviderKey(account), profileId);
+  }
+
+  async setProfileFallbackOrder(accountId: string, orderedProfileIds: string[]): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    await reorderProviderProfiles(ProviderService.resolveAuthProfileProviderKey(account), orderedProfileIds);
+  }
+
+  async setPrimaryProfile(accountId: string, profileId: string): Promise<void> {
+    const account = await this.getAccount(accountId);
+    if (!account) throw new Error('Provider account not found');
+    const providerKey = ProviderService.resolveAuthProfileProviderKey(account);
+    const profiles = await listProfilesForProvider(providerKey);
+    const reordered = [profileId, ...profiles.map((entry) => entry.id).filter((id) => id !== profileId)];
+    await reorderProviderProfiles(providerKey, reordered);
   }
 }
 

--- a/electron/shared/providers/types.ts
+++ b/electron/shared/providers/types.ts
@@ -137,6 +137,16 @@ export interface ProviderAccount {
   updatedAt: string;
 }
 
+export interface ProviderProfile {
+  id: string;
+  label: string;
+  authMode: ProviderAuthMode;
+  hasCredential: boolean;
+  isDefault: boolean;
+  order: number;
+}
+
+
 export type ProviderSecret =
   | {
     type: 'api_key';

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -28,7 +28,7 @@ import {
 } from './provider-keys';
 import { withConfigLock } from './config-mutex';
 
-const AUTH_STORE_VERSION = 1;
+const AUTH_STORE_VERSION = 2;
 const AUTH_PROFILE_FILENAME = 'auth-profiles.json';
 const LEGACY_MINIMAX_OAUTH_PLUGIN_ID = 'minimax-portal-auth';
 const MERGED_MINIMAX_PLUGIN_ID = 'minimax';
@@ -311,13 +311,13 @@ async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
 
 // ── Types ────────────────────────────────────────────────────────
 
-interface AuthProfileEntry {
+export interface AuthProfileEntry {
   type: 'api_key';
   provider: string;
   key: string;
 }
 
-interface OAuthProfileEntry {
+export interface OAuthProfileEntry {
   type: 'oauth';
   provider: string;
   access: string;
@@ -421,7 +421,15 @@ async function readAuthProfiles(agentId = 'main'): Promise<AuthProfilesStore> {
   try {
     const data = await readJsonFile<AuthProfilesStore>(filePath);
     if (data?.version && data.profiles && typeof data.profiles === 'object') {
-      return data;
+      if (data.version >= AUTH_STORE_VERSION) {
+        return data;
+      }
+      return {
+        ...data,
+        version: AUTH_STORE_VERSION,
+        order: data.order ?? {},
+        lastGood: data.lastGood ?? {},
+      };
     }
   } catch (error) {
     console.warn('Failed to read auth-profiles.json, creating fresh store:', error);
@@ -615,6 +623,8 @@ async function writeOpenClawJson(config: Record<string, unknown>): Promise<void>
 export async function saveOAuthTokenToOpenClaw(
   provider: string,
   token: { access: string; refresh: string; expires: number; email?: string; projectId?: string },
+  profileId = `${provider}:default`,
+  appendToOrder = false,
   agentId?: string
 ): Promise<void> {
   const agentIds = agentId ? [agentId] : await discoverAgentIds();
@@ -622,7 +632,6 @@ export async function saveOAuthTokenToOpenClaw(
 
   for (const id of agentIds) {
     const store = await readAuthProfiles(id);
-    const profileId = `${provider}:default`;
 
     store.profiles[profileId] = {
       type: 'oauth',
@@ -635,10 +644,12 @@ export async function saveOAuthTokenToOpenClaw(
     };
 
     if (!store.order) store.order = {};
-    if (!store.order[provider]) store.order[provider] = [];
-    if (!store.order[provider].includes(profileId)) {
-      store.order[provider].push(profileId);
-    }
+    const existingOrder = store.order[provider] ?? [];
+    const dedupedOrder = existingOrder.filter((id) => id !== profileId);
+    const hasExistingProfileOrder = existingOrder.includes(profileId);
+    store.order[provider] = appendToOrder
+      ? [...dedupedOrder, profileId]
+      : (hasExistingProfileOrder ? existingOrder : [profileId, ...dedupedOrder]);
 
     if (!store.lastGood) store.lastGood = {};
     store.lastGood[provider] = profileId;
@@ -680,6 +691,8 @@ export async function getOAuthTokenFromOpenClaw(
 export async function saveProviderKeyToOpenClaw(
   provider: string,
   apiKey: string,
+  profileId = `${provider}:default`,
+  appendToOrder = false,
   agentId?: string
 ): Promise<void> {
   if (isOAuthProviderType(provider) && !apiKey) {
@@ -691,15 +704,16 @@ export async function saveProviderKeyToOpenClaw(
 
   for (const id of agentIds) {
     const store = await readAuthProfiles(id);
-    const profileId = `${provider}:default`;
 
     store.profiles[profileId] = { type: 'api_key', provider, key: apiKey };
 
     if (!store.order) store.order = {};
-    if (!store.order[provider]) store.order[provider] = [];
-    if (!store.order[provider].includes(profileId)) {
-      store.order[provider].push(profileId);
-    }
+    const existingOrder = store.order[provider] ?? [];
+    const dedupedOrder = existingOrder.filter((id) => id !== profileId);
+    const hasExistingProfileOrder = existingOrder.includes(profileId);
+    store.order[provider] = appendToOrder
+      ? [...dedupedOrder, profileId]
+      : (hasExistingProfileOrder ? existingOrder : [profileId, ...dedupedOrder]);
 
     if (!store.lastGood) store.lastGood = {};
     store.lastGood[provider] = profileId;
@@ -707,6 +721,110 @@ export async function saveProviderKeyToOpenClaw(
     await writeAuthProfiles(store, id);
   }
   console.log(`Saved API key for provider "${provider}" to OpenClaw auth-profiles (agents: ${agentIds.join(', ')})`);
+}
+
+export async function addProfileToProvider(
+  provider: string,
+  profileId: string,
+  credential: AuthProfileEntry | OAuthProfileEntry,
+  agentId?: string,
+): Promise<void> {
+  const agentIds = agentId ? [agentId] : await discoverAgentIds();
+  if (agentIds.length === 0) agentIds.push('main');
+
+  for (const id of agentIds) {
+    const store = await readAuthProfiles(id);
+    store.profiles[profileId] = credential;
+    if (!store.order) store.order = {};
+    const existingOrder = store.order[provider] ?? [];
+    store.order[provider] = [...existingOrder.filter((id) => id !== profileId), profileId];
+    if (!store.lastGood) store.lastGood = {};
+    store.lastGood[provider] = store.order[provider][0] ?? profileId;
+    await writeAuthProfiles(store, id);
+  }
+}
+
+export async function listProfilesForProvider(
+  provider: string,
+  agentId?: string,
+): Promise<Array<{ id: string; profile: AuthProfileEntry | OAuthProfileEntry }>> {
+  const store = await readAuthProfiles(agentId ?? 'main');
+  const orderedIds = store.order?.[provider] ?? [];
+  const ordered = orderedIds
+    .map((id) => ({ id, profile: store.profiles[id] }))
+    .filter((entry): entry is { id: string; profile: AuthProfileEntry | OAuthProfileEntry } => Boolean(entry.profile))
+    .filter((entry) => entry.profile.provider === provider);
+  const seen = new Set(ordered.map((entry) => entry.id));
+  const remaining = Object.entries(store.profiles)
+    .filter(([id, entry]) => !seen.has(id) && entry.provider === provider)
+    .map(([id, profile]) => ({ id, profile }));
+  return [...ordered, ...remaining];
+}
+
+export async function reorderProviderProfiles(
+  provider: string,
+  orderedProfileIds: string[],
+  agentId?: string,
+): Promise<void> {
+  const agentIds = agentId ? [agentId] : await discoverAgentIds();
+  if (agentIds.length === 0) agentIds.push('main');
+
+  for (const id of agentIds) {
+    const store = await readAuthProfiles(id);
+    const knownProviderProfileIds = new Set(
+      Object.entries(store.profiles)
+        .filter(([, profile]) => profile.provider === provider)
+        .map(([profileId]) => profileId),
+    );
+    const nextOrder = orderedProfileIds.filter((profileId) => knownProviderProfileIds.has(profileId));
+    for (const profileId of knownProviderProfileIds) {
+      if (!nextOrder.includes(profileId)) {
+        nextOrder.push(profileId);
+      }
+    }
+    if (!store.order) store.order = {};
+    if (nextOrder.length > 0) {
+      store.order[provider] = nextOrder;
+      if (!store.lastGood) store.lastGood = {};
+      store.lastGood[provider] = nextOrder[0];
+    } else {
+      delete store.order[provider];
+      if (store.lastGood) delete store.lastGood[provider];
+    }
+    await writeAuthProfiles(store, id);
+  }
+}
+
+export async function removeProfileById(
+  provider: string,
+  profileId: string,
+  agentId?: string,
+  expectedType?: AuthProfileEntry['type'] | OAuthProfileEntry['type'],
+): Promise<void> {
+  const agentIds = agentId ? [agentId] : await discoverAgentIds();
+  if (agentIds.length === 0) agentIds.push('main');
+
+  for (const id of agentIds) {
+    const store = await readAuthProfiles(id);
+    const profile = store.profiles[profileId];
+    if (profile && profile.provider !== provider) {
+      continue;
+    }
+    if (!removeProfileFromStore(store, profileId, expectedType)) {
+      continue;
+    }
+    const providerOrder = store.order?.[provider] ?? [];
+    if (providerOrder.length > 0) {
+      if (!store.lastGood) store.lastGood = {};
+      if (!store.lastGood[provider] || store.lastGood[provider] === profileId) {
+        store.lastGood[provider] = providerOrder[0];
+      }
+    } else {
+      if (store.order) delete store.order[provider];
+      if (store.lastGood) delete store.lastGood[provider];
+    }
+    await writeAuthProfiles(store, id);
+  }
 }
 
 /**

--- a/src/components/settings/AddProfileDialog.tsx
+++ b/src/components/settings/AddProfileDialog.tsx
@@ -1,0 +1,68 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+
+interface AddProfileDialogProps {
+  providerLabel: string;
+  open: boolean;
+  onClose: () => void;
+  onSubmit: (payload: { label: string; apiKey: string; addAsFallback: boolean }) => Promise<void>;
+}
+
+export function AddProfileDialog({ providerLabel, open, onClose, onSubmit }: AddProfileDialogProps) {
+  const [label, setLabel] = useState('');
+  const [apiKey, setApiKey] = useState('');
+  const [addAsFallback, setAddAsFallback] = useState(true);
+  const [saving, setSaving] = useState(false);
+
+  if (!open) return null;
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 p-4" data-testid="add-profile-dialog">
+      <div className="w-full max-w-md rounded-2xl bg-background p-5 border border-black/10 dark:border-white/10 space-y-4">
+        <h3 className="text-base font-semibold">Add profile for {providerLabel}</h3>
+        <div className="space-y-2">
+          <Label>Profile Name</Label>
+          <Input value={label} onChange={(e) => setLabel(e.target.value)} data-testid="add-profile-label-input" />
+        </div>
+        <div className="space-y-2">
+          <Label>API Key</Label>
+          <Input value={apiKey} onChange={(e) => setApiKey(e.target.value)} data-testid="add-profile-api-key-input" />
+        </div>
+        <div className="space-y-2 text-sm">
+          <Label>Fallback Position</Label>
+          <label className="flex items-center gap-2">
+            <input type="radio" checked={!addAsFallback} onChange={() => setAddAsFallback(false)} />
+            Primary (replace existing)
+          </label>
+          <label className="flex items-center gap-2">
+            <input type="radio" checked={addAsFallback} onChange={() => setAddAsFallback(true)} />
+            Fallback (add to chain end)
+          </label>
+        </div>
+        <div className="flex justify-end gap-2">
+          <Button variant="outline" onClick={onClose}>Cancel</Button>
+          <Button
+            data-testid="add-profile-submit-button"
+            disabled={saving || !label.trim() || !apiKey.trim()}
+            onClick={async () => {
+              setSaving(true);
+              try {
+                await onSubmit({ label: label.trim(), apiKey: apiKey.trim(), addAsFallback });
+                setLabel('');
+                setApiKey('');
+                setAddAsFallback(true);
+                onClose();
+              } finally {
+                setSaving(false);
+              }
+            }}
+          >
+            Add Profile
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/ProviderProfileRow.tsx
+++ b/src/components/settings/ProviderProfileRow.tsx
@@ -1,0 +1,50 @@
+import { ArrowDown, ArrowUp, Circle, Trash2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import type { ProviderProfile } from '@/lib/providers';
+
+interface ProviderProfileRowProps {
+  profile: ProviderProfile;
+  isPrimary: boolean;
+  onMakePrimary: () => void;
+  onDelete: () => void;
+  onMoveUp: () => void;
+  onMoveDown: () => void;
+  canMoveUp: boolean;
+  canMoveDown: boolean;
+}
+
+export function ProviderProfileRow({
+  profile,
+  isPrimary,
+  onMakePrimary,
+  onDelete,
+  onMoveUp,
+  onMoveDown,
+  canMoveUp,
+  canMoveDown,
+}: ProviderProfileRowProps) {
+  return (
+    <div className="flex items-center justify-between rounded-xl border border-black/10 dark:border-white/10 px-3 py-2">
+      <div className="min-w-0">
+        <p className="text-sm font-medium truncate">{profile.label}</p>
+        <p className="text-xs text-muted-foreground truncate">{profile.id}</p>
+      </div>
+      <div className="flex items-center gap-1">
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onMakePrimary} title="Set primary">
+          <Circle className={isPrimary ? 'h-4 w-4 fill-current text-green-600' : 'h-4 w-4'} />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onMoveUp} disabled={!canMoveUp} title="Move up">
+          <ArrowUp className="h-4 w-4" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onMoveDown} disabled={!canMoveDown} title="Move down">
+          <ArrowDown className="h-4 w-4" />
+        </Button>
+        <Button variant="ghost" size="icon" className="h-7 w-7" onClick={onDelete} title="Delete profile">
+          <Trash2 className="h-4 w-4 text-destructive" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export type { ProviderProfileRowProps };

--- a/src/components/settings/ProvidersSettings.tsx
+++ b/src/components/settings/ProvidersSettings.tsx
@@ -53,6 +53,8 @@ import { invokeIpc } from '@/lib/api-client';
 import { useSettingsStore } from '@/stores/settings';
 import { hostApiFetch } from '@/lib/host-api';
 import { subscribeHostEvent } from '@/lib/host-events';
+import { ProviderProfileRow } from '@/components/settings/ProviderProfileRow';
+import { AddProfileDialog } from '@/components/settings/AddProfileDialog';
 
 const inputClasses = 'h-[44px] rounded-xl font-mono text-meta bg-surface-input border-black/10 dark:border-white/10 focus-visible:ring-2 focus-visible:ring-blue-500/50 focus-visible:border-blue-500 shadow-sm transition-all text-foreground placeholder:text-foreground/40';
 const labelClasses = 'text-sm text-foreground/80 font-bold';
@@ -155,6 +157,7 @@ export function ProvidersSettings() {
     statuses,
     accounts,
     vendors,
+    profilesByAccount,
     defaultAccountId,
     loading,
     refreshProviderSnapshot,
@@ -163,6 +166,11 @@ export function ProvidersSettings() {
     updateAccount,
     setDefaultAccount,
     validateAccountApiKey,
+    fetchProfilesForAccount,
+    addProfileToAccount,
+    removeProfileFromAccount,
+    reorderProfiles,
+    setPrimaryProfile,
   } = useProviderStore();
 
   const [showAddDialog, setShowAddDialog] = useState(false);
@@ -301,6 +309,12 @@ export function ProvidersSettings() {
                 setEditingProvider(null);
               }}
               onValidateKey={(key, options) => validateAccountApiKey(item.account.id, key, options)}
+              profiles={profilesByAccount[item.account.id] ?? []}
+              onLoadProfiles={() => fetchProfilesForAccount(item.account.id)}
+              onAddProfile={(label, apiKey, _addAsFallback) => addProfileToAccount(item.account.id, label, apiKey)}
+              onRemoveProfile={(profileId) => removeProfileFromAccount(item.account.id, profileId)}
+              onReorderProfiles={(ids) => reorderProfiles(item.account.id, ids)}
+              onSetPrimaryProfile={(profileId) => setPrimaryProfile(item.account.id, profileId)}
               devModeUnlocked={devModeUnlocked}
             />
           ))}
@@ -336,6 +350,16 @@ interface ProviderCardProps {
     key: string,
     options?: { baseUrl?: string; apiProtocol?: ProviderAccount['apiProtocol'] }
   ) => Promise<{ valid: boolean; error?: string }>;
+  profiles: Array<{
+    id: string;
+    label: string;
+    isDefault: boolean;
+  }>;
+  onLoadProfiles: () => Promise<void>;
+  onAddProfile: (label: string, apiKey: string, addAsFallback: boolean) => Promise<void>;
+  onRemoveProfile: (profileId: string) => Promise<void>;
+  onReorderProfiles: (orderedProfileIds: string[]) => Promise<void>;
+  onSetPrimaryProfile: (profileId: string) => Promise<void>;
   devModeUnlocked: boolean;
 }
 
@@ -352,6 +376,12 @@ function ProviderCard({
   onSetDefault,
   onSaveEdits,
   onValidateKey,
+  profiles,
+  onLoadProfiles,
+  onAddProfile,
+  onRemoveProfile,
+  onReorderProfiles,
+  onSetPrimaryProfile,
   devModeUnlocked,
 }: ProviderCardProps) {
   const { t, i18n } = useTranslation('settings');
@@ -372,6 +402,7 @@ function ProviderCard({
   const [validating, setValidating] = useState(false);
   const [saving, setSaving] = useState(false);
   const [arkMode, setArkMode] = useState<ArkMode>('apikey');
+  const [showAddProfileDialog, setShowAddProfileDialog] = useState(false);
 
   const typeInfo = PROVIDER_TYPE_INFO.find((t) => t.id === account.vendorId);
   const providerDocsUrl = getProviderDocsUrl(typeInfo, i18n.language);
@@ -387,6 +418,12 @@ function ProviderCard({
     : providerDocsUrl;
   const canEditModelConfig = Boolean(typeInfo?.showBaseUrl || showModelIdField);
   const showUserAgentField = shouldShowUserAgentField(account);
+
+  useEffect(() => {
+    if (account.authMode === 'api_key') {
+      void onLoadProfiles();
+    }
+  }, [account.authMode, onLoadProfiles]);
 
   useEffect(() => {
     if (isEditing) {
@@ -606,6 +643,49 @@ function ProviderCard({
           </div>
         )}
       </div>
+
+      {account.authMode !== 'local' && (
+        <div className="mt-4 rounded-xl border border-black/10 dark:border-white/10 p-3 space-y-2" data-testid={`provider-profiles-${account.id}`}>
+          <div className="flex items-center justify-between">
+            <p className="text-sm font-semibold">Profiles (Fallback Order)</p>
+            {account.authMode === 'api_key' ? (
+              <Button size="sm" variant="outline" onClick={() => setShowAddProfileDialog(true)} data-testid={`provider-add-profile-${account.id}`}>
+                <Plus className="h-3 w-3 mr-1" />
+                Add Profile
+              </Button>
+            ) : (
+              <span className="text-xs text-muted-foreground">Add via OAuth sign-in</span>
+            )}
+          </div>
+          {profiles.length === 0 ? (
+            <p className="text-xs text-muted-foreground">No extra profiles configured.</p>
+          ) : (
+            <div className="space-y-2">
+              {profiles.map((profile, index) => (
+                <ProviderProfileRow
+                  key={profile.id}
+                  profile={{ ...profile, authMode: account.authMode, hasCredential: true, order: index }}
+                  isPrimary={index === 0 || profile.isDefault}
+                  canMoveUp={index > 0}
+                  canMoveDown={index < profiles.length - 1}
+                  onMakePrimary={() => onSetPrimaryProfile(profile.id)}
+                  onDelete={() => onRemoveProfile(profile.id)}
+                  onMoveUp={() => {
+                    const next = profiles.map((p) => p.id);
+                    [next[index - 1], next[index]] = [next[index], next[index - 1]];
+                    void onReorderProfiles(next);
+                  }}
+                  onMoveDown={() => {
+                    const next = profiles.map((p) => p.id);
+                    [next[index + 1], next[index]] = [next[index], next[index + 1]];
+                    void onReorderProfiles(next);
+                  }}
+                />
+              ))}
+            </div>
+          )}
+        </div>
+      )}
 
       {isEditing && (
         <div className="space-y-6 mt-4 pt-4 border-t border-black/5 dark:border-white/5">
@@ -884,6 +964,23 @@ function ProviderCard({
             </div>
           </div>
         </div>
+      )}
+      {account.authMode === 'api_key' && (
+        <AddProfileDialog
+          providerLabel={account.label}
+          open={showAddProfileDialog}
+          onClose={() => setShowAddProfileDialog(false)}
+          onSubmit={async ({ label, apiKey, addAsFallback }) => {
+            await onAddProfile(label, apiKey, addAsFallback);
+            if (!addAsFallback) {
+              const matching = profiles.find((profile) => profile.label.toLowerCase() === label.toLowerCase());
+              if (matching) {
+                await onSetPrimaryProfile(matching.id);
+              }
+            }
+            await onLoadProfiles();
+          }}
+        />
       )}
     </div>
   );

--- a/src/lib/provider-accounts.ts
+++ b/src/lib/provider-accounts.ts
@@ -1,6 +1,7 @@
 import { hostApiFetch } from '@/lib/host-api';
 import type {
   ProviderAccount,
+  ProviderProfile,
   ProviderType,
   ProviderVendorInfo,
   ProviderWithKeyInfo,
@@ -123,4 +124,63 @@ export function buildProviderListItems(
     vendor: vendorMap.get(status.type),
     status,
   }));
+}
+
+export async function fetchProfilesForAccount(accountId: string): Promise<ProviderProfile[]> {
+  return hostApiFetch<ProviderProfile[]>(`/api/provider-accounts/${encodeURIComponent(accountId)}/profiles`);
+}
+
+export async function addProfile(
+  accountId: string,
+  label: string,
+  apiKey: string,
+  options?: {
+    authMode?: ProviderAccount['authMode'];
+    oauthToken?: { access: string; refresh: string; expires: number; email?: string; projectId?: string };
+  },
+): Promise<ProviderProfile> {
+  const result = await hostApiFetch<{ success: boolean; profile: ProviderProfile; error?: string }>(
+    `/api/provider-accounts/${encodeURIComponent(accountId)}/profiles`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ label, apiKey, authMode: options?.authMode, oauthToken: options?.oauthToken }),
+    },
+  );
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to add provider profile');
+  }
+  return result.profile;
+}
+
+export async function deleteProfile(accountId: string, profileId: string): Promise<void> {
+  const result = await hostApiFetch<{ success: boolean; error?: string }>(
+    `/api/provider-accounts/${encodeURIComponent(accountId)}/profiles/${encodeURIComponent(profileId)}`,
+    { method: 'DELETE' },
+  );
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to delete provider profile');
+  }
+}
+
+export async function reorderProfiles(accountId: string, orderedProfileIds: string[]): Promise<void> {
+  const result = await hostApiFetch<{ success: boolean; error?: string }>(
+    `/api/provider-accounts/${encodeURIComponent(accountId)}/profiles/order`,
+    {
+      method: 'PUT',
+      body: JSON.stringify({ orderedProfileIds }),
+    },
+  );
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to reorder provider profiles');
+  }
+}
+
+export async function setPrimaryProfile(accountId: string, profileId: string): Promise<void> {
+  const result = await hostApiFetch<{ success: boolean; error?: string }>(
+    `/api/provider-accounts/${encodeURIComponent(accountId)}/profiles/${encodeURIComponent(profileId)}/primary`,
+    { method: 'PUT' },
+  );
+  if (!result.success) {
+    throw new Error(result.error || 'Failed to set primary profile');
+  }
 }

--- a/src/lib/providers.ts
+++ b/src/lib/providers.ts
@@ -130,6 +130,16 @@ export interface ProviderAccount {
   updatedAt: string;
 }
 
+export interface ProviderProfile {
+  id: string;
+  label: string;
+  authMode: ProviderAuthMode;
+  hasCredential: boolean;
+  isDefault: boolean;
+  order: number;
+}
+
+
 import { providerIcons } from '@/assets/providers';
 
 /** All supported provider types with UI metadata */

--- a/src/stores/providers.ts
+++ b/src/stores/providers.ts
@@ -6,13 +6,19 @@ import { create } from 'zustand';
 import type {
   ProviderAccount,
   ProviderConfig,
+  ProviderProfile,
   ProviderVendorInfo,
   ProviderWithKeyInfo,
 } from '@/lib/providers';
 import { normalizeProviderApiKeyInput } from '@/lib/providers';
 import { hostApiFetch } from '@/lib/host-api';
 import {
+  addProfile,
+  deleteProfile,
+  fetchProfilesForAccount,
   fetchProviderSnapshot,
+  reorderProfiles,
+  setPrimaryProfile,
 } from '@/lib/provider-accounts';
 
 // Re-export types for consumers that imported from here
@@ -28,6 +34,7 @@ interface ProviderState {
   statuses: ProviderWithKeyInfo[];
   accounts: ProviderAccount[];
   vendors: ProviderVendorInfo[];
+  profilesByAccount: Record<string, ProviderProfile[]>;
   defaultAccountId: string | null;
   loading: boolean;
   error: string | null;
@@ -43,6 +50,11 @@ interface ProviderState {
     options?: { baseUrl?: string; apiProtocol?: ProviderAccount['apiProtocol'] }
   ) => Promise<{ valid: boolean; error?: string }>;
   getAccountApiKey: (accountId: string) => Promise<string | null>;
+  fetchProfilesForAccount: (accountId: string) => Promise<void>;
+  addProfileToAccount: (accountId: string, label: string, apiKey: string) => Promise<void>;
+  removeProfileFromAccount: (accountId: string, profileId: string) => Promise<void>;
+  reorderProfiles: (accountId: string, orderedProfileIds: string[]) => Promise<void>;
+  setPrimaryProfile: (accountId: string, profileId: string) => Promise<void>;
 
   // Legacy compatibility aliases
   fetchProviders: () => Promise<void>;
@@ -73,6 +85,7 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
   statuses: [],
   accounts: [],
   vendors: [],
+  profilesByAccount: {},
   defaultAccountId: null,
   loading: false,
   error: null,
@@ -350,4 +363,34 @@ export const useProviderStore = create<ProviderState>((set, get) => ({
   },
 
   getApiKey: async (providerId) => get().getAccountApiKey(providerId),
+
+  fetchProfilesForAccount: async (accountId) => {
+    const profiles = await fetchProfilesForAccount(accountId);
+    set((state) => ({
+      profilesByAccount: {
+        ...state.profilesByAccount,
+        [accountId]: profiles,
+      },
+    }));
+  },
+
+  addProfileToAccount: async (accountId, label, apiKey) => {
+    await addProfile(accountId, label, apiKey);
+    await get().fetchProfilesForAccount(accountId);
+  },
+
+  removeProfileFromAccount: async (accountId, profileId) => {
+    await deleteProfile(accountId, profileId);
+    await get().fetchProfilesForAccount(accountId);
+  },
+
+  reorderProfiles: async (accountId, orderedProfileIds) => {
+    await reorderProfiles(accountId, orderedProfileIds);
+    await get().fetchProfilesForAccount(accountId);
+  },
+
+  setPrimaryProfile: async (accountId, profileId) => {
+    await setPrimaryProfile(accountId, profileId);
+    await get().fetchProfilesForAccount(accountId);
+  },
 }));

--- a/tests/e2e/provider-lifecycle.spec.ts
+++ b/tests/e2e/provider-lifecycle.spec.ts
@@ -27,6 +27,7 @@ test.describe('ClawX provider lifecycle', () => {
     await page.getByTestId('sidebar-nav-models').click();
     await expect(page.getByTestId('providers-settings')).toBeVisible();
     await expect(page.getByTestId(`provider-card-${TEST_PROVIDER_ID}`)).toContainText(TEST_PROVIDER_LABEL);
+    await expect(page.getByTestId(`provider-profiles-${TEST_PROVIDER_ID}`)).toContainText('Profiles (Fallback Order)');
 
     await page.getByTestId(`provider-card-${TEST_PROVIDER_ID}`).hover();
     await page.getByTestId(`provider-delete-${TEST_PROVIDER_ID}`).click();

--- a/tests/unit/openclaw-auth.test.ts
+++ b/tests/unit/openclaw-auth.test.ts
@@ -133,6 +133,81 @@ describe('saveProviderKeyToOpenClaw', () => {
   });
 });
 
+describe('saveOAuthTokenToOpenClaw', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+  });
+
+  it('supports writing multiple oauth profiles and preserving fallback order', async () => {
+    const { saveOAuthTokenToOpenClaw, listProfilesForProvider } = await import('@electron/utils/openclaw-auth');
+
+    await saveOAuthTokenToOpenClaw('openai-codex', {
+      access: 'acc-primary',
+      refresh: 'ref-primary',
+      expires: 1000,
+    }, 'openai-codex:default', false, 'main');
+
+    await saveOAuthTokenToOpenClaw('openai-codex', {
+      access: 'acc-backup',
+      refresh: 'ref-backup',
+      expires: 2000,
+    }, 'openai-codex:work', true, 'main');
+
+    const profiles = await listProfilesForProvider('openai-codex', 'main');
+    expect(profiles.map((profile) => profile.id)).toEqual(['openai-codex:default', 'openai-codex:work']);
+    expect((profiles[1].profile as { access: string }).access).toBe('acc-backup');
+  });
+
+  it('updates existing oauth profile without changing its position in order', async () => {
+    const { saveOAuthTokenToOpenClaw } = await import('@electron/utils/openclaw-auth');
+
+    await writeAgentAuthProfiles('main', {
+      version: 2,
+      profiles: {
+        'openai-codex:default': {
+          type: 'oauth',
+          provider: 'openai-codex',
+          access: 'acc-default',
+          refresh: 'ref-default',
+          expires: 100,
+          email: 'primary@example.com',
+        },
+        'openai-codex:work': {
+          type: 'oauth',
+          provider: 'openai-codex',
+          access: 'acc-work-old',
+          refresh: 'ref-work-old',
+          expires: 200,
+          email: 'work@example.com',
+        },
+      },
+      order: {
+        'openai-codex': ['openai-codex:default', 'openai-codex:work'],
+      },
+      lastGood: {
+        'openai-codex': 'openai-codex:default',
+      },
+    });
+
+    await saveOAuthTokenToOpenClaw('openai-codex', {
+      access: 'acc-work-new',
+      refresh: 'ref-work-new',
+      expires: 300,
+      email: 'work@example.com',
+    }, 'openai-codex:work', false, 'main');
+
+    const updated = await readAuthProfiles('main');
+    expect((updated.order as Record<string, string[]>)['openai-codex']).toEqual([
+      'openai-codex:default',
+      'openai-codex:work',
+    ]);
+    expect(((updated.profiles as Record<string, { access: string }>)['openai-codex:work']).access).toBe('acc-work-new');
+  });
+});
+
 describe('removeProviderKeyFromOpenClaw', () => {
   beforeEach(async () => {
     vi.resetModules();
@@ -312,6 +387,46 @@ describe('removeProviderKeyFromOpenClaw', () => {
       'minimax-portal': ['minimax-portal:oauth-backup'],
     });
     expect(mainProfiles.lastGood).toEqual({});
+  });
+});
+
+describe('multi-profile auth store helpers', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+  });
+
+  it('adds, lists, reorders, and deletes provider profiles', async () => {
+    const {
+      addProfileToProvider,
+      listProfilesForProvider,
+      removeProfileById,
+      reorderProviderProfiles,
+    } = await import('@electron/utils/openclaw-auth');
+
+    await addProfileToProvider('openai', 'openai:default', {
+      type: 'api_key',
+      provider: 'openai',
+      key: 'sk-primary',
+    }, 'main');
+    await addProfileToProvider('openai', 'openai:backup', {
+      type: 'api_key',
+      provider: 'openai',
+      key: 'sk-backup',
+    }, 'main');
+
+    const initial = await listProfilesForProvider('openai', 'main');
+    expect(initial.map((profile) => profile.id)).toEqual(['openai:default', 'openai:backup']);
+
+    await reorderProviderProfiles('openai', ['openai:backup', 'openai:default'], 'main');
+    const reordered = await listProfilesForProvider('openai', 'main');
+    expect(reordered.map((profile) => profile.id)).toEqual(['openai:backup', 'openai:default']);
+
+    await removeProfileById('openai', 'openai:backup', 'main');
+    const afterDelete = await listProfilesForProvider('openai', 'main');
+    expect(afterDelete.map((profile) => profile.id)).toEqual(['openai:default']);
   });
 });
 


### PR DESCRIPTION
Summary

This PR adds first-class multi-profile support for provider accounts, including fallback-chain management across API-key and OAuth profiles.
It introduces backend APIs and service logic to list/add/remove/reorder profiles and set a primary profile, updates OpenClaw auth-profiles.json handling (order/lastGood + schema migration), and wires renderer helpers/store/UI so users can manage profiles from Settings.

Additionally, OAuth profile updates now safely reuse existing profiles (e.g., same email) and avoid unintended fallback-order reshuffling.

