### PR TITLE
fix(providers): wrap provider apiKey env ref in ${} so OpenClaw expands it

### DIFF
--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -1845,7 +1845,12 @@ function upsertOpenClawProviderEntry(
   if (options.api === 'anthropic-messages') {
     ensureAnthropicMessagesProviderDefaults(nextProvider, provider);
   }
-  if (options.apiKeyEnv) nextProvider.apiKey = options.apiKeyEnv;
+  // OpenClaw expands `${ENV_VAR}` placeholders inside config string values
+  // (the legacy `apiKeyEnv` field was removed in the 2026.6.x runtime). The
+  // value must be wrapped in `${...}`; a bare env name is treated as a literal
+  // string and sent verbatim as the bearer token, so every model call to that
+  // provider fails with 401 Invalid token while the real key sits unused in env.
+  if (options.apiKeyEnv) nextProvider.apiKey = '${' + options.apiKeyEnv + '}';
   if (options.headers !== undefined) {
     if (Object.keys(options.headers).length > 0) {
       nextProvider.headers = options.headers;


### PR DESCRIPTION
## Problem

App-internal chat returns **`401 Invalid token`** for every env-keyed (non-OAuth) provider — openai, deepseek, openrouter, minimax, etc.

OpenClaw's 2026.6.x runtime **removed the `apiKeyEnv` config field** and now expands `${ENV_VAR}` placeholders inside config string values instead (`docs/help/environment.md`, e.g. `apiKey: "${VERCEL_GATEWAY_API_KEY}"`).

But `upsertOpenClawProviderEntry` still writes the **bare env name** into `provider.apiKey`:

```ts
if (options.apiKeyEnv) nextProvider.apiKey = options.apiKeyEnv; // -> "OPENAI_API_KEY"
```

So OpenClaw sends the literal string `OPENAI_API_KEY` as the bearer token and 401s, while the real key — correctly injected into the gateway process env by the launcher — is never used. This is easy to miss: `curl`-ing the provider with the real key succeeds; only the in-app path (which relies on `${}` substitution) breaks.

## Fix

```ts
if (options.apiKeyEnv) nextProvider.apiKey = '${' + options.apiKeyEnv + '}';
```

## Verification

Packaged + launched the app:
- `openclaw.json` now writes `apiKey: "${OPENAI_API_KEY}"`
- gateway prewarm `provider-auth-sync` / `models.authStatus` / `models.list` all OK (previously 401)
- real `chat.send` -> model streamed a reply, zero 401

No test changes needed: the existing `*_API_KEY` strings in the suite are `writeOpenClawJson` inputs, not assertions on the upsert output.