### PR TITLE
refactor(headers): update header keys to use 'X-OpenRouter-Title' for consistency

### DIFF
--- a/electron/gateway/process-launcher.ts
+++ b/electron/gateway/process-launcher.ts
@@ -32,8 +32,10 @@ const GATEWAY_FETCH_PRELOAD_SOURCE = `'use strict';
       delete flat['HTTP-Referer'];
       delete flat['x-title'];
       delete flat['X-Title'];
+      delete flat['x-openrouter-title'];
+      delete flat['X-OpenRouter-Title'];
       flat['HTTP-Referer'] = 'https://claw-x.com';
-      flat['X-Title'] = 'ClawX';
+      flat['X-OpenRouter-Title'] = 'ClawX';
       init.headers = flat;
     }
     return _f.call(globalThis, input, init);

--- a/electron/shared/providers/registry.ts
+++ b/electron/shared/providers/registry.ts
@@ -84,7 +84,7 @@ export const PROVIDER_DEFINITIONS: ProviderDefinition[] = [
       apiKeyEnv: 'OPENROUTER_API_KEY',
       headers: {
         'HTTP-Referer': 'https://claw-x.com',
-        'X-Title': 'ClawX',
+        'X-OpenRouter-Title': 'ClawX',
       },
     },
   },

--- a/electron/utils/openrouter-headers-preload.cjs
+++ b/electron/utils/openrouter-headers-preload.cjs
@@ -36,8 +36,10 @@
       delete flat['HTTP-Referer'];
       delete flat['x-title'];
       delete flat['X-Title'];
+      delete flat['x-openrouter-title'];
+      delete flat['X-OpenRouter-Title'];
       flat['HTTP-Referer'] = 'https://claw-x.com';
-      flat['X-Title'] = 'ClawX';
+      flat['X-OpenRouter-Title'] = 'ClawX';
       init.headers = flat;
     }
     return _f.call(globalThis, input, init);


### PR DESCRIPTION
## Summary

openrouter.ai app name is error

## Related Issue(s)

<!-- e.g. Closes #123 -->

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.
