### PR TITLE
fix(chat): stabilize auto-scroll on tool runs; hide leaked NO_REPLY lines

### DIFF
--- a/src/hooks/use-stick-to-bottom-instant.ts
+++ b/src/hooks/use-stick-to-bottom-instant.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef } from "react";
+import { useCallback, useEffect, useRef } from "react";
 import { useStickToBottom } from "use-stick-to-bottom";
 
 /**
@@ -7,17 +7,74 @@ import { useStickToBottom } from "use-stick-to-bottom";
  *
  * @param resetKey - When this key changes, the scroll position will be reset to bottom instantly.
  *                   Typically this should be the conversation ID.
+ * @param active   - When true (e.g. an AI run is streaming), the scroll position is pinned to the
+ *                   very bottom instantly on every layout change — both growth and shrink — so
+ *                   tool-heavy runs that churn the layout don't produce erratic up/down jitter.
+ *                   Pinning is suppressed once the user manually scrolls up (`escapedFromLock`),
+ *                   so it never fights a user reading earlier history.
  */
-export function useStickToBottomInstant(resetKey?: string) {
+export function useStickToBottomInstant(resetKey?: string, active = false) {
   const lastKeyRef = useRef(resetKey);
   const hasInitializedRef = useRef(false);
 
   const result = useStickToBottom({
     initial: "instant",
-    resize: "smooth",
+    resize: "instant",
   });
 
-  const { scrollRef } = result;
+  const { scrollRef, contentRef, escapedFromLock } = result;
+
+  // Keep the latest "should we pin?" inputs available inside the ResizeObserver
+  // callback without re-creating the observer on every render.
+  const activeRef = useRef(active);
+  const escapedRef = useRef(escapedFromLock);
+  useEffect(() => {
+    activeRef.current = active;
+    escapedRef.current = escapedFromLock;
+  }, [active, escapedFromLock]);
+
+  // Instantly glue the scrollbar to the bottom. The library only animates on
+  // *positive* resizes and ignores *negative* ones; this covers both so the
+  // bar stays at the very bottom through promotion/demotion, graph collapse,
+  // and indicator swaps during a run.
+  const pinToBottom = useCallback(() => {
+    const scrollElement = scrollRef.current;
+    if (!scrollElement) return;
+    if (!activeRef.current || escapedRef.current) return;
+    scrollElement.scrollTop = scrollElement.scrollHeight;
+  }, [scrollRef]);
+
+  // Combine the library's content ref with our own ResizeObserver so we can
+  // react to every layout change (the library's observer only scrolls on
+  // growth).
+  const pinObserverRef = useRef<ResizeObserver | null>(null);
+  const combinedContentRef = useCallback(
+    (element: HTMLElement | null) => {
+      contentRef(element);
+
+      pinObserverRef.current?.disconnect();
+      pinObserverRef.current = null;
+
+      if (!element) return;
+
+      const observer = new ResizeObserver(() => {
+        pinToBottom();
+        // A trailing frame lets the library's own scroll settle first so our
+        // instant pin wins the final position.
+        requestAnimationFrame(() => pinToBottom());
+      });
+      observer.observe(element);
+      pinObserverRef.current = observer;
+    },
+    [contentRef, pinToBottom],
+  );
+
+  useEffect(() => {
+    return () => {
+      pinObserverRef.current?.disconnect();
+      pinObserverRef.current = null;
+    };
+  }, []);
 
   // Reset initialization when key changes
   useEffect(() => {
@@ -54,5 +111,5 @@ export function useStickToBottomInstant(resetKey?: string) {
     return () => cancelAnimationFrame(frame1);
   }, [scrollRef, resetKey]);
 
-  return result;
+  return { ...result, contentRef: combinedContentRef };
 }

--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -221,7 +221,7 @@ export function Chat() {
   const [graphExpandedOverrides, setGraphExpandedOverrides] = useState<Record<string, boolean>>({});
   const graphStepCache: Record<string, GraphStepCacheEntry> = graphStepCacheStore.get(currentSessionKey) ?? {};
   const minLoading = useMinLoading(loading && messages.length > 0);
-  const { contentRef, scrollRef, scrollToBottom, isAtBottom } = useStickToBottomInstant(currentSessionKey);
+  const { contentRef, scrollRef, scrollToBottom, isAtBottom } = useStickToBottomInstant(currentSessionKey, sending);
 
   // Load data when gateway is running.
   // When the store already holds messages for this session (i.e. the user

--- a/src/pages/Chat/message-utils.ts
+++ b/src/pages/Chat/message-utils.ts
@@ -180,6 +180,21 @@ export function isInternalAssistantReplyText(text: string): boolean {
   return /^(HEARTBEAT_OK|NO_REPLY)\s*$/i.test(text.trim());
 }
 
+/**
+ * Remove standalone internal sentinel lines (`NO_REPLY` / `HEARTBEAT_OK`) that
+ * the model sometimes appends *after* a real reply. The whole-message form is
+ * caught by `isInternalAssistantReplyText`; this covers the mixed case so the
+ * sentinel never leaks into the rendered chat bubble.
+ */
+export function stripInternalSentinelLines(text: string): string {
+  if (!text) return text;
+  return text
+    .replace(/(^|\n)[ \t]*(?:HEARTBEAT_OK|NO_REPLY)[ \t]*(?=\n|$)/gi, '$1')
+    .replace(/[ \t]+\n/g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
 /** Interim image-generation status the user should not see as a final answer. */
 export function isGeneratingStatusNarration(text: string): boolean {
   const trimmed = text.trim();
@@ -268,6 +283,9 @@ export function extractText(message: RawMessage | unknown): string {
     // path is surfaced as a clickable file card via `_attachedFiles`,
     // so leaving it inline would duplicate the artifact.
     result = stripAssistantMediaTags(result);
+    // Drop a trailing `NO_REPLY` / `HEARTBEAT_OK` the model may append after
+    // an otherwise-real answer.
+    result = stripInternalSentinelLines(result);
   }
 
   return result;
@@ -299,7 +317,7 @@ export function extractTextSegments(message: RawMessage | unknown): string[] {
 
   if (!isUser) {
     return segments
-      .map((segment) => stripAssistantMediaTags(segment))
+      .map((segment) => stripInternalSentinelLines(stripAssistantMediaTags(segment)))
       .filter((segment) => segment.length > 0);
   }
 

--- a/tests/e2e/chat-scroll-pin-bottom.spec.ts
+++ b/tests/e2e/chat-scroll-pin-bottom.spec.ts
@@ -1,0 +1,168 @@
+import { closeElectronApp, expect, getStableWindow, installIpcMocks, test } from './fixtures/electron';
+
+const SESSION_KEY = 'agent:main:main';
+const RUN_ID = 'run-pin-e2e';
+
+function stableStringify(value: unknown): string {
+  if (value == null || typeof value !== 'object') return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([key, entryValue]) => `${JSON.stringify(key)}:${stableStringify(entryValue)}`);
+  return `{${entries.join(',')}}`;
+}
+
+// Seed enough history that the scroll container overflows from the start.
+const seededHistory = Array.from({ length: 40 }, (_, idx) => ({
+  role: idx % 2 === 0 ? 'user' : 'assistant',
+  content: `Chat history message ${idx + 1}`,
+  timestamp: Date.now() + idx,
+}));
+
+// Build a streaming assistant text of `paragraphs` markdown paragraphs so each
+// delta grows the rendered height deterministically.
+function streamingText(paragraphs: number): string {
+  return Array.from({ length: paragraphs }, (_, idx) => `Streaming paragraph ${idx + 1}.`).join('\n\n');
+}
+
+test.describe('ClawX chat scroll pin-to-bottom during runs', () => {
+  test('keeps the scrollbar pinned to the bottom through oscillating tool-heavy streaming, and yields to manual scroll-up', async ({ launchElectronApp }) => {
+    const app = await launchElectronApp({ skipSetup: true });
+
+    try {
+      await installIpcMocks(app, {
+        gatewayStatus: { state: 'running', port: 18789, pid: 12345, gatewayReady: true },
+        gatewayRpc: {
+          // Null-arg fallbacks match regardless of the exact request payload.
+          [stableStringify(['sessions.list', null])]: {
+            success: true,
+            result: { sessions: [{ key: SESSION_KEY, displayName: 'main' }] },
+          },
+          [stableStringify(['chat.history', null])]: {
+            success: true,
+            result: { messages: seededHistory },
+          },
+          [stableStringify(['chat.send', null])]: {
+            success: true,
+            result: { runId: RUN_ID },
+          },
+        },
+        hostApi: {
+          [stableStringify(['/api/gateway/status', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { state: 'running', port: 18789, pid: 12345, gatewayReady: true },
+            },
+          },
+          [stableStringify(['/api/agents', 'GET'])]: {
+            ok: true,
+            data: {
+              status: 200,
+              ok: true,
+              json: { success: true, agents: [{ id: 'main', name: 'main' }] },
+            },
+          },
+        },
+      });
+
+      const page = await getStableWindow(app);
+      try {
+        await page.reload();
+      } catch (error) {
+        if (!String(error).includes('ERR_FILE_NOT_FOUND')) {
+          throw error;
+        }
+      }
+
+      await expect(page.getByTestId('main-layout')).toBeVisible();
+      await expect(page.getByText('Chat history message 40')).toBeVisible({ timeout: 30_000 });
+
+      const scrollContainer = page.getByTestId('chat-scroll-container');
+
+      // Emit a runtime streaming event for the active run.
+      const emitDelta = async (message: Record<string, unknown>) => {
+        await app.evaluate(({ BrowserWindow }, payload) => {
+          BrowserWindow.getAllWindows()[0]?.webContents.send('gateway:notification', {
+            method: 'agent',
+            params: {
+              runId: payload.runId,
+              sessionKey: payload.sessionKey,
+              data: { state: 'delta', message: payload.message },
+            },
+          });
+        }, { runId: RUN_ID, sessionKey: SESSION_KEY, message });
+      };
+
+      // Assert the scrollbar is glued to the very bottom (within a small epsilon
+      // that tolerates sub-pixel rounding).
+      const expectPinnedToBottom = async () => {
+        await expect
+          .poll(
+            async () =>
+              scrollContainer.evaluate((el) => {
+                const element = el as HTMLElement;
+                return Math.round(element.scrollHeight - element.clientHeight - element.scrollTop);
+              }),
+            { timeout: 5_000 },
+          )
+          .toBeLessThanOrEqual(8);
+      };
+
+      // Start a run so pinning becomes active (sending === true).
+      await expect(page.getByTestId('chat-composer-input')).toBeEnabled({ timeout: 30_000 });
+      await page.getByTestId('chat-composer-input').fill('do a multi-tool task');
+      await page.getByTestId('chat-composer-send').click();
+      await expect(page.getByTestId('chat-composer-send')).toHaveAttribute('title', 'Stop');
+
+      // Growing text stream -> height keeps increasing; bar must stay at bottom.
+      await emitDelta({ role: 'assistant', content: [{ type: 'text', text: streamingText(3) }] });
+      await expectPinnedToBottom();
+
+      await emitDelta({ role: 'assistant', content: [{ type: 'text', text: streamingText(8) }] });
+      await expectPinnedToBottom();
+
+      // Tool round -> layout oscillates (bubble/graph/tool-status churn); the
+      // bar must still snap to the bottom rather than jitter upward.
+      await emitDelta({
+        role: 'assistant',
+        content: [
+          { type: 'text', text: streamingText(8) },
+          { type: 'toolCall', id: 'tool-1', name: 'exec', arguments: { command: 'ls -la' } },
+        ],
+      });
+      await expectPinnedToBottom();
+
+      // Back to text growth after the tool round.
+      await emitDelta({ role: 'assistant', content: [{ type: 'text', text: streamingText(14) }] });
+      await expectPinnedToBottom();
+
+      // Manual scroll-up while the run is live: pinning must yield to the user
+      // and surface the "scroll to latest" affordance.
+      await scrollContainer.evaluate((el) => {
+        const element = el as HTMLElement;
+        element.scrollTop = 0;
+        element.dispatchEvent(new Event('scroll', { bubbles: true }));
+      });
+
+      const jumpButton = page.getByTestId('chat-scroll-to-latest');
+      await expect(jumpButton).toBeVisible();
+
+      // Further growth must NOT yank the user back down while they've escaped.
+      await emitDelta({ role: 'assistant', content: [{ type: 'text', text: streamingText(20) }] });
+      await expect(jumpButton).toBeVisible();
+      const distanceFromBottom = await scrollContainer.evaluate((el) => {
+        const element = el as HTMLElement;
+        return Math.round(element.scrollHeight - element.clientHeight - element.scrollTop);
+      });
+      expect(distanceFromBottom).toBeGreaterThan(8);
+
+      // Clicking the affordance returns to the bottom.
+      await jumpButton.click();
+      await expect(jumpButton).toBeHidden({ timeout: 10_000 });
+    } finally {
+      await closeElectronApp(app);
+    }
+  });
+});

--- a/tests/unit/chat-internal-sentinel-display.test.ts
+++ b/tests/unit/chat-internal-sentinel-display.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { extractText, extractTextSegments, stripInternalSentinelLines } from '@/pages/Chat/message-utils';
+
+describe('internal sentinel display cleanup', () => {
+  it('drops a trailing NO_REPLY appended after a real reply', () => {
+    const text = [
+      '今天杭州闷热潮湿，出门带把伞比较稳妥～',
+      '',
+      '如有需要我进一步深挖某条 AI 新闻的详情，可以告诉我！',
+      '',
+      'NO_REPLY',
+    ].join('\n');
+
+    expect(extractText({ role: 'assistant', content: text })).toBe(
+      ['今天杭州闷热潮湿，出门带把伞比较稳妥～', '', '如有需要我进一步深挖某条 AI 新闻的详情，可以告诉我！'].join('\n'),
+    );
+  });
+
+  it('drops a trailing HEARTBEAT_OK and is case-insensitive', () => {
+    const text = 'All done.\nheartbeat_ok';
+    expect(extractText({ role: 'assistant', content: text })).toBe('All done.');
+  });
+
+  it('still returns empty for a whole-message sentinel', () => {
+    expect(extractText({ role: 'assistant', content: 'NO_REPLY' })).toBe('');
+  });
+
+  it('does not strip the token when embedded mid-sentence', () => {
+    const text = 'The constant NO_REPLY signals a skipped turn.';
+    expect(extractText({ role: 'assistant', content: text })).toBe(text);
+  });
+
+  it('removes sentinel-only segments from extractTextSegments', () => {
+    const message = {
+      role: 'assistant',
+      content: [
+        { type: 'text', text: 'Here is the weather summary.' },
+        { type: 'text', text: 'NO_REPLY' },
+      ],
+    };
+    expect(extractTextSegments(message)).toEqual(['Here is the weather summary.']);
+  });
+
+  it('stripInternalSentinelLines leaves clean text untouched', () => {
+    expect(stripInternalSentinelLines('Hello world')).toBe('Hello world');
+  });
+});


### PR DESCRIPTION


## Summary

stabilize auto-scroll on tool runs; hide leaked NO_REPLY lines

## Related Issue(s)

 Closes #1079 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [ ] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [ ] I verified there are no unrelated changes in this PR.
