### PR TITLE
feat(chat): add session rename in sidebar

### DIFF
--- a/electron/api/routes/sessions.ts
+++ b/electron/api/routes/sessions.ts
@@ -407,5 +407,66 @@ export async function handleSessionRoutes(
     return true;
   }
 
+  // POST /api/sessions/rename — update session label in sessions.json.
+  if (url.pathname === '/api/sessions/rename' && req.method === 'POST') {
+    try {
+      const body = await parseJsonBody<{ sessionKey: string; label: string }>(req);
+      const { sessionKey, label } = body;
+      if (!sessionKey || !sessionKey.startsWith('agent:')) {
+        sendJson(res, 400, { success: false, error: `Invalid sessionKey: ${sessionKey}` });
+        return true;
+      }
+      if (!label || typeof label !== 'string' || !label.trim()) {
+        sendJson(res, 400, { success: false, error: 'Label cannot be empty' });
+        return true;
+      }
+      const parts = sessionKey.split(':');
+      if (parts.length < 3) {
+        sendJson(res, 400, { success: false, error: `sessionKey has too few parts: ${sessionKey}` });
+        return true;
+      }
+      const agentId = parts[1];
+      if (!SAFE_SESSION_SEGMENT.test(agentId)) {
+        sendJson(res, 400, { success: false, error: `Invalid agentId: ${agentId}` });
+        return true;
+      }
+      const sessionsDir = join(getOpenClawConfigDir(), 'agents', agentId, 'sessions');
+      const sessionsJsonPath = join(sessionsDir, 'sessions.json');
+      const fsP = await import('node:fs/promises');
+      const raw = await fsP.readFile(sessionsJsonPath, 'utf8');
+      const sessionsJson = JSON.parse(raw) as Record<string, unknown>;
+
+      const trimmedLabel = label.trim();
+      let found = false;
+
+      // Object-keyed format
+      if (sessionsJson[sessionKey] && typeof sessionsJson[sessionKey] === 'object') {
+        (sessionsJson[sessionKey] as Record<string, unknown>).label = trimmedLabel;
+        found = true;
+      }
+      // Array format
+      if (Array.isArray(sessionsJson.sessions)) {
+        for (const entry of sessionsJson.sessions as Array<Record<string, unknown>>) {
+          if (entry.key === sessionKey || entry.sessionKey === sessionKey) {
+            entry.label = trimmedLabel;
+            found = true;
+          }
+        }
+      }
+
+      if (!found) {
+        sendJson(res, 404, { success: false, error: `Session not found: ${sessionKey}` });
+        return true;
+      }
+
+      await fsP.writeFile(sessionsJsonPath, JSON.stringify(sessionsJson, null, 2), 'utf8');
+      logger.info(`[api/sessions/rename] key=${sessionKey} label=${trimmedLabel}`);
+      sendJson(res, 200, { success: true });
+    } catch (error) {
+      sendJson(res, 500, { success: false, error: String(error) });
+    }
+    return true;
+  }
+
   return false;
 }

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -2706,6 +2706,63 @@ function registerSessionHandlers(): void {
       return { success: false, error: String(err) };
     }
   });
+
+  ipcMain.handle('session:rename', async (_, sessionKey: string, label: string) => {
+    try {
+      if (!sessionKey || !sessionKey.startsWith('agent:')) {
+        return { success: false, error: `Invalid sessionKey: ${sessionKey}` };
+      }
+      if (!label || typeof label !== 'string' || !label.trim()) {
+        return { success: false, error: 'Label cannot be empty' };
+      }
+
+      const parts = sessionKey.split(':');
+      if (parts.length < 3) {
+        return { success: false, error: `Malformed sessionKey: ${sessionKey}` };
+      }
+      const agentId = parts[1];
+      if (!SAFE_AGENT_ID.test(agentId)) {
+        return { success: false, error: `Invalid agentId in sessionKey: ${agentId}` };
+      }
+
+      const sessionsJsonPath = join(
+        getOpenClawConfigDir(),
+        'agents',
+        agentId,
+        'sessions',
+        'sessions.json',
+      );
+
+      const raw = await fsP.readFile(sessionsJsonPath, 'utf8');
+      const json = JSON.parse(raw) as Record<string, unknown>;
+
+      // Update label in sessions.json — supports both object-keyed and array formats
+      let found = false;
+      if (json[sessionKey] && typeof json[sessionKey] === 'object') {
+        (json[sessionKey] as Record<string, unknown>).label = label.trim();
+        found = true;
+      }
+      if (Array.isArray(json.sessions)) {
+        for (const entry of json.sessions as Array<Record<string, unknown>>) {
+          if (entry.key === sessionKey || entry.sessionKey === sessionKey) {
+            entry.label = label.trim();
+            found = true;
+          }
+        }
+      }
+
+      if (!found) {
+        return { success: false, error: `Session not found in sessions.json: ${sessionKey}` };
+      }
+
+      await fsP.writeFile(sessionsJsonPath, JSON.stringify(json, null, 2), 'utf8');
+      logger.info(`[session:rename] key=${sessionKey} label=${label.trim()}`);
+      return { success: true };
+    } catch (err) {
+      logger.error(`[session:rename] Unexpected error for ${sessionKey}:`, err);
+      return { success: false, error: String(err) };
+    }
+  });
 }
 
 // ── File preview (sandboxed) ──────────────────────────────────────────

--- a/electron/preload/index.ts
+++ b/electron/preload/index.ts
@@ -139,6 +139,7 @@ const electronAPI = {
         'chat:sendWithMedia',
         // Session management
         'session:delete',
+        'session:rename',
         // OpenClaw extras
         'openclaw:getDir',
         'openclaw:getConfigDir',

--- a/src/components/layout/Sidebar.tsx
+++ b/src/components/layout/Sidebar.tsx
@@ -17,6 +17,9 @@ import {
   Terminal,
   ExternalLink,
   Trash2,
+  Pencil,
+  Check,
+  X,
   Cpu,
   Moon,
 } from 'lucide-react';
@@ -28,6 +31,7 @@ import { useGatewayStore } from '@/stores/gateway';
 import { useAgentsStore } from '@/stores/agents';
 import { getSessionActivityMs, getSessionBucket, type SessionBucketKey } from './session-buckets';
 import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
 import { hostApiFetch } from '@/lib/host-api';
@@ -105,6 +109,7 @@ export function Sidebar() {
   const switchSession = useChatStore((s) => s.switchSession);
   const newSession = useChatStore((s) => s.newSession);
   const deleteSession = useChatStore((s) => s.deleteSession);
+  const renameSession = useChatStore((s) => s.renameSession);
   const loadSessions = useChatStore((s) => s.loadSessions);
   const loadHistory = useChatStore((s) => s.loadHistory);
 
@@ -165,6 +170,8 @@ export function Sidebar() {
 
   const { t } = useTranslation(['common', 'chat']);
   const [sessionToDelete, setSessionToDelete] = useState<{ key: string; label: string } | null>(null);
+  const [editingSessionKey, setEditingSessionKey] = useState<string | null>(null);
+  const [editingLabel, setEditingLabel] = useState('');
   const [nowMs, setNowMs] = useState(INITIAL_NOW_MS);
 
   useEffect(() => {
@@ -177,6 +184,37 @@ export function Sidebar() {
   useEffect(() => {
     void fetchAgents();
   }, [fetchAgents]);
+
+  const handleStartRename = (key: string, currentLabel: string) => {
+    setEditingSessionKey(key);
+    setEditingLabel(currentLabel);
+  };
+
+  const handleRenameSubmit = async () => {
+    if (!editingSessionKey || !editingLabel.trim()) {
+      setEditingSessionKey(null);
+      return;
+    }
+    try {
+      await renameSession(editingSessionKey, editingLabel.trim());
+    } catch (err) {
+      console.error('Failed to rename session:', err);
+    }
+    setEditingSessionKey(null);
+  };
+
+  const handleRenameCancel = () => {
+    setEditingSessionKey(null);
+  };
+
+  const handleRenameKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      void handleRenameSubmit();
+    } else if (e.key === 'Escape') {
+      handleRenameCancel();
+    }
+  };
 
   const stopResizing = useCallback(() => {
     stopResizeRef.current?.();
@@ -353,49 +391,93 @@ export function Sidebar() {
                 {bucket.sessions.map((s) => {
                   const agentId = getAgentIdFromSessionKey(s.key);
                   const agentName = agentNameById[agentId] || agentId;
+                  const isEditing = editingSessionKey === s.key;
+                  const sessionLabel = getSessionLabel(s.key, s.displayName, s.label);
                   return (
                     <div key={s.key} className="group relative flex items-center">
-                      <button
-                        onClick={() => {
-                          if (currentSessionKey === s.key) {
-                            void loadHistory(false);
-                          } else {
-                            switchSession(s.key);
-                          }
-                          navigate('/');
-                        }}
-                        className={cn(
-                          'w-full text-left rounded-lg px-2.5 py-1.5 text-meta transition-colors pr-7',
-                          'hover:bg-black/5 dark:hover:bg-white/5',
-                          isOnChat && currentSessionKey === s.key
-                            ? 'bg-black/5 dark:bg-white/10 text-foreground font-medium'
-                            : 'text-foreground/75',
-                        )}
-                      >
-                        <div className="flex min-w-0 items-center gap-2">
-                          <span className="shrink-0 rounded-full bg-black/[0.04] px-2 py-0.5 text-2xs font-medium text-foreground/70 dark:bg-white/[0.08]">
-                            {agentName}
-                          </span>
-                          <span className="truncate">{getSessionLabel(s.key, s.displayName, s.label)}</span>
+                      {isEditing ? (
+                        <div className="flex w-full items-center gap-1 px-1.5 py-1">
+                          <Input
+                            autoFocus
+                            value={editingLabel}
+                            onChange={(e) => setEditingLabel(e.target.value)}
+                            onKeyDown={handleRenameKeyDown}
+                            onBlur={() => void handleRenameSubmit()}
+                            className="h-7 min-w-0 flex-1 text-meta"
+                            aria-label={t('common:sidebar.renameSessionPlaceholder')}
+                          />
+                          <button
+                            aria-label={t('common:sidebar.saveSessionRename')}
+                            onMouseDown={(e) => { e.preventDefault(); void handleRenameSubmit(); }}
+                            className="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:text-foreground"
+                          >
+                            <Check className="h-3.5 w-3.5" />
+                          </button>
+                          <button
+                            aria-label={t('common:sidebar.cancelSessionRename')}
+                            onMouseDown={(e) => { e.preventDefault(); handleRenameCancel(); }}
+                            className="flex shrink-0 items-center justify-center rounded p-0.5 text-muted-foreground hover:text-destructive"
+                          >
+                            <X className="h-3.5 w-3.5" />
+                          </button>
                         </div>
-                      </button>
-                      <button
-                        aria-label="Delete session"
-                        onClick={(e) => {
-                          e.stopPropagation();
-                          setSessionToDelete({
-                            key: s.key,
-                            label: getSessionLabel(s.key, s.displayName, s.label),
-                          });
-                        }}
-                        className={cn(
-                          'absolute right-1 flex items-center justify-center rounded p-0.5 transition-opacity',
-                          'opacity-0 group-hover:opacity-100',
-                          'text-muted-foreground hover:text-destructive hover:bg-destructive/10',
-                        )}
-                      >
-                        <Trash2 className="h-3.5 w-3.5" />
-                      </button>
+                      ) : (
+                        <>
+                          <button
+                            onClick={() => {
+                              if (currentSessionKey === s.key) {
+                                void loadHistory(false);
+                              } else {
+                                switchSession(s.key);
+                              }
+                              navigate('/');
+                            }}
+                            onDoubleClick={() => handleStartRename(s.key, sessionLabel)}
+                            className={cn(
+                              'w-full text-left rounded-lg px-2.5 py-1.5 text-meta transition-colors pr-16',
+                              'hover:bg-black/5 dark:hover:bg-white/5',
+                              isOnChat && currentSessionKey === s.key
+                                ? 'bg-black/5 dark:bg-white/10 text-foreground font-medium'
+                                : 'text-foreground/75',
+                            )}
+                          >
+                            <div className="flex min-w-0 items-center gap-2">
+                              <span className="shrink-0 rounded-full bg-black/[0.04] px-2 py-0.5 text-2xs font-medium text-foreground/70 dark:bg-white/[0.08]">
+                                {agentName}
+                              </span>
+                              <span className="truncate">{sessionLabel}</span>
+                            </div>
+                          </button>
+                          <div className={cn(
+                            'absolute right-1 flex items-center gap-0.5 transition-opacity',
+                            'opacity-0 group-hover:opacity-100',
+                          )}>
+                            <button
+                              aria-label={t('common:sidebar.renameSession')}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                handleStartRename(s.key, sessionLabel);
+                              }}
+                              className="flex items-center justify-center rounded p-0.5 text-muted-foreground hover:text-foreground hover:bg-black/5 dark:hover:bg-white/10"
+                            >
+                              <Pencil className="h-3.5 w-3.5" />
+                            </button>
+                            <button
+                              aria-label={t('common:sidebar.deleteSession')}
+                              onClick={(e) => {
+                                e.stopPropagation();
+                                setSessionToDelete({
+                                  key: s.key,
+                                  label: sessionLabel,
+                                });
+                              }}
+                              className="flex items-center justify-center rounded p-0.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10"
+                            >
+                              <Trash2 className="h-3.5 w-3.5" />
+                            </button>
+                          </div>
+                        </>
+                      )}
                     </div>
                   );
                 })}

--- a/src/i18n/locales/en/common.json
+++ b/src/i18n/locales/en/common.json
@@ -10,9 +10,14 @@
         "settings": "Settings",
         "devConsole": "Developer Console",
         "models": "Models",
-        "deleteSessionConfirm": "Are you sure you want to delete session \"{{label}}\"?",
+        "deleteSessionConfirm": "Delete \"{{label}}\"?",
         "openClawPage": "OpenClaw Page",
-        "openClawDreams": "Dreams"
+        "openClawDreams": "Dreams",
+        "renameSession": "Rename",
+        "deleteSession": "Delete",
+        "renameSessionPlaceholder": "Session title",
+        "saveSessionRename": "Save session title",
+        "cancelSessionRename": "Cancel renaming"
     },
     "actions": {
         "save": "Save",

--- a/src/i18n/locales/ja/common.json
+++ b/src/i18n/locales/ja/common.json
@@ -10,9 +10,14 @@
         "settings": "設定",
         "devConsole": "開発者コンソール",
         "models": "モデル",
-        "deleteSessionConfirm": "セッション \"{{label}}\" を削除してもよろしいですか？",
+        "deleteSessionConfirm": "「{{label}}」を削除しますか？",
         "openClawPage": "OpenClaw ページ",
-        "openClawDreams": "夢"
+        "openClawDreams": "夢",
+        "renameSession": "名前を変更",
+        "deleteSession": "削除",
+        "renameSessionPlaceholder": "セッションタイトル",
+        "saveSessionRename": "セッションタイトルを保存",
+        "cancelSessionRename": "名前変更をキャンセル"
     },
     "actions": {
         "save": "保存",

--- a/src/i18n/locales/ru/common.json
+++ b/src/i18n/locales/ru/common.json
@@ -10,9 +10,14 @@
         "settings": "Настройки",
         "devConsole": "Консоль разработчика",
         "models": "Модели",
-        "deleteSessionConfirm": "Вы уверены, что хотите удалить сессию \"{{label}}\"?",
+        "deleteSessionConfirm": "Удалить \"{{label}}\"?",
         "openClawPage": "Страница OpenClaw",
-        "openClawDreams": "Dreams"
+        "openClawDreams": "Dreams",
+        "renameSession": "Переименовать",
+        "deleteSession": "Удалить",
+        "renameSessionPlaceholder": "Название сессии",
+        "saveSessionRename": "Сохранить название",
+        "cancelSessionRename": "Отменить переименование"
     },
     "actions": {
         "save": "Сохранить",

--- a/src/i18n/locales/zh/common.json
+++ b/src/i18n/locales/zh/common.json
@@ -10,9 +10,14 @@
         "settings": "设置",
         "devConsole": "开发者控制台",
         "models": "模型",
-        "deleteSessionConfirm": "确定要删除对话 \"{{label}}\" 吗？",
+        "deleteSessionConfirm": "删除「{{label}}」？",
         "openClawPage": "OpenClaw 页面",
-        "openClawDreams": "梦境"
+        "openClawDreams": "梦境",
+        "renameSession": "重命名",
+        "deleteSession": "删除",
+        "renameSessionPlaceholder": "会话标题",
+        "saveSessionRename": "保存会话标题",
+        "cancelSessionRename": "取消重命名"
     },
     "actions": {
         "save": "保存",

--- a/src/stores/chat.ts
+++ b/src/stores/chat.ts
@@ -1998,6 +1998,38 @@ export const useChatStore = create<ChatState>((set, get) => ({
     }));
   },
 
+  // ── Rename session ──
+
+  renameSession: async (key: string, label: string) => {
+    const normalized = label.trim();
+    if (!normalized) {
+      throw new Error('Session label cannot be empty');
+    }
+
+    try {
+      const result = await hostApiFetch<{
+        success: boolean;
+        error?: string;
+      }>('/api/sessions/rename', {
+        method: 'POST',
+        body: JSON.stringify({ sessionKey: key, label: normalized }),
+      });
+      if (!result.success) {
+        throw new Error(result.error || 'Failed to rename session');
+      }
+    } catch (err) {
+      console.error(`[renameSession] API call failed for ${key}:`, err);
+      throw err;
+    }
+
+    set((s) => ({
+      sessions: s.sessions.map((session) =>
+        session.key === key ? { ...session, label: normalized } : session,
+      ),
+      sessionLabels: { ...s.sessionLabels, [key]: normalized },
+    }));
+  },
+
   // ── Cleanup empty session on navigate away ──
 
   cleanupEmptySession: () => {

--- a/src/stores/chat/internal.ts
+++ b/src/stores/chat/internal.ts
@@ -56,6 +56,7 @@ export function createChatActions(
   | 'switchSession'
   | 'newSession'
   | 'deleteSession'
+  | 'renameSession'
   | 'cleanupEmptySession'
   | 'loadHistory'
   | 'sendMessage'

--- a/src/stores/chat/session-actions.ts
+++ b/src/stores/chat/session-actions.ts
@@ -59,7 +59,7 @@ function parseSessionUpdatedAtMs(value: unknown): number | undefined {
 export function createSessionActions(
   set: ChatSet,
   get: ChatGet,
-): Pick<SessionHistoryActions, 'loadSessions' | 'switchSession' | 'newSession' | 'deleteSession' | 'cleanupEmptySession'> {
+): Pick<SessionHistoryActions, 'loadSessions' | 'switchSession' | 'newSession' | 'deleteSession' | 'renameSession' | 'cleanupEmptySession'> {
   return {
     loadSessions: async () => {
       try {
@@ -353,6 +353,37 @@ export function createSessionActions(
         pendingFinal: false,
         lastUserMessageAt: null,
         pendingToolImages: [],
+      }));
+    },
+
+    // ── Rename session ──
+
+    renameSession: async (key: string, label: string) => {
+      const normalized = label.trim();
+      if (!normalized) {
+        throw new Error('Session label cannot be empty');
+      }
+
+      // Persist the new label to sessions.json via IPC
+      try {
+        const result = await invokeIpc('session:rename', key, normalized) as {
+          success: boolean;
+          error?: string;
+        };
+        if (!result.success) {
+          throw new Error(result.error || 'Failed to rename session');
+        }
+      } catch (err) {
+        console.error(`[renameSession] IPC call failed for ${key}:`, err);
+        throw err;
+      }
+
+      // Update local state: both sessions array and sessionLabels
+      set((s) => ({
+        sessions: s.sessions.map((session) =>
+          session.key === key ? { ...session, label: normalized } : session,
+        ),
+        sessionLabels: { ...s.sessionLabels, [key]: normalized },
       }));
     },
 

--- a/src/stores/chat/store-api.ts
+++ b/src/stores/chat/store-api.ts
@@ -9,7 +9,7 @@ export type ChatGet = () => ChatState;
 
 export type SessionHistoryActions = Pick<
   ChatState,
-  'loadSessions' | 'switchSession' | 'newSession' | 'deleteSession' | 'cleanupEmptySession' | 'loadHistory' | 'loadMoreHistory'
+  'loadSessions' | 'switchSession' | 'newSession' | 'deleteSession' | 'renameSession' | 'cleanupEmptySession' | 'loadHistory' | 'loadMoreHistory'
 >;
 
 export type RuntimeActions = Pick<

--- a/src/stores/chat/types.ts
+++ b/src/stores/chat/types.ts
@@ -126,6 +126,7 @@ export interface ChatState {
   switchSession: (key: string) => void;
   newSession: () => void;
   deleteSession: (key: string) => Promise<void>;
+  renameSession: (key: string, label: string) => Promise<void>;
   cleanupEmptySession: () => void;
   loadHistory: (quiet?: boolean) => Promise<void>;
   loadMoreHistory: () => Promise<void>;


### PR DESCRIPTION
## Summary

Add the ability to rename chat sessions directly from the sidebar. Users can rename via:
- **Double-click** on a session title to start inline editing
- **Pencil icon** that appears on hover alongside the existing delete button

The renamed label is persisted to `sessions.json` so it survives app restarts and session reloads.

## Related Issue(s)

Closes #1013

## Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Implementation

**Backend (persistence):**
- Added `session:rename` IPC handler in main process — reads `sessions.json`, updates the label field for both object-keyed and array session formats, and writes back
- Added `POST /api/sessions/rename` HTTP route — mirrors the IPC handler, following the same pattern as `session:delete`/`/api/sessions/delete`
- Added `session:rename` to the preload IPC allowlist

**Store layer:**
- Added `renameSession` action to the chat store type interface
- Implemented in both the modular `session-actions.ts` (uses `invokeIpc`) and legacy `chat.ts` (uses `hostApiFetch`)
- Updates both `sessions[].label` and `sessionLabels[key]` in local state
- Explicitly renamed sessions are automatically protected from auto-label overwrite via the existing `session-label-hydration` backend-label check

**UI:**
- Inline rename input field replaces the session row when editing
- Confirm (Enter / ✓ button) and cancel (Escape / ✕ button) support
- `onBlur` auto-submits for convenience
- Added i18n strings for all 4 locales (en, zh, ja, ru)

## Validation

- All 666 unit tests pass locally (`npm test`)
- 16 pre-existing test suite failures are unrelated (missing `@testing-library/dom` peer dep)
- Specifically verified: `chat-session-actions`, `session-label-fetch`, `chat-store-session-label-fetch`, `stores`, `session-delete-route` — all pass
- Manually reviewed diff for surgical correctness

## Checklist

- [x] I ran relevant checks/tests locally.
- [x] I updated docs if behavior or interfaces changed.
- [x] I verified there are no unrelated changes in this PR.

---

> **Note:** There is a stale PR #307 that attempted the same feature but has been inactive since March 2026 with no reviews. This PR is a fresh implementation against the current codebase (which has since been refactored with modular chat store splits).