### PR TITLE
fix: preserve custom provider model capabilities on switch

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -131,6 +131,7 @@ Skills ページでは OpenClaw の複数ソース（管理ディレクトリ、
 複数のAIプロバイダー（OpenAI、Anthropicなど）に接続でき、資格情報はシステムのネイティブキーチェーンに安全に保存されます。OpenAI は API キーとブラウザ OAuth（Codex サブスクリプション）の両方に対応しています。
 開発者モードでは、専用の Image Generation ページで、独立した OpenAI 互換の画像生成エンドポイント（Base URL、API キー、`gpt-image-2` などのモデル名）を設定でき、画像生成だけ専用の `/v1/images/generations` サービスを使い、チャットは通常の OpenAI Provider のまま継続できます。
 OpenAI-compatible ゲートウェイを **Custom プロバイダー** で使う場合、**設定 → AI Providers → Provider 編集** でカスタム `User-Agent` を設定でき、互換性が必要なエンドポイントで有効です。
+プロバイダーの編集や切り替え時、ClawX は `input: ["text", "image"]` など既存のモデル単位の能力メタデータを保持します。新しく選択した Custom プロバイダーのモデルには OpenClaw onboarding と同等の画像入力推論を適用し、不明なモデルはテキスト専用として扱います。
 互換ゲートウェイで `/models` が認証以外の理由で使えない場合、ClawX は API キー検証時に軽量な `/chat/completions` または `/responses` プローブへ自動フォールバックします。
 
 ### 🌙 アダプティブテーマ

--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Environment variables for bundled search skills:
 Connect to multiple AI providers (OpenAI, Anthropic, and more) with credentials stored securely in your system's native keychain. OpenAI supports both API key and browser OAuth (Codex subscription) sign-in.
 In developer mode, the dedicated Image Generation page supports an independent OpenAI-compatible image-generation endpoint (Base URL, API key, and model name such as `gpt-image-2`) so image generation can use a dedicated `/v1/images/generations` service while chat continues using the normal OpenAI provider.
 For **Custom** providers used with OpenAI-compatible gateways, you can set a custom `User-Agent` in **Settings → AI Providers → Edit Provider** for compatibility-sensitive endpoints.
+When you edit or switch providers, ClawX preserves existing per-model capability metadata such as `input: ["text", "image"]`. Newly selected Custom-provider models use OpenClaw onboarding-compatible image-input inference, with unknown models defaulting to text-only.
 When a compatible gateway rejects `/models` for non-auth reasons, ClawX automatically falls back to a lightweight `/chat/completions` or `/responses` probe during API key validation.
 
 ### 🌙 Adaptive Theming

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -132,6 +132,7 @@ Skills 页面可展示来自多个 OpenClaw 来源的技能（托管目录、wor
 连接多个 AI 供应商（OpenAI、Anthropic 等），凭证安全存储在系统原生密钥链中。OpenAI 同时支持 API Key 与浏览器 OAuth（Codex 订阅）登录。
 在开发者模式下，独立的“图像生成”页面支持配置 OpenAI 兼容生图端点（Base URL、API Key 和模型名，例如 `gpt-image-2`），生图请求会走专用的 `/v1/images/generations` 服务，聊天仍继续使用正常的 OpenAI Provider。
 如果你通过 **自定义（Custom）Provider** 对接 OpenAI-compatible 网关，可以在 **设置 → AI Providers → 编辑 Provider** 中配置自定义 `User-Agent`，以提高兼容性。
+编辑或切换 Provider 时，ClawX 会保留已有的模型级能力元数据，例如 `input: ["text", "image"]`。新选择的自定义 Provider 模型会使用与 OpenClaw onboarding 一致的图片输入能力推断；未知模型默认按纯文本模型处理。
 如果兼容网关的 `/models` 因非鉴权原因不可用，ClawX 会在校验 API Key 时自动降级为轻量的 `/chat/completions` 或 `/responses` 探测。
 
 ### 🌙 自适应主题

--- a/electron/shared/providers/model-capabilities.ts
+++ b/electron/shared/providers/model-capabilities.ts
@@ -1,0 +1,19 @@
+export type ModelInputModality = 'text' | 'image';
+
+/**
+ * Mirrors OpenClaw 2026.5.20 custom-provider onboarding inference.
+ * Unknown models use the same conservative text-only fallback as non-interactive onboarding.
+ */
+export function inferCustomModelInputModalities(modelId: string): ModelInputModality[] {
+  const normalized = modelId.trim().toLowerCase();
+  const supportsImageInput = (
+    /\b(?:gpt-4o|gpt-4\.1|gpt-[5-9]|o[134])\b/.test(normalized)
+    || /\bclaude-(?:3|4|sonnet|opus|haiku)\b/.test(normalized)
+    || /\bgemini\b/.test(normalized)
+    || /\b(?:qwen[\w.-]*-?vl|qwen-vl)\b/.test(normalized)
+    || /\b(?:vision|llava|pixtral|internvl|mllama|minicpm-v|glm-4v)\b/.test(normalized)
+    || /(?:^|[-_/])vl(?:[-_/]|$)/.test(normalized)
+  );
+
+  return supportsImageInput ? ['text', 'image'] : ['text'];
+}

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -34,6 +34,7 @@ import {
   OPENCLAW_API_PROTOCOLS,
   assertValidApiProtocol,
 } from '../shared/providers/types';
+import { inferCustomModelInputModalities } from '../shared/providers/model-capabilities';
 import {
   CLAWX_OPENAI_IMAGE_DEFAULT_MODEL,
   CLAWX_OPENAI_IMAGE_PROVIDER_KEY,
@@ -1221,6 +1222,7 @@ type ProviderEntryBuildOptions = {
   modelIds?: string[];
   includeRegistryModels?: boolean;
   mergeExistingModels?: boolean;
+  inferRuntimeModelInputs?: boolean;
 };
 
 function normalizeModelRef(provider: string, modelOverride?: string): string | undefined {
@@ -1515,7 +1517,13 @@ function upsertOpenClawProviderEntry(
   const registryModels = options.includeRegistryModels
     ? ((getProviderConfig(provider)?.models ?? []).map((m) => ({ ...m })) as Array<Record<string, unknown>>)
     : [];
-  const runtimeModels = (options.modelIds ?? []).map((id) => ({ id, name: id }));
+  const runtimeModels = (options.modelIds ?? []).map((id) => ({
+    id,
+    name: id,
+    ...(options.inferRuntimeModelInputs
+      ? { input: inferCustomModelInputModalities(id) }
+      : {}),
+  }));
   let mergedModels = mergeProviderModels(registryModels, existingModels, runtimeModels);
   if (options.api === 'anthropic-messages') {
     mergedModels = mergedModels.map((model) => ensureAnthropicMessagesModelEntry(model, provider, existingProvider));
@@ -1686,6 +1694,8 @@ export async function syncProviderConfigToOpenClaw(
         apiKeyEnv: override.apiKeyEnv,
         headers: override.headers,
         modelIds: modelId ? [modelId] : [],
+        mergeExistingModels: true,
+        inferRuntimeModelInputs: true,
       });
     }
 
@@ -1875,6 +1885,8 @@ export async function setOpenClawDefaultModelWithOverride(
         headers: override.headers,
         authHeader: override.authHeader,
         modelIds: [modelId, ...fallbackModelIds],
+        mergeExistingModels: true,
+        inferRuntimeModelInputs: true,
       });
     }
 

--- a/harness/specs/rules/provider-model-metadata-preservation.md
+++ b/harness/specs/rules/provider-model-metadata-preservation.md
@@ -1,0 +1,18 @@
+---
+id: provider-model-metadata-preservation
+title: Provider Model Metadata Preservation
+type: ai-coding-rule
+appliesTo:
+  - gateway-backend-communication
+---
+
+When ClawX rewrites an explicit `models.providers.*` entry, existing model rows
+must be merged by exact model ID instead of reconstructed from only `id` and
+`name`.
+
+All fields on an existing matching row are user/runtime-owned metadata and must
+survive provider save, update, default-switch, and reload flows unless a task
+explicitly owns that field.
+
+New model IDs may receive deterministic capability defaults, but metadata from a
+different model ID must never be copied onto them.

--- a/harness/specs/scenarios/gateway-backend-communication.md
+++ b/harness/specs/scenarios/gateway-backend-communication.md
@@ -32,6 +32,7 @@ requiredRules:
   - channel-plugin-migration-guards
   - capability-owner-resolution
   - active-config-guards
+  - provider-model-metadata-preservation
   - comms-regression
   - docs-sync
 forbiddenPatterns:

--- a/harness/specs/tasks/preserve-provider-model-metadata.md
+++ b/harness/specs/tasks/preserve-provider-model-metadata.md
@@ -1,0 +1,65 @@
+---
+id: preserve-provider-model-metadata
+title: Preserve explicit provider model capabilities during runtime sync
+scenario: gateway-backend-communication
+taskType: runtime-bridge
+intent: Prevent ClawX provider save, update, and default-switch flows from deleting user-authored models.providers model metadata, while giving newly selected custom-provider models the same image-input inference used by OpenClaw onboarding.
+touchedAreas:
+  - docs/superpowers/specs/2026-06-09-provider-model-metadata-preservation-design.md
+  - docs/superpowers/plans/2026-06-09-provider-model-metadata-preservation.md
+  - harness/specs/tasks/preserve-provider-model-metadata.md
+  - harness/specs/rules/provider-model-metadata-preservation.md
+  - harness/specs/scenarios/gateway-backend-communication.md
+  - electron/shared/providers/model-capabilities.ts
+  - electron/utils/openclaw-auth.ts
+  - tests/unit/provider-model-capabilities.test.ts
+  - tests/unit/openclaw-auth.test.ts
+  - README.md
+  - README.zh-CN.md
+  - README.ja-JP.md
+expectedUserBehavior:
+  - Switching away from and back to a custom provider keeps manually configured model input capabilities and other model-level metadata.
+  - Changing a custom provider to a known vision model such as Claude or Gemini writes image-capable input metadata without copying metadata from the previous model ID.
+  - Changing to an unknown model creates a conservative text-only model row instead of silently claiming image support.
+requiredProfiles:
+  - fast
+  - comms
+requiredRules:
+  - active-config-guards
+  - backend-communication-boundary
+  - provider-model-metadata-preservation
+  - renderer-main-boundary
+requiredTests:
+  - tests/unit/provider-model-capabilities.test.ts
+  - tests/unit/openclaw-auth.test.ts
+acceptance:
+  - Explicit provider synchronization merges existing models.providers model rows by exact model ID and preserves all fields on existing rows.
+  - Newly created runtime model rows receive input metadata matching OpenClaw custom-provider onboarding inference.
+  - Metadata from one model ID is never copied to a different model ID.
+  - Renderer transport boundaries remain unchanged.
+  - Focused tests, harness validation, communication replay, and communication compare pass.
+docs:
+  required: true
+---
+
+## Background
+
+ClawX explicit-provider sync paths rebuild model rows from the currently selected
+model ID. Before this task, those paths replaced rich rows such as
+`{ id, name, input, reasoning, contextWindow, maxTokens, cost }` with
+`{ id, name }`. OpenClaw then treated previously image-capable custom models as
+text-only.
+
+## Scope
+
+- Preserve existing explicit provider model rows during save, update, and
+  default-provider switch.
+- Mirror OpenClaw onboarding's custom-model image-input inference for new model
+  IDs.
+- Add regression tests and translated documentation.
+
+## Out Of Scope
+
+- New renderer settings or modality controls.
+- Copying capability metadata between different model IDs.
+- Per-agent `models.json` reconciliation.

--- a/tests/unit/openclaw-auth.test.ts
+++ b/tests/unit/openclaw-auth.test.ts
@@ -864,6 +864,73 @@ describe('syncProviderConfigToOpenClaw', () => {
     await rm(testUserData, { recursive: true, force: true });
   });
 
+  it('preserves existing custom-provider model metadata during provider sync', async () => {
+    await writeOpenClawJson({
+      models: {
+        providers: {
+          'custom-example': {
+            baseUrl: 'https://example.com/v1',
+            api: 'openai-completions',
+            models: [
+              {
+                id: 'model-a',
+                name: 'Model A',
+                input: ['text', 'image'],
+                reasoning: true,
+                contextWindow: 200000,
+                customField: 'keep-me',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const { syncProviderConfigToOpenClaw } = await import('@electron/utils/openclaw-auth');
+    await syncProviderConfigToOpenClaw('custom-example', 'model-a', {
+      baseUrl: 'https://example.com/v1',
+      api: 'openai-completions',
+    });
+
+    const result = await readOpenClawJson();
+    const providers = (result.models as Record<string, unknown>).providers as Record<string, unknown>;
+    const entry = providers['custom-example'] as Record<string, unknown>;
+    const models = entry.models as Array<Record<string, unknown>>;
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'model-a',
+        name: 'Model A',
+        input: ['text', 'image'],
+        reasoning: true,
+        contextWindow: 200000,
+        customField: 'keep-me',
+      }),
+    ]);
+  });
+
+  it('infers text-only input for a new unknown custom-provider model', async () => {
+    await writeOpenClawJson({ models: { providers: {} } });
+
+    const { syncProviderConfigToOpenClaw } = await import('@electron/utils/openclaw-auth');
+    await syncProviderConfigToOpenClaw('custom-example', 'private-model-x', {
+      baseUrl: 'https://example.com/v1',
+      api: 'openai-completions',
+    });
+
+    const result = await readOpenClawJson();
+    const providers = (result.models as Record<string, unknown>).providers as Record<string, unknown>;
+    const entry = providers['custom-example'] as Record<string, unknown>;
+    const models = entry.models as Array<Record<string, unknown>>;
+
+    expect(models).toEqual([
+      expect.objectContaining({
+        id: 'private-model-x',
+        input: ['text'],
+      }),
+    ]);
+  });
+
   it('uses legacy minimax-portal-auth plugin registration when only the legacy plugin exists', async () => {
     await writeOpenClawJson({
       models: { providers: {} },
@@ -1004,6 +1071,112 @@ describe('syncProviderConfigToOpenClaw', () => {
 
     expect(load).toEqual(['/tmp/custom-plugin.js']);
     expect(moonshot.baseUrl).toBe('https://api.moonshot.cn/v1');
+  });
+});
+
+describe('setOpenClawDefaultModelWithOverride model metadata', () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.restoreAllMocks();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+  });
+
+  it('preserves old rows and infers image input for a newly selected vision model', async () => {
+    await writeOpenClawJson({
+      models: {
+        providers: {
+          'custom-example': {
+            baseUrl: 'https://example.com/v1',
+            api: 'openai-completions',
+            models: [
+              {
+                id: 'model-a',
+                name: 'Model A',
+                input: ['text', 'image'],
+                customField: 'keep-me',
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const { setOpenClawDefaultModelWithOverride } = await import('@electron/utils/openclaw-auth');
+    await setOpenClawDefaultModelWithOverride(
+      'custom-example',
+      'custom-example/claude-opus-4-6',
+      {
+        baseUrl: 'https://example.com/v1',
+        api: 'openai-completions',
+      },
+    );
+
+    const result = await readOpenClawJson();
+    const providers = (result.models as Record<string, unknown>).providers as Record<string, unknown>;
+    const entry = providers['custom-example'] as Record<string, unknown>;
+    const models = entry.models as Array<Record<string, unknown>>;
+    const oldModel = models.find((model) => model.id === 'model-a');
+    const newModel = models.find((model) => model.id === 'claude-opus-4-6');
+
+    expect(oldModel).toEqual(expect.objectContaining({
+      input: ['text', 'image'],
+      customField: 'keep-me',
+    }));
+    expect(newModel).toEqual(expect.objectContaining({
+      input: ['text', 'image'],
+    }));
+    expect(newModel).not.toHaveProperty('customField');
+  });
+
+  it('preserves model input metadata after switching to another provider and back', async () => {
+    await writeOpenClawJson({
+      models: {
+        providers: {
+          'custom-a': {
+            baseUrl: 'https://a.example.com/v1',
+            api: 'openai-completions',
+            models: [
+              {
+                id: 'model-a',
+                name: 'Model A',
+                input: ['text', 'image'],
+              },
+            ],
+          },
+          'custom-b': {
+            baseUrl: 'https://b.example.com/v1',
+            api: 'openai-completions',
+            models: [
+              {
+                id: 'model-b',
+                name: 'Model B',
+                input: ['text'],
+              },
+            ],
+          },
+        },
+      },
+    });
+
+    const { setOpenClawDefaultModelWithOverride } = await import('@electron/utils/openclaw-auth');
+    await setOpenClawDefaultModelWithOverride('custom-b', 'custom-b/model-b', {
+      baseUrl: 'https://b.example.com/v1',
+      api: 'openai-completions',
+    });
+    await setOpenClawDefaultModelWithOverride('custom-a', 'custom-a/model-a', {
+      baseUrl: 'https://a.example.com/v1',
+      api: 'openai-completions',
+    });
+
+    const result = await readOpenClawJson();
+    const providers = (result.models as Record<string, unknown>).providers as Record<string, unknown>;
+    const providerA = providers['custom-a'] as Record<string, unknown>;
+    const models = providerA.models as Array<Record<string, unknown>>;
+
+    expect(models.find((model) => model.id === 'model-a')).toEqual(expect.objectContaining({
+      input: ['text', 'image'],
+    }));
   });
 });
 

--- a/tests/unit/provider-model-capabilities.test.ts
+++ b/tests/unit/provider-model-capabilities.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+
+import { inferCustomModelInputModalities } from '@electron/shared/providers/model-capabilities';
+
+describe('inferCustomModelInputModalities', () => {
+  it.each([
+    'gpt-4o',
+    'claude-opus-4-6',
+    'gemini-3-flash',
+    'qwen2.5-vl',
+    'glm-4v',
+  ])('marks known vision model %s as image-capable', (modelId) => {
+    expect(inferCustomModelInputModalities(modelId)).toEqual(['text', 'image']);
+  });
+
+  it.each([
+    'deepseek-chat',
+    'kimi-k2.6',
+    'qwen3.6-plus',
+    'unknown-private-model',
+  ])('uses conservative text-only input for %s', (modelId) => {
+    expect(inferCustomModelInputModalities(modelId)).toEqual(['text']);
+  });
+});


### PR DESCRIPTION
## Summary

fix: preserve custom provider model capabilities on switch

## Related Issue(s)

 Closes #1105 

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation
- [ ] Refactor
- [ ] Other

## Validation

<!-- How did you verify this change? -->

## Checklist

- [ ] I ran relevant checks/tests locally.
- [ ] I updated docs if behavior or interfaces changed.
- [ ] I verified there are no unrelated changes in this PR.
