### PR TITLE
fix(gateway): bypass Windows TIME_WAIT in waitForPortFree probe

### DIFF
--- a/electron/gateway/supervisor.ts
+++ b/electron/gateway/supervisor.ts
@@ -138,7 +138,19 @@ export async function waitForPortFree(port: number, timeoutMs = 30000): Promise<
       server.once('listening', () => {
         server.close(() => resolve(true));
       });
-      server.listen(port, '127.0.0.1');
+      // exclusive: false → SO_REUSEADDR on Linux/macOS, and on Windows
+      // bypasses SO_EXCLUSIVEADDRUSE so the probe can bind during the
+      // ~120-second TCP TIME_WAIT window left by a force-killed gateway.
+      // Without this, the probe falsely reports the port as occupied for
+      // the full timeoutMs after every gateway restart on Windows, and
+      // startup aborts. This deadlocks the gateway after every channel
+      // config change (which triggers a full restart) until the user
+      // reboots Windows.
+      //
+      // OpenClaw's actual gateway listen() is unaffected — this probe's
+      // role is only to confirm the port is bindable; the real bind that
+      // follows succeeds whether or not the OS is still in TIME_WAIT.
+      server.listen({ port, host: '127.0.0.1', exclusive: false });
     });
 
     if (available) {


### PR DESCRIPTION
## Summary

Force-killing the gateway leaves port 18789 in Windows TCP TIME_WAIT (~120 seconds). The probe in waitForPortFree (electron/gateway/supervisor.ts) binds with the default exclusive: true, which on Windows triggers SO_EXCLUSIVEADDRUSE. That option refuses to bind during TIME_WAIT, so the probe falsely reports the port as occupied for the full timeoutMs and aborts startup.

## Trigger / repro

Observed on Windows portable installs (also reproducible on stock dev install) running on default gateway.ports = [18789]:

1. User saves any channel config (QQ Bot, WeChat, Feishu, WhatsApp, etc.).
2. Gateway full-restart kicks in, force-kills the existing gateway pid.
3. Old gateway listen socket lingers in TIME_WAIT for ~120 seconds.
4. New waitForPortFree(18789) probe sits in EADDRINUSE retry loop for the full 30 s timeout and aborts.
5. Channel runtime gets stuck in degraded / 未连接 until the user either reboots Windows or waits ~2 minutes.

Customer log signature:

\`\`\`
Port 18789 still occupied after 30000ms; aborting startup
\`\`\`

The trigger is widespread because every channel config save goes through the full-restart path on the current main, and Clash/V2Ray-TUN setups (very common in mainland China) make the OS socket churn even more aggressive, increasing the chance of hitting this bug on every restart.

## Fix

Single-line change: switch the probe socket to exclusive: false.

\`\`\`diff
-      server.listen(port, '127.0.0.1');
+      server.listen({ port, host: '127.0.0.1', exclusive: false });
\`\`\`

- On Windows, bypasses SO_EXCLUSIVEADDRUSE and lets the probe bind during TIME_WAIT.
- On Linux/macOS, sets SO_REUSEADDR (equivalent semantics, no behavior change in practice since the trigger is Windows-specific).
- OpenClaw actual gateway listen() is unaffected — this probe role is only to confirm the port is bindable; the real bind that follows succeeds in practice once the gateway socket is fully released by the kernel after force-kill.

## Verification

End-to-end test on Windows portable build (also with Clash TUN mode enabled, which exposes the bug more often):

- Pre-fix: probe times out at 30 s after every channel-config save; channel UI shows 异常降级 / 未连接 until reboot.
- Post-fix: port becomes bindable within <500 ms after force-kill; channel UI returns to 已连接 within ~30 s of saving config.
- pnpm typecheck clean.
- pnpm exec vitest run — no new failures.

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Related

Reproduced and tracked in our downstream portable fork (dongsheng123132/clawx-portable@experimental); the gateway-port-deadlock has been blocking customers for several days. This is the minimal change that resolves it; happy to follow up with separate PRs for the deeper related issues (force-kill grace timeout, fallback_restart cause=windows path) if you would prefer them split out.