### PR TITLE
fix: guard against undefined updatedAt when sorting provider accounts

### DIFF
--- a/src/lib/model-options.ts
+++ b/src/lib/model-options.ts
@@ -99,7 +99,7 @@ export function buildRuntimeProviderOptions(
     .sort((left, right) => {
       if (left.id === providerDefaultAccountId) return -1;
       if (right.id === providerDefaultAccountId) return 1;
-      return right.updatedAt.localeCompare(left.updatedAt);
+      return (right.updatedAt ?? '').localeCompare(left.updatedAt ?? '');
     });
 
   const deduped = new Map<string, RuntimeProviderOption>();
@@ -142,7 +142,7 @@ export function buildConfiguredModelOptions(
     .sort((left, right) => {
       if (left.id === providerDefaultAccountId) return -1;
       if (right.id === providerDefaultAccountId) return 1;
-      return right.updatedAt.localeCompare(left.updatedAt);
+      return (right.updatedAt ?? '').localeCompare(left.updatedAt ?? '');
     });
 
   const deduped = new Map<string, ConfiguredModelOption>();

--- a/src/lib/provider-accounts.ts
+++ b/src/lib/provider-accounts.ts
@@ -189,7 +189,7 @@ export function buildProviderListItems(
       .sort((left, right) => {
         if (left.account.id === defaultAccountId) return -1;
         if (right.account.id === defaultAccountId) return 1;
-        return right.account.updatedAt.localeCompare(left.account.updatedAt);
+        return (right.account.updatedAt ?? '').localeCompare(left.account.updatedAt ?? '');
       });
   }
 


### PR DESCRIPTION
## Problem

`buildConfiguredModelOptions` and `buildRuntimeProviderOptions` (in `src/lib/model-options.ts`), and the account-list builder in `src/lib/provider-accounts.ts`, sort accounts with:

```ts
return right.updatedAt.localeCompare(left.updatedAt);
```

This assumes every `ProviderAccount.updatedAt` is a string. But `listProviderAccounts()` returns the persisted `providerAccounts` map verbatim — no normalization / backfill:

```ts
export async function listProviderAccounts(): Promise<ProviderAccount[]> {
  const store = await getClawXProviderStore();
  const accounts = store.get('providerAccounts') as Record<string, ProviderAccount> | undefined;
  return Object.values(accounts ?? {});
}
```

So if a single persisted account is missing `updatedAt` (a record written by an external tool, an import/migration, or a hand-edited `clawx-providers.json`), `updatedAt` is `undefined` at runtime. As soon as there are ≥2 qualifying accounts, `Array.sort` invokes the comparator and the **entire renderer crashes** at the error boundary:

```
TypeError: Cannot read properties of undefined (reading 'localeCompare')
    at Array.sort (<anonymous>)
    at <useMemo>  // buildConfiguredModelOptions / buildRuntimeProviderOptions
```

This takes down both the **Chat** page (model picker) and the **Agents** page — the user only sees "Something went wrong", and the Reload button doesn't help because the malformed record is still on disk.

## Fix

Make the three `updatedAt` comparators null-safe:

```ts
return (right.updatedAt ?? '').localeCompare(left.updatedAt ?? '');
```

- `src/lib/model-options.ts` (×2 — `buildRuntimeProviderOptions`, `buildConfiguredModelOptions`)
- `src/lib/provider-accounts.ts` (×1)

An empty string sorts such a record to the end (reasonable for an account with no known update time), and a single malformed record can no longer crash the whole app.

## Repro

1. Configure two provider accounts.
2. In `%APPDATA%/ClawX/clawx-providers.json`, remove the `updatedAt` field from one entry under `providerAccounts`.
3. Restart ClawX → "Something went wrong" / `localeCompare` crash.

With this patch, ClawX loads normally.

> Note: a defense-in-depth follow-up would be to normalize/backfill `createdAt`/`updatedAt` in `listProviderAccounts()` (or `providerConfigToAccount`) so malformed persisted records are healed on read. This PR only fixes the crash itself, which is the minimal change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
