### PR TITLE
fix(clawhub): add HTTP-first search/explore to bypass broken cn-mirror (fixes #960)

### DIFF
--- a/electron/gateway/clawhub.ts
+++ b/electron/gateway/clawhub.ts
@@ -46,6 +46,8 @@ export interface MarketplaceProvider {
     install(params: ClawHubInstallParams): Promise<void>;
 }
 
+const CLAWHUB_OFFICIAL_API = 'https://clawhub.ai';
+
 export class ClawHubService {
     private workDir: string;
     private cliPath: string;
@@ -212,6 +214,30 @@ export class ClawHubService {
     }
 
     /**
+     * Try fetching search/explore results directly from the official ClawHub API.
+     * Returns null on any failure so callers can fall back to CLI.
+     */
+    private async httpFetchResults(endpoint: string): Promise<ClawHubSkillResult[] | null> {
+        try {
+            const url = `${CLAWHUB_OFFICIAL_API}${endpoint}`;
+            const res = await fetch(url);
+            if (!res.ok) return null;
+            const contentType = res.headers.get('content-type') || '';
+            if (!contentType.includes('application/json')) return null;
+            const data = await res.json();
+            if (!Array.isArray(data.results)) return null;
+            return data.results.map((r: Record<string, unknown>) => ({
+                slug: r.slug as string,
+                name: (r.displayName as string) || (r.slug as string),
+                description: (r.summary as string) || '',
+                version: (r.version as string) || 'latest',
+            }));
+        } catch {
+            return null;
+        }
+    }
+
+    /**
      * Search for skills. Delegates to the marketplace provider if one is set,
      * otherwise falls back to the local ClawHub CLI.
      */
@@ -224,6 +250,11 @@ export class ClawHubService {
             if (!params.query || params.query.trim() === '') {
                 return this.explore({ limit: params.limit });
             }
+
+            // Try HTTP-first from the official registry
+            const limit = params.limit ? `&limit=${params.limit}` : '';
+            const httpResults = await this.httpFetchResults(`/api/search?q=${encodeURIComponent(params.query)}${limit}`);
+            if (httpResults) return httpResults;
 
             const args = ['search', params.query];
             if (params.limit) {
@@ -288,6 +319,11 @@ export class ClawHubService {
      */
     async explore(params: { limit?: number } = {}): Promise<ClawHubSkillResult[]> {
         try {
+            // Try HTTP-first from the official registry
+            const limit = params.limit ? `?limit=${params.limit}` : '';
+            const httpResults = await this.httpFetchResults(`/api/explore${limit}`);
+            if (httpResults) return httpResults;
+
             const args = ['explore'];
             if (params.limit) {
                 args.push('--limit', String(params.limit));

--- a/electron/gateway/clawhub.ts
+++ b/electron/gateway/clawhub.ts
@@ -220,7 +220,10 @@ export class ClawHubService {
     private async httpFetchResults(endpoint: string): Promise<ClawHubSkillResult[] | null> {
         try {
             const url = `${CLAWHUB_OFFICIAL_API}${endpoint}`;
-            const res = await fetch(url);
+            const controller = new AbortController();
+            const timer = setTimeout(() => controller.abort(), 5000);
+            const res = await fetch(url, { signal: controller.signal });
+            clearTimeout(timer);
             if (!res.ok) return null;
             const contentType = res.headers.get('content-type') || '';
             if (!contentType.includes('application/json')) return null;

--- a/tests/unit/clawhub-search-http-fallback.test.ts
+++ b/tests/unit/clawhub-search-http-fallback.test.ts
@@ -105,6 +105,19 @@ describe('ClawHub HTTP-first search/explore fallback', () => {
             expect(results[0].slug).toBe('my-skill');
         });
 
+        it('falls back to CLI on abort/timeout', async () => {
+            fetchMock.mockRejectedValueOnce(new DOMException('The operation was aborted', 'AbortError'));
+
+            mockSpawnResult('my-skill v1.0.0 A great skill');
+
+            const service = new ClawHubService();
+            const results = await service.search({ query: 'test' });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].slug).toBe('my-skill');
+        });
+
         it('falls back to CLI on network error', async () => {
             fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
 

--- a/tests/unit/clawhub-search-http-fallback.test.ts
+++ b/tests/unit/clawhub-search-http-fallback.test.ts
@@ -1,0 +1,173 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import EventEmitter from 'events';
+
+const spawnMock = vi.fn();
+
+vi.mock('electron', () => ({
+    app: { isPackaged: false },
+    shell: { openPath: vi.fn() },
+}));
+
+vi.mock('../../electron/utils/paths', () => ({
+    getOpenClawConfigDir: () => '/tmp/test-openclaw',
+    ensureDir: vi.fn(),
+    getClawHubCliBinPath: () => '/tmp/test-bin/clawhub',
+    getClawHubCliEntryPath: () => '/tmp/test-bin/clawhub.js',
+    quoteForCmd: (s: string) => s,
+}));
+
+vi.mock('child_process', () => ({
+    default: { spawn: (...args: unknown[]) => spawnMock(...args) },
+    spawn: (...args: unknown[]) => spawnMock(...args),
+}));
+
+vi.mock('fs', () => {
+    const base = {
+        existsSync: vi.fn(() => true),
+        readFileSync: vi.fn(),
+        readdirSync: vi.fn(() => []),
+        promises: { rm: vi.fn(), writeFile: vi.fn() },
+    };
+    return { default: base, ...base };
+});
+
+const fetchMock = vi.fn();
+global.fetch = fetchMock;
+
+function mockSpawnResult(stdout: string, code = 0) {
+    spawnMock.mockImplementation(() => {
+        const child = new EventEmitter() as EventEmitter & { stdout: EventEmitter; stderr: EventEmitter };
+        child.stdout = new EventEmitter();
+        child.stderr = new EventEmitter();
+        process.nextTick(() => {
+            child.stdout.emit('data', Buffer.from(stdout));
+            child.stderr.emit('data', Buffer.from(''));
+            child.emit('close', code);
+        });
+        return child;
+    });
+}
+
+function jsonResponse(data: unknown, contentType = 'application/json') {
+    return Promise.resolve({
+        ok: true,
+        headers: { get: (h: string) => h === 'content-type' ? contentType : null },
+        json: () => Promise.resolve(data),
+    });
+}
+
+describe('ClawHub HTTP-first search/explore fallback', () => {
+    let ClawHubService: typeof import('../../electron/gateway/clawhub').ClawHubService;
+
+    beforeEach(async () => {
+        vi.resetModules();
+        vi.clearAllMocks();
+        fetchMock.mockReset();
+        const mod = await import('../../electron/gateway/clawhub');
+        ClawHubService = mod.ClawHubService;
+    });
+
+    describe('search()', () => {
+        it('returns HTTP results when the official API responds with valid JSON', async () => {
+            fetchMock.mockReturnValueOnce(jsonResponse({
+                results: [
+                    { slug: 'test-skill', displayName: 'Test Skill', summary: 'A test', version: '1.0.0' },
+                ],
+            }));
+
+            const service = new ClawHubService();
+            const results = await service.search({ query: 'test' });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock.mock.calls[0][0]).toContain('/api/search?q=test');
+            expect(results).toEqual([{
+                slug: 'test-skill',
+                name: 'Test Skill',
+                description: 'A test',
+                version: '1.0.0',
+            }]);
+        });
+
+        it('falls back to CLI when HTTP returns HTML (cn-mirror scenario)', async () => {
+            fetchMock.mockReturnValueOnce(Promise.resolve({
+                ok: true,
+                headers: { get: (h: string) => h === 'content-type' ? 'text/html' : null },
+                json: () => Promise.reject(new Error('not json')),
+            }));
+
+            mockSpawnResult('my-skill v1.0.0 A great skill');
+
+            const service = new ClawHubService();
+            const results = await service.search({ query: 'test' });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].slug).toBe('my-skill');
+        });
+
+        it('falls back to CLI on network error', async () => {
+            fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+            mockSpawnResult('my-skill v1.0.0 A great skill');
+
+            const service = new ClawHubService();
+            const results = await service.search({ query: 'test' });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].slug).toBe('my-skill');
+        });
+
+        it('falls back to CLI on 5xx response', async () => {
+            fetchMock.mockReturnValueOnce(Promise.resolve({
+                ok: false,
+                status: 500,
+                headers: { get: () => null },
+            }));
+
+            mockSpawnResult('my-skill v1.0.0 A great skill');
+
+            const service = new ClawHubService();
+            const results = await service.search({ query: 'test' });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].slug).toBe('my-skill');
+        });
+    });
+
+    describe('explore()', () => {
+        it('returns HTTP results when the official API responds with valid JSON', async () => {
+            fetchMock.mockReturnValueOnce(jsonResponse({
+                results: [
+                    { slug: 'trending-skill', displayName: 'Trending', summary: 'Popular', version: '2.0.0' },
+                ],
+            }));
+
+            const service = new ClawHubService();
+            const results = await service.explore({ limit: 10 });
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(fetchMock.mock.calls[0][0]).toContain('/api/explore?limit=10');
+            expect(results).toEqual([{
+                slug: 'trending-skill',
+                name: 'Trending',
+                description: 'Popular',
+                version: '2.0.0',
+            }]);
+        });
+
+        it('falls back to CLI when HTTP fails', async () => {
+            fetchMock.mockRejectedValueOnce(new Error('ECONNREFUSED'));
+
+            mockSpawnResult('cool-skill v1.0.0 2 hours ago A cool skill');
+
+            const service = new ClawHubService();
+            const results = await service.explore();
+
+            expect(fetchMock).toHaveBeenCalledTimes(1);
+            expect(results.length).toBeGreaterThan(0);
+            expect(results[0].slug).toBe('cool-skill');
+        });
+    });
+});


### PR DESCRIPTION
## Summary

When the ClawHub CLI source is set to `cn-mirror` (the default for Chinese users), Skills marketplace search returns 404 because `cn.clawhub-mirror.com` is a static HTML mirror that does not serve the `/api/search` and `/api/explore` JSON endpoints.

This PR adds an HTTP-first fallback in `ClawHubService`: both `search()` and `explore()` now try fetching directly from the official `clawhub.ai` API first. If the HTTP request succeeds with valid JSON, results are returned immediately. If it fails for any reason (network error, non-JSON response, 5xx), the existing CLI-based logic runs as before.

## Related Issue(s)

Closes #960

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

- Confirmed the bug: `curl 'https://cn.clawhub-mirror.com/api/search?q=pdf'` returns HTML; `curl 'https://clawhub.ai/api/search?q=pdf'` returns JSON
- Added 6 unit tests covering:
  - HTTP success returns mapped results (search + explore)
  - Falls back to CLI when HTTP returns HTML (cn-mirror scenario)
  - Falls back to CLI on network error
  - Falls back to CLI on 5xx response
- All 6 new tests pass; 595 existing tests still pass

## Changes

- `electron/gateway/clawhub.ts`: Added `httpFetchResults()` helper and HTTP-first calls in `search()` and `explore()`
- `tests/unit/clawhub-search-http-fallback.test.ts`: New test file (6 tests)

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

---

🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do — you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop — no hard feelings.