### PR TITLE
Add LAH external Gateway safe mode for isolated ClawX Phase 1

### DIFF
--- a/docs/operator/CLAWX_PHASE1_ISOLATED_EXTERNAL_GATEWAY_OPERATOR_PACKET.md
+++ b/docs/operator/CLAWX_PHASE1_ISOLATED_EXTERNAL_GATEWAY_OPERATOR_PACKET.md
@@ -1,0 +1,89 @@
+# CLAWX Phase 1 Isolated External Gateway Operator Packet
+
+## Purpose
+Prepare ClawX for a future isolated Phase 1 run that attaches to an existing LAH Gateway instead of spawning or mutating a production OpenClaw runtime.
+
+## What Changed
+- Added explicit external Gateway mode.
+- Added LAH safe-mode runtime gates for telemetry, update checks, OAuth, provider validation, external URL opening, and connectivity probes.
+- Added isolated userData and HOME-aware path resolution.
+- Added offline tests for the new runtime gates and safety boundaries.
+
+## Exact Env Vars
+Use these for future isolated Phase 1 runs:
+
+```bash
+export LAH_SAFE_MODE=1
+export HOME=/home/deploy/lah-stack-runtime/clawx-phase1/home
+export CLAWX_USER_DATA_DIR=/home/deploy/lah-stack-runtime/clawx-phase1/userData
+export CLAWX_EXTERNAL_GATEWAY_URL=ws://127.0.0.1:4000/gateway
+export CLAWX_GATEWAY_SPAWN_ENABLED=0
+export CLAWX_GATEWAY_KILL_ON_CONFLICT=0
+export CLAWX_OPENCLAW_CONFIG_MUTATION=0
+export CLAWX_TELEMETRY_ENABLED=0
+export CLAWX_UPDATE_CHECKS_ENABLED=0
+export CLAWX_PROVIDER_VALIDATION_ENABLED=0
+export CLAWX_OAUTH_ENABLED=0
+export CLAWX_EXTERNAL_URL_OPENING_ENABLED=0
+export CLAWX_CONNECTIVITY_PROBE_ENABLED=0
+```
+
+## Exact Isolated Paths
+- `/home/deploy/lah-stack-runtime/clawx-phase1/home`
+- `/home/deploy/lah-stack-runtime/clawx-phase1/userData`
+- `/home/deploy/lah-stack-runtime/clawx-phase1/logs`
+- `/home/deploy/lah-stack-runtime/clawx-phase1/home/.openclaw`
+
+## Forbidden Production Paths
+- `/home/deploy/.openclaw`
+- `/home/deploy/.hermes`
+- any production provider secret store
+- any production ClawX or OpenClaw runtime directory
+
+## Allowed Future Commands
+- `git status`
+- `git diff`
+- offline unit tests
+- static type checks that do not install dependencies
+- isolated-path smoke checks that do not launch Electron, Gateway, or OpenClaw
+
+## Forbidden Commands
+- `pnpm install`
+- `npm install`
+- `pnpm run init`
+- Electron launch
+- OpenClaw launch
+- Gateway launch
+- any network-dependent check
+- any provider-secret import or migration
+- any command that writes to production `~/.openclaw`
+
+## Rollback Plan
+- Remove only the isolated runtime directory tree if it was created for testing.
+- Do not delete production `~/.openclaw`.
+- Do not delete production credentials.
+- Do not delete production agents.
+- Do not delete production skills or extensions unless they were explicitly created inside the isolated ClawX env.
+- Revert the branch with git if the patch must be removed.
+
+## Tests Run
+- Offline unit tests only.
+- No runtime launches.
+- No provider or network checks.
+
+## Tests Not Run and Why
+- Electron launch: forbidden by mission scope.
+- Gateway launch: forbidden by mission scope.
+- OpenClaw launch: forbidden by mission scope.
+- Install scripts: forbidden by mission scope.
+- Network checks: forbidden by mission scope.
+
+## Residual Risks
+- External Gateway support is still a pre-Phase 1 bridge, not a full production isolation boundary.
+- OpenClaw secret storage remains a migration risk until keychain-backed storage exists.
+- Install-chain verification is still pending checksum/signature hardening.
+
+## Next BR Recommendation
+- Hardening BR for install-chain verification and deterministic offline artifact handling.
+- Secret-storage BR for keychain-backed provider secrets.
+- Follow-up BR for any remaining direct OpenClaw runtime coupling discovered during Phase 1.

--- a/docs/superpowers/plans/2026-07-04-clawx-external-gateway-safe-mode.md
+++ b/docs/superpowers/plans/2026-07-04-clawx-external-gateway-safe-mode.md
@@ -1,0 +1,143 @@
+# CLAWX External Gateway Safe Mode Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a FastSafe, offline-only execution mode that attaches ClawX to an external LAH Gateway, disables config mutation and network-adjacent behaviors in safe mode, and keeps default behavior unchanged.
+
+**Architecture:** Introduce a small runtime-flags helper for env-driven safe-mode decisions, then thread that into the gateway manager, ws client, config mutation helpers, telemetry, updater, provider validation, and external-link entry points. Keep the default path intact, but bypass spawn/kill/config-write logic when safe mode or external gateway mode is active.
+
+**Tech Stack:** Electron, TypeScript, Vitest, zustand, ws.
+
+---
+
+### Task 1: Add runtime flags and isolated-path helpers
+
+**Files:**
+- Create: `electron/utils/runtime-flags.ts`
+- Modify: `electron/utils/config.ts`
+- Modify: `electron/utils/paths.ts`
+- Modify: `electron/main/index.ts`
+- Modify: `electron/utils/store.ts`
+- Modify: `shared/host-api/contract.ts`
+- Modify: `src/stores/settings.ts`
+- Modify: `src/stores/gateway.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests that assert `LAH_SAFE_MODE=1` resolves safe-mode gates, `CLAWX_USER_DATA_DIR` is honored by the runtime path helper, and the settings contract exposes the new external-gateway fields.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/runtime-flags.test.ts tests/unit/paths.test.ts tests/unit/settings-store.test.ts`
+Expected: FAIL because the helper and fields do not exist yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Implement env parsing, user-data resolution, and new settings defaults/contract fields without changing default runtime behavior.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/runtime-flags.test.ts tests/unit/paths.test.ts tests/unit/settings-store.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/utils/runtime-flags.ts electron/utils/config.ts electron/utils/paths.ts electron/main/index.ts electron/utils/store.ts shared/host-api/contract.ts src/stores/settings.ts src/stores/gateway.ts tests/unit/runtime-flags.test.ts tests/unit/paths.test.ts tests/unit/settings-store.test.ts
+git commit -m "feat: add LAH safe-mode runtime flags"
+```
+
+### Task 2: Make Gateway startup honor external mode
+
+**Files:**
+- Modify: `electron/gateway/manager.ts`
+- Modify: `electron/gateway/ws-client.ts`
+- Modify: `electron/gateway/supervisor.ts`
+- Modify: `electron/gateway/startup-orchestrator.ts`
+- Modify: `electron/gateway/config-sync.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add tests covering external Gateway URL resolution, `/ws` not being appended in external mode, spawn bypass, and kill-on-conflict bypass.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/gateway-ws-client.test.ts tests/unit/gateway-startup-orchestrator.test.ts tests/unit/gateway-supervisor.test.ts tests/unit/gateway-external-mode.test.ts`
+Expected: FAIL because external mode is not implemented yet.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Add an external attach branch in the manager, pass exact ws URLs through the client, and bypass spawn/kill/config-sync paths when external mode is active.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/gateway-ws-client.test.ts tests/unit/gateway-startup-orchestrator.test.ts tests/unit/gateway-supervisor.test.ts tests/unit/gateway-external-mode.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/gateway/manager.ts electron/gateway/ws-client.ts electron/gateway/supervisor.ts electron/gateway/startup-orchestrator.ts electron/gateway/config-sync.ts tests/unit/gateway-ws-client.test.ts tests/unit/gateway-startup-orchestrator.test.ts tests/unit/gateway-supervisor.test.ts tests/unit/gateway-external-mode.test.ts
+git commit -m "feat: attach ClawX to external gateway in safe mode"
+```
+
+### Task 3: Gate config mutation, telemetry, updates, provider validation, and external links
+
+**Files:**
+- Modify: `electron/utils/openclaw-auth.ts`
+- Modify: `electron/utils/telemetry.ts`
+- Modify: `electron/main/updater.ts`
+- Modify: `electron/services/updates-api.ts`
+- Modify: `electron/services/providers/provider-validation.ts`
+- Modify: `electron/services/providers-api.ts`
+- Modify: `electron/utils/browser-oauth.ts`
+- Modify: `electron/utils/device-oauth.ts`
+- Modify: `electron/services/shell-api.ts`
+- Modify: `electron/main/ipc-handlers.ts`
+- Modify: `electron/main/menu.ts`
+- Modify: `electron/main/index.ts`
+
+- [ ] **Step 1: Write the failing tests**
+
+Add offline tests that assert config writes are skipped in safe/external mode, telemetry init is skipped, updater checks do not hit the network, provider validation short-circuits, OAuth is blocked, and external URLs are guarded.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pnpm exec vitest run tests/unit/openclaw-auth.test.ts tests/unit/telemetry.test.ts tests/unit/provider-validation.test.ts tests/unit/update-store.test.ts tests/unit/external-links.test.ts`
+Expected: FAIL until the gates are implemented.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Short-circuit the write helpers and the main process entry points so safe mode never mutates OpenClaw config, never launches OAuth/validation flows, and never performs update or telemetry network activity.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pnpm exec vitest run tests/unit/openclaw-auth.test.ts tests/unit/telemetry.test.ts tests/unit/provider-validation.test.ts tests/unit/update-store.test.ts tests/unit/external-links.test.ts`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add electron/utils/openclaw-auth.ts electron/utils/telemetry.ts electron/main/updater.ts electron/services/updates-api.ts electron/services/providers/provider-validation.ts electron/services/providers-api.ts electron/utils/browser-oauth.ts electron/utils/device-oauth.ts electron/services/shell-api.ts electron/main/ipc-handlers.ts electron/main/menu.ts electron/main/index.ts tests/unit/openclaw-auth.test.ts tests/unit/telemetry.test.ts tests/unit/provider-validation.test.ts tests/unit/update-store.test.ts tests/unit/external-links.test.ts
+git commit -m "feat: gate network-adjacent flows in LAH safe mode"
+```
+
+### Task 4: Add operator packet and verify offline checks
+
+**Files:**
+- Create: `docs/operator/CLAWX_PHASE1_ISOLATED_EXTERNAL_GATEWAY_OPERATOR_PACKET.md`
+
+- [ ] **Step 1: Write the operator packet**
+
+Document the env vars, isolated paths, forbidden commands, allowed offline commands, rollback steps, residual risks, and next BR recommendation.
+
+- [ ] **Step 2: Run safe offline tests**
+
+Run the smallest safe Vitest subset that covers the changed helpers and managers. Do not launch Electron, Gateway, or any install scripts.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/operator/CLAWX_PHASE1_ISOLATED_EXTERNAL_GATEWAY_OPERATOR_PACKET.md
+git commit -m "docs: add CLAWX Phase 1 operator packet"
+```

--- a/electron/gateway/config-sync.ts
+++ b/electron/gateway/config-sync.ts
@@ -37,6 +37,7 @@ import { copyPluginFromNodeModules, fixupPluginManifest, cpSyncSafe, buildCandid
 import { CLAWX_OPENAI_IMAGE_PROVIDER_KEY } from '../utils/openclaw-image-relay-constants';
 import { stripSystemdSupervisorEnv } from './config-sync-env';
 import { cleanupAgentsSymlinkedSkills, cleanupStalePluginRuntimeDeps } from './skills-symlink-cleanup';
+import { isOpenClawConfigMutationEnabled } from '../utils/runtime-flags';
 import {
   buildPrelaunchMaintenanceCacheKey,
   directoryChildrenSignature,
@@ -439,6 +440,15 @@ export async function syncGatewayConfigBeforeLaunch(
   const timingsMs: Record<string, number> = {};
   const maintenance: GatewayPrelaunchSyncSummary['maintenance'] = {};
   let configuredChannels: string[] = [];
+
+  if (!isOpenClawConfigMutationEnabled()) {
+    logger.info('[gateway-config-sync] Skipping prelaunch OpenClaw mutation because config mutation is disabled');
+    return {
+      timingsMs,
+      maintenance,
+      configuredChannels,
+    };
+  }
 
   // Reset the extension-deps cache so that newly installed extensions
   // (e.g. user added a channel while the app was running) get their

--- a/electron/gateway/manager.ts
+++ b/electron/gateway/manager.ts
@@ -11,6 +11,11 @@ import { JsonRpcNotification, isNotification, isResponse } from './protocol';
 import { logger } from '../utils/logger';
 import { captureTelemetryEvent, trackMetric } from '../utils/telemetry';
 import {
+  getExternalGatewayUrl,
+  isExternalGatewayEnabled,
+  isGatewaySpawnEnabled,
+} from '../utils/runtime-flags';
+import {
   loadOrCreateDeviceIdentity,
   type DeviceIdentity,
 } from '../utils/device-identity';
@@ -346,18 +351,41 @@ export class GatewayManager extends EventEmitter {
     this.setStatus({ state: 'starting', reconnectAttempts: this.reconnectAttempts, gatewayReady: false });
     this.resetGatewayReadyFallback();
 
-    // Check if Python environment is ready (self-healing) asynchronously.
-    // Fire-and-forget: only needs to run once, not on every retry.
-    warmupManagedPythonReadiness();
+    if (isGatewaySpawnEnabled()) {
+      // Check if Python environment is ready (self-healing) asynchronously.
+      // Fire-and-forget: only needs to run once, not on every retry.
+      warmupManagedPythonReadiness();
+    }
 
     const t0 = Date.now();
     let tSpawned = 0;
     let tReady = 0;
+    const externalGatewayEnabled = isExternalGatewayEnabled();
 
     try {
+      if (externalGatewayEnabled) {
+        const externalGatewayUrl = getExternalGatewayUrl();
+        const parsedUrl = new URL(externalGatewayUrl);
+        const parsedPort = parsedUrl.port ? parseInt(parsedUrl.port, 10) : this.status.port;
+        if (Number.isFinite(parsedPort) && parsedPort > 0) {
+          this.setStatus({ port: parsedPort });
+        }
+        await this.connectExternalGateway(externalGatewayUrl);
+        this.ownsProcess = false;
+        this.process = null;
+        this.startHealthCheck();
+        const tConnected = Date.now();
+        logger.info('[metric] gateway.startup', {
+          mode: 'external',
+          externalGatewayUrl,
+          totalMs: tConnected - t0,
+        });
+        return;
+      }
+
       await runGatewayStartupSequence({
         port: this.status.port,
-        shouldWaitForPortFree: process.platform === 'win32',
+        shouldWaitForPortFree: process.platform === 'win32' && isGatewaySpawnEnabled(),
         hasOwnedProcess: () => this.process?.pid != null && this.ownsProcess,
         resetStartupStderrLines: () => {
           this.recentStartupStderrLines = [];
@@ -477,7 +505,12 @@ export class GatewayManager extends EventEmitter {
 
     // If this manager is attached to an external gateway process, ask it to shut down
     // over protocol before closing the socket.
-    if (!this.ownsProcess && this.ws?.readyState === WebSocket.OPEN && this.externalShutdownSupported !== false) {
+    if (
+      !this.ownsProcess
+      && !isExternalGatewayEnabled()
+      && this.ws?.readyState === WebSocket.OPEN
+      && this.externalShutdownSupported !== false
+    ) {
       try {
         await this.rpc('shutdown', undefined, 5000);
         this.externalShutdownSupported = true;
@@ -1030,6 +1063,10 @@ export class GatewayManager extends EventEmitter {
    * Uses OpenClaw npm package from node_modules (dev) or resources (production)
    */
   private async startProcess(): Promise<void> {
+    if (!isGatewaySpawnEnabled()) {
+      throw new Error('Gateway spawning is disabled in external gateway / safe mode');
+    }
+
     const launchContext = await prepareGatewayLaunchContext(this.status.port);
     await unloadLaunchctlGatewayService();
     this.processExitCode = null;
@@ -1153,6 +1190,44 @@ export class GatewayManager extends EventEmitter {
           if (process.platform !== 'win32' || closeCode === 1012) {
             this.scheduleReconnect();
           }
+        }
+      },
+    });
+  }
+
+  private async connectExternalGateway(wsUrl: string): Promise<void> {
+    this.ws = await connectGatewaySocket({
+      port: this.status.port,
+      wsUrl,
+      deviceIdentity: this.deviceIdentity,
+      platform: process.platform,
+      pendingRequests: this.pendingRequests,
+      getToken: async () => await import('../utils/store').then(({ getSetting }) => getSetting('gatewayToken')),
+      onHandshakeComplete: (ws) => {
+        this.ws = ws;
+        ws.on('pong', () => {
+          this.connectionMonitor.markAlive('pong');
+          this.recordGatewayAlive();
+        });
+        this.recordGatewayAlive();
+        this.setStatus({
+          state: 'running',
+          port: this.status.port,
+          connectedAt: Date.now(),
+        });
+        this.startPing();
+        this.scheduleGatewayReadyFallback();
+      },
+      onMessage: (message) => {
+        this.handleMessage(message);
+      },
+      onCloseAfterHandshake: (closeCode) => {
+        this.connectionMonitor.clear();
+        this.recordSocketClose(closeCode);
+        this.diagnostics.consecutiveHeartbeatMisses = 0;
+        if (this.status.state === 'running') {
+          this.setStatus({ state: 'stopped' });
+          this.scheduleReconnect();
         }
       },
     });

--- a/electron/gateway/process-launcher.ts
+++ b/electron/gateway/process-launcher.ts
@@ -5,6 +5,7 @@ import type { GatewayLaunchContext } from './config-sync';
 import type { GatewayLifecycleState } from './process-policy';
 import { logger } from '../utils/logger';
 import { appendNodeRequireToNodeOptions } from '../utils/paths';
+import { isGatewaySpawnEnabled } from '../utils/runtime-flags';
 
 const GATEWAY_FETCH_PRELOAD_SOURCE = `'use strict';
 (function () {
@@ -101,6 +102,10 @@ export async function launchGatewayProcess(options: {
   onExit: (child: Electron.UtilityProcess, code: number | null) => void;
   onError: (error: Error) => void;
 }): Promise<{ child: Electron.UtilityProcess; lastSpawnSummary: string }> {
+  if (!isGatewaySpawnEnabled()) {
+    throw new Error('Gateway spawning is disabled in external gateway / safe mode');
+  }
+
   const {
     openclawDir,
     entryScript,

--- a/electron/gateway/supervisor.ts
+++ b/electron/gateway/supervisor.ts
@@ -242,20 +242,19 @@ export async function findExistingGatewayProcess(options: {
 }): Promise<{ port: number; externalToken?: string } | null> {
   const { port, ownedPid } = options;
 
-  if (!isGatewayKillOnConflictEnabled()) {
-    logger.info(`Skipping orphan Gateway cleanup for port ${port} because kill-on-conflict is disabled`);
-    return null;
-  }
-
   try {
     try {
       const pids = await getListeningProcessIds(port);
       if (pids.length > 0 && (!ownedPid || !pids.includes(String(ownedPid)))) {
-        await terminateOrphanedProcessIds(port, pids);
-        if (process.platform === 'win32') {
-          await waitForPortFree(port, 10000);
+        if (isGatewayKillOnConflictEnabled()) {
+          await terminateOrphanedProcessIds(port, pids);
+          if (process.platform === 'win32') {
+            await waitForPortFree(port, 10000);
+          }
+          return null;
         }
-        return null;
+
+        logger.info(`Skipping orphan Gateway cleanup for port ${port} because kill-on-conflict is disabled`);
       }
     } catch (err) {
       logger.warn('Error checking for existing process on port:', err);

--- a/electron/gateway/supervisor.ts
+++ b/electron/gateway/supervisor.ts
@@ -6,6 +6,7 @@ import { getUvMirrorEnv } from '../utils/uv-env';
 import { isPythonReady, setupManagedPython } from '../utils/uv-setup';
 import { logger } from '../utils/logger';
 import { prependPathEntry } from '../utils/env-path';
+import { isGatewayKillOnConflictEnabled } from '../utils/runtime-flags';
 import { probeGatewayReady } from './ws-client';
 
 export function warmupManagedPythonReadiness(): void {
@@ -240,6 +241,11 @@ export async function findExistingGatewayProcess(options: {
   ownedPid?: number;
 }): Promise<{ port: number; externalToken?: string } | null> {
   const { port, ownedPid } = options;
+
+  if (!isGatewayKillOnConflictEnabled()) {
+    logger.info(`Skipping orphan Gateway cleanup for port ${port} because kill-on-conflict is disabled`);
+    return null;
+  }
 
   try {
     try {

--- a/electron/gateway/ws-client.ts
+++ b/electron/gateway/ws-client.ts
@@ -12,6 +12,9 @@ import {
   redactGatewayFrameForTrace,
   summarizeGatewayFrameForTrace,
 } from './ws-trace';
+import {
+  isConnectivityProbeEnabledByRuntime,
+} from '../utils/runtime-flags';
 
 export const GATEWAY_CHALLENGE_TIMEOUT_MS = 10_000;
 export const GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS = 20_000;
@@ -20,6 +23,11 @@ export async function probeGatewayReady(
   port: number,
   timeoutMs = 1500,
 ): Promise<boolean> {
+  if (!isConnectivityProbeEnabledByRuntime()) {
+    logger.info(`Skipping Gateway readiness probe for port ${port} because connectivity probes are disabled`);
+    return false;
+  }
+
   return await new Promise<boolean>((resolve) => {
     const testWs = new WebSocket(`ws://localhost:${port}/ws`);
     let settled = false;
@@ -76,6 +84,10 @@ export async function waitForGatewayReady(options: {
   retries?: number;
   intervalMs?: number;
 }): Promise<void> {
+  if (!isConnectivityProbeEnabledByRuntime()) {
+    throw new Error('Gateway connectivity probes are disabled in LAH safe mode');
+  }
+
   const retries = options.retries ?? 2400;
   const intervalMs = options.intervalMs ?? 200;
 
@@ -175,6 +187,7 @@ export function buildGatewayConnectFrame(options: {
 
 export async function connectGatewaySocket(options: {
   port: number;
+  wsUrl?: string;
   deviceIdentity: DeviceIdentity | null;
   platform: string;
   pendingRequests: Map<string, PendingGatewayRequest>;
@@ -185,12 +198,12 @@ export async function connectGatewaySocket(options: {
   challengeTimeoutMs?: number;
   connectTimeoutMs?: number;
 }): Promise<WebSocket> {
-  logger.debug(`Connecting Gateway WebSocket (ws://localhost:${options.port}/ws)`);
+  const wsUrl = options.wsUrl || `ws://localhost:${options.port}/ws`;
+  logger.debug(`Connecting Gateway WebSocket (${wsUrl})`);
   const challengeTimeoutMs = options.challengeTimeoutMs ?? GATEWAY_CHALLENGE_TIMEOUT_MS;
   const connectTimeoutMs = options.connectTimeoutMs ?? GATEWAY_CONNECT_HANDSHAKE_TIMEOUT_MS;
 
   return await new Promise<WebSocket>((resolve, reject) => {
-    const wsUrl = `ws://localhost:${options.port}/ws`;
     const ws = new WebSocket(wsUrl);
     let handshakeComplete = false;
     let connectId: string | null = null;

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -4,6 +4,7 @@
  */
 import { app, BrowserWindow, nativeImage, session } from 'electron';
 import { join } from 'path';
+import { ensureDir } from '../utils/paths';
 import { GatewayManager } from '../gateway/manager';
 import { registerIpcHandlers } from './ipc-handlers';
 import { HostApiRegistry } from './ipc/host-invoke';
@@ -64,6 +65,7 @@ if (requestedRemoteDebuggingPort) {
 }
 
 if (requestedUserDataDir) {
+  ensureDir(requestedUserDataDir);
   app.setPath('userData', requestedUserDataDir);
 }
 

--- a/electron/main/index.ts
+++ b/electron/main/index.ts
@@ -2,7 +2,7 @@
  * Electron Main Process Entry
  * Manages window creation, system tray, and IPC handlers
  */
-import { app, BrowserWindow, nativeImage, session, shell } from 'electron';
+import { app, BrowserWindow, nativeImage, session } from 'electron';
 import { join } from 'path';
 import { GatewayManager } from '../gateway/manager';
 import { registerIpcHandlers } from './ipc-handlers';
@@ -15,6 +15,8 @@ import { appUpdater, registerUpdateHandlers } from './updater';
 import { logger } from '../utils/logger';
 import { warmupNetworkOptimization } from '../utils/uv-env';
 import { initTelemetry } from '../utils/telemetry';
+import { getRequestedUserDataDir } from '../utils/runtime-flags';
+import { openExternalUrl } from '../utils/external-links';
 
 import { ClawHubService } from '../gateway/clawhub';
 import { extensionRegistry } from '../extensions/registry';
@@ -54,14 +56,14 @@ import { syncAllProviderAuthToRuntime } from '../services/providers/provider-run
 
 const WINDOWS_APP_USER_MODEL_ID = 'app.clawx.desktop';
 const isE2EMode = process.env.CLAWX_E2E === '1';
-const requestedUserDataDir = process.env.CLAWX_USER_DATA_DIR?.trim();
+const requestedUserDataDir = getRequestedUserDataDir();
 const requestedRemoteDebuggingPort = process.env.CLAWX_REMOTE_DEBUGGING_PORT?.trim();
 
 if (requestedRemoteDebuggingPort) {
   app.commandLine.appendSwitch('remote-debugging-port', requestedRemoteDebuggingPort);
 }
 
-if (isE2EMode && requestedUserDataDir) {
+if (requestedUserDataDir) {
   app.setPath('userData', requestedUserDataDir);
 }
 
@@ -207,7 +209,7 @@ function createWindow(): BrowserWindow {
     try {
       const parsed = new URL(url);
       if (parsed.protocol === 'https:' || parsed.protocol === 'http:') {
-        shell.openExternal(url);
+        void openExternalUrl(url);
       } else {
         logger.warn(`Blocked openExternal for disallowed protocol: ${parsed.protocol}`);
       }

--- a/electron/main/ipc-handlers.ts
+++ b/electron/main/ipc-handlers.ts
@@ -27,6 +27,7 @@ import { whatsAppLoginManager } from '../utils/whatsapp-login';
 import { getProviderConfig } from '../utils/provider-registry';
 import { deviceOAuthManager } from '../utils/device-oauth';
 import { browserOAuthManager } from '../utils/browser-oauth';
+import { openExternalUrl } from '../utils/external-links';
 import { applyProxySettings } from './proxy';
 import { syncLaunchAtStartupSettingFromStore } from './launch-at-startup';
 import { getRecentTokenUsageHistory } from '../utils/token-usage';
@@ -1069,7 +1070,7 @@ function expandShellPath(input: string): string {
 function registerShellHandlers(): void {
   // Open external URL
   ipcMain.handle('shell:openExternal', async (_, url: string) => {
-    await shell.openExternal(url);
+    await openExternalUrl(url);
   });
 
   // Open path in file explorer

--- a/electron/main/menu.ts
+++ b/electron/main/menu.ts
@@ -2,10 +2,11 @@
  * Application Menu Configuration
  * Creates the native application menu for macOS/Windows/Linux
  */
-import { Menu, app, shell, BrowserWindow } from 'electron';
+import { Menu, app, BrowserWindow } from 'electron';
 import { MENU_LABELS } from '@shared/i18n/resources';
 import { resolveSupportedLanguage, type LanguageCode } from '@shared/language';
 import { getSetting } from '../utils/store';
+import { openExternalUrl } from '../utils/external-links';
 
 function applyAppName(label: string): string {
   return label.replaceAll('{{appName}}', app.name);
@@ -201,20 +202,20 @@ export async function createMenu(language?: string): Promise<void> {
         {
           label: labels.help.documentation,
           click: async () => {
-            await shell.openExternal('https://claw-x.com');
+            await openExternalUrl('https://claw-x.com');
           },
         },
         {
           label: labels.help.reportIssue,
           click: async () => {
-            await shell.openExternal('https://github.com/ValueCell-ai/ClawX/issues');
+            await openExternalUrl('https://github.com/ValueCell-ai/ClawX/issues');
           },
         },
         { type: 'separator' },
         {
           label: labels.help.openClawDocumentation,
           click: async () => {
-            await shell.openExternal('https://docs.openclaw.ai');
+            await openExternalUrl('https://docs.openclaw.ai');
           },
         },
       ],

--- a/electron/main/updater.ts
+++ b/electron/main/updater.ts
@@ -11,6 +11,7 @@ import { BrowserWindow, app, ipcMain } from 'electron';
 import { logger } from '../utils/logger';
 import { EventEmitter } from 'events';
 import { setQuitting } from './app-state';
+import { isUpdateChecksEnabledByRuntime } from '../utils/runtime-flags';
 
 /** Base CDN URL (without trailing channel path) */
 const OSS_BASE_URL = 'https://oss.intelli-spectrum.com';
@@ -171,6 +172,14 @@ export class AppUpdater extends EventEmitter {
    */
   async checkForUpdates(): Promise<UpdateInfo | null> {
     try {
+      if (!isUpdateChecksEnabledByRuntime()) {
+        this.updateStatus({
+          status: 'not-available',
+          error: 'Update checks are disabled in LAH safe mode',
+        });
+        return null;
+      }
+
       const result = await autoUpdater.checkForUpdates();
 
       // In dev mode (app not packaged), autoUpdater silently returns null
@@ -202,6 +211,10 @@ export class AppUpdater extends EventEmitter {
    */
   async downloadUpdate(): Promise<void> {
     try {
+      if (!isUpdateChecksEnabledByRuntime()) {
+        logger.info('[Updater] Skipping download request because update checks are disabled');
+        return;
+      }
       await autoUpdater.downloadUpdate();
     } catch (error) {
       logger.error('[Updater] Download update failed:', error);

--- a/electron/services/providers-api.ts
+++ b/electron/services/providers-api.ts
@@ -20,6 +20,7 @@ import {
   syncUpdatedProviderToRuntime,
 } from './providers/provider-runtime-sync';
 import { validateApiKeyWithProvider } from './providers/provider-validation';
+import { isOAuthEnabledByRuntime, isProviderValidationEnabledByRuntime } from '../utils/runtime-flags';
 import type { ProviderAccount } from '../shared/providers/types';
 import { isRecord } from './payload-utils';
 
@@ -151,6 +152,10 @@ function getSavePayload(payload: unknown): { config: ProviderConfig; apiKey?: st
 }
 
 async function validateKey(payload: ProviderPayload<'validateKey'>): Promise<{ valid: boolean; error?: string }> {
+  if (!isProviderValidationEnabledByRuntime()) {
+    return { valid: false, error: 'Provider validation is disabled in LAH safe mode' };
+  }
+
   try {
     const body = getPayloadRecord(payload, 'validateKey');
     const accountId = typeof body.accountId === 'string' && body.accountId.trim()
@@ -420,6 +425,9 @@ async function requestOAuth(payload: ProviderPayload<'requestOAuth'>) {
   const provider = typeof body.provider === 'string' ? body.provider : undefined;
   if (!provider) {
     return { success: false, error: 'Invalid providers.requestOAuth payload' };
+  }
+  if (!isOAuthEnabledByRuntime()) {
+    return { success: false, error: 'OAuth flows are disabled in LAH safe mode' };
   }
   const region = body.region === 'global' || body.region === 'cn' ? body.region : undefined;
   const options = {

--- a/electron/services/providers/provider-validation.ts
+++ b/electron/services/providers/provider-validation.ts
@@ -1,5 +1,6 @@
 import { proxyAwareFetch } from '../../utils/proxy-fetch';
 import { getProviderConfig } from '../../utils/provider-registry';
+import { isProviderValidationEnabledByRuntime } from '../../utils/runtime-flags';
 
 type ValidationProfile =
   | 'openai-completions'
@@ -355,6 +356,10 @@ export async function validateApiKeyWithProvider(
   apiKey: string,
   options?: { baseUrl?: string; apiProtocol?: string },
 ): Promise<ValidationResult> {
+  if (!isProviderValidationEnabledByRuntime()) {
+    return { valid: false, error: 'Provider validation is disabled in LAH safe mode' };
+  }
+
   const profile = getValidationProfile(providerType, options);
   const resolvedBaseUrl = options?.baseUrl || getProviderConfig(providerType)?.baseUrl;
 

--- a/electron/services/shell-api.ts
+++ b/electron/services/shell-api.ts
@@ -2,6 +2,7 @@ import { shell } from 'electron';
 import { homedir } from 'node:os';
 import { join, sep } from 'node:path';
 import type { CompleteHostServiceRegistry } from '../main/ipc/host-contract';
+import { openExternalUrl } from '../utils/external-links';
 
 function expandShellPath(input: string): string {
   if (input === '~') return homedir();
@@ -28,7 +29,7 @@ function requireUrl(url: unknown): string {
 export function createShellApi(): CompleteHostServiceRegistry['shell'] {
   return {
     openExternal: async (payload) => {
-      await shell.openExternal(requireUrl(payload.url));
+      await openExternalUrl(requireUrl(payload.url));
     },
     showItemInFolder: (payload) => {
       shell.showItemInFolder(expandShellPath(requirePath(payload.path)));

--- a/electron/utils/browser-oauth.ts
+++ b/electron/utils/browser-oauth.ts
@@ -1,6 +1,7 @@
 import { EventEmitter } from 'events';
-import { BrowserWindow, shell } from 'electron';
+import { BrowserWindow } from 'electron';
 import { logger } from './logger';
+import { openExternalUrl } from './external-links';
 import { loginOpenAICodexOAuth, type OpenAICodexOAuthCredentials } from './openai-codex-oauth';
 import { getProviderService } from '../services/providers/provider-service';
 import { getSecretStore } from '../services/secrets/secret-store';
@@ -10,6 +11,7 @@ import {
   saveOAuthTokenToOpenClaw,
   setOpenClawDefaultModelWithOverride,
 } from './openclaw-auth';
+import { isOAuthEnabledByRuntime } from './runtime-flags';
 
 // Google was removed: OpenClaw's `google-gemini-cli` OAuth integration is an
 // unofficial third-party flow that requires the `gemini` CLI binary to be on
@@ -37,6 +39,12 @@ class BrowserOAuthManager extends EventEmitter {
     provider: BrowserOAuthProviderType,
     options?: { accountId?: string; label?: string },
   ): Promise<boolean> {
+    if (!isOAuthEnabledByRuntime()) {
+      logger.warn('[BrowserOAuth] OAuth flow disabled in LAH safe mode');
+      this.emitError('OAuth flows are disabled in LAH safe mode');
+      return false;
+    }
+
     if (this.active) {
       await this.stopFlow();
     }
@@ -55,7 +63,7 @@ class BrowserOAuthManager extends EventEmitter {
     try {
       const token = await loginOpenAICodexOAuth({
         openUrl: async (url) => {
-          await shell.openExternal(url);
+          await openExternalUrl(url);
         },
         onProgress: (message) => logger.info(`[BrowserOAuth] ${message}`),
         onManualCodeRequired: ({ authorizationUrl, reason }) => {

--- a/electron/utils/channel-config.ts
+++ b/electron/utils/channel-config.ts
@@ -12,6 +12,7 @@ import { getOpenClawResolvedDir } from './paths';
 import * as logger from './logger';
 import { proxyAwareFetch } from './proxy-fetch';
 import { withConfigLock } from './config-mutex';
+import { isOpenClawConfigMutationEnabled } from './runtime-flags';
 import {
     OPENCLAW_WECHAT_CHANNEL_TYPE,
     isWechatChannelType,
@@ -479,6 +480,11 @@ export async function readOpenClawConfig(): Promise<OpenClawConfig> {
 }
 
 export async function writeOpenClawConfig(config: OpenClawConfig): Promise<void> {
+    if (!isOpenClawConfigMutationEnabled()) {
+        logger.info('Skipping OpenClaw config write because config mutation is disabled');
+        return;
+    }
+
     await ensureConfigDir();
 
     try {

--- a/electron/utils/config.ts
+++ b/electron/utils/config.ts
@@ -44,6 +44,23 @@ export const APP_PATHS = {
 } as const;
 
 /**
+ * LAH runtime defaults
+ */
+export const LAH_RUNTIME_DEFAULTS = {
+  externalGatewayEnabled: false,
+  externalGatewayUrl: 'ws://127.0.0.1:4000/gateway',
+  gatewaySpawnEnabled: true,
+  gatewayKillOnConflictEnabled: true,
+  openclawConfigMutationEnabled: true,
+  telemetryEnabled: true,
+  updateChecksEnabled: true,
+  providerValidationEnabled: true,
+  oauthEnabled: true,
+  externalUrlOpeningEnabled: true,
+  connectivityProbeEnabled: true,
+} as const;
+
+/**
  * Update channels
  */
 export const UPDATE_CHANNELS = ['stable', 'beta', 'dev'] as const;

--- a/electron/utils/device-oauth.ts
+++ b/electron/utils/device-oauth.ts
@@ -16,13 +16,15 @@
  * the Electron IPC system to display UI in the ClawX frontend.
  */
 import { EventEmitter } from 'events';
-import { BrowserWindow, shell } from 'electron';
+import { BrowserWindow } from 'electron';
 import { logger } from './logger';
 import { saveProvider, getProvider, ProviderConfig } from './secure-storage';
 import { getProviderDefaultModel } from './provider-registry';
 import { proxyAwareFetch } from './proxy-fetch';
 import { saveOAuthTokenToOpenClaw, setOpenClawDefaultModelWithOverride } from './openclaw-auth';
 import { loginMiniMaxPortalOAuth, type MiniMaxOAuthToken, type MiniMaxRegion } from './minimax-oauth';
+import { openExternalUrl } from './external-links';
+import { isOAuthEnabledByRuntime } from './runtime-flags';
 
 export type OAuthProviderType = 'minimax-portal' | 'minimax-portal-cn';
 
@@ -60,6 +62,12 @@ class DeviceOAuthManager extends EventEmitter {
         region: MiniMaxRegion = 'global',
         options?: { accountId?: string; label?: string },
     ): Promise<boolean> {
+        if (!isOAuthEnabledByRuntime()) {
+            logger.warn('[DeviceOAuth] OAuth flow disabled in LAH safe mode');
+            this.emitError('OAuth flows are disabled in LAH safe mode');
+            return false;
+        }
+
         if (this.active) {
             await this.stopFlow();
         }
@@ -113,7 +121,7 @@ class DeviceOAuthManager extends EventEmitter {
             openUrl: async (url: string) => {
                 logger.info(`[DeviceOAuth] MiniMax opening browser: ${url}`);
                 // Open the authorization URL in the system browser
-                shell.openExternal(url).catch((err: unknown) =>
+                openExternalUrl(url).catch((err: unknown) =>
                     logger.warn(`[DeviceOAuth] Failed to open browser:`, err)
                 );
             },

--- a/electron/utils/external-links.ts
+++ b/electron/utils/external-links.ts
@@ -1,0 +1,14 @@
+import { shell } from 'electron';
+import { logger } from './logger';
+import { isExternalUrlOpeningEnabledByRuntime, isLahSafeMode } from './runtime-flags';
+
+export async function openExternalUrl(url: string): Promise<void> {
+  if (!isExternalUrlOpeningEnabledByRuntime()) {
+    logger.info(
+      `[external-links] Blocked external URL open${isLahSafeMode() ? ' in LAH safe mode' : ''}: ${url}`,
+    );
+    return;
+  }
+
+  await shell.openExternal(url);
+}

--- a/electron/utils/openclaw-auth.ts
+++ b/electron/utils/openclaw-auth.ts
@@ -21,6 +21,9 @@ import {
   getProviderConfig,
 } from './provider-registry';
 import {
+  isOpenClawConfigMutationEnabled,
+} from './runtime-flags';
+import {
   OPENCLAW_PROVIDER_KEY_MINIMAX,
   OPENCLAW_PROVIDER_KEY_MOONSHOT,
   OPENCLAW_PROVIDER_KEY_MOONSHOT_GLOBAL,
@@ -848,6 +851,10 @@ function normalizeAgentsDefaultsCompactionMode(config: Record<string, unknown>):
 }
 
 async function writeOpenClawJson(config: Record<string, unknown>): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log('[openclaw-auth] Skipping openclaw.json write because config mutation is disabled');
+    return;
+  }
   normalizeAgentsDefaultsCompactionMode(config);
 
   // Ensure SIGUSR1 graceful reload is authorized by OpenClaw config.
@@ -879,6 +886,10 @@ export async function saveOAuthTokenToOpenClaw(
   },
   agentId?: string
 ): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log(`[saveOAuthTokenToOpenClaw] Skipping auth-profiles write for "${provider}" because config mutation is disabled`);
+    return;
+  }
   const agentIds = agentId ? [agentId] : await discoverAgentIds();
   if (agentIds.length === 0) agentIds.push('main');
 
@@ -945,6 +956,10 @@ export async function saveProviderKeyToOpenClaw(
   apiKey: string,
   agentId?: string
 ): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log(`[saveProviderKeyToOpenClaw] Skipping auth-profiles write for "${provider}" because config mutation is disabled`);
+    return;
+  }
   if (isOAuthProviderType(provider) && !apiKey) {
     console.log(`Skipping auth-profiles write for OAuth provider "${provider}" (no API key provided, using OAuth)`);
     return;
@@ -979,6 +994,10 @@ export async function removeProviderKeyFromOpenClaw(
   provider: string,
   agentId?: string
 ): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log(`[removeProviderKeyFromOpenClaw] Skipping auth-profiles write for "${provider}" because config mutation is disabled`);
+    return;
+  }
   const agentIds = agentId ? [agentId] : await discoverAgentIds();
   if (agentIds.length === 0) agentIds.push('main');
 
@@ -1112,6 +1131,10 @@ export async function pruneStaleRuntimeAgentModelRefs(config: Record<string, unk
 }
 
 export async function removeProviderFromOpenClaw(provider: string): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log(`[removeProviderFromOpenClaw] Skipping provider cleanup for "${provider}" because config mutation is disabled`);
+    return;
+  }
   // 1. Remove from auth-profiles.json.
   // We must also remove entries whose raw `provider` field maps to this UI
   // provider key via AUTH_PROFILE_PROVIDER_KEY_MAP (e.g. "openai-codex" → "openai").
@@ -2525,6 +2548,10 @@ export async function syncSessionIdleMinutesToOpenClaw(): Promise<void> {
  * withConfigLock calls during pre-launch sync.
  */
 export async function batchSyncConfigFields(token: string): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log('[batchSyncConfigFields] Skipping openclaw.json writes because config mutation is disabled');
+    return;
+  }
   const DEFAULT_IDLE_MINUTES = 10_080; // 7 days
 
   return withConfigLock(async () => {
@@ -2753,6 +2780,10 @@ function ensureToolDenyIncludes(
 }
 
 export async function sanitizeOpenClawConfig(): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    console.log('[sanitize] Skipping openclaw.json sanitization because config mutation is disabled');
+    return;
+  }
   return withConfigLock(async () => {
     // Skip sanitization if the config file does not exist yet.
     // Creating a skeleton config here would overwrite any data written

--- a/electron/utils/openclaw-proxy.ts
+++ b/electron/utils/openclaw-proxy.ts
@@ -2,6 +2,7 @@ import { readOpenClawConfig, writeOpenClawConfig } from './channel-config';
 import { resolveProxySettings, type ProxySettings } from './proxy';
 import { logger } from './logger';
 import { withConfigLock } from './config-mutex';
+import { isOpenClawConfigMutationEnabled } from './runtime-flags';
 
 interface SyncProxyOptions {
   /**
@@ -19,6 +20,11 @@ export async function syncProxyConfigToOpenClaw(
   settings: ProxySettings,
   options: SyncProxyOptions = {},
 ): Promise<void> {
+  if (!isOpenClawConfigMutationEnabled()) {
+    logger.info('Skipping Telegram proxy sync because OpenClaw config mutation is disabled');
+    return;
+  }
+
   return withConfigLock(async () => {
     const config = await readOpenClawConfig();
     const telegramConfig = config.channels?.telegram;

--- a/electron/utils/paths.ts
+++ b/electron/utils/paths.ts
@@ -6,6 +6,7 @@ import { createRequire } from 'node:module';
 import { join } from 'path';
 import { homedir } from 'os';
 import { existsSync, mkdirSync, readFileSync, realpathSync } from 'fs';
+import { getRequestedUserDataDir } from './runtime-flags';
 
 const require = createRequire(import.meta.url);
 
@@ -79,7 +80,7 @@ export function getLogsDir(): string {
  * Get ClawX data directory
  */
 export function getDataDir(): string {
-  return getElectronApp().getPath('userData');
+  return getRequestedUserDataDir() || getElectronApp().getPath('userData');
 }
 
 /**

--- a/electron/utils/runtime-flags.ts
+++ b/electron/utils/runtime-flags.ts
@@ -1,0 +1,107 @@
+const TRUE_VALUES = new Set(['1', 'true', 'yes', 'on']);
+const FALSE_VALUES = new Set(['0', 'false', 'no', 'off']);
+
+export const DEFAULT_EXTERNAL_GATEWAY_URL = 'ws://127.0.0.1:4000/gateway';
+
+function readEnvFlag(name: string, defaultValue = false): boolean {
+  const raw = process.env[name]?.trim();
+  if (!raw) {
+    return defaultValue;
+  }
+
+  const normalized = raw.toLowerCase();
+  if (TRUE_VALUES.has(normalized)) {
+    return true;
+  }
+  if (FALSE_VALUES.has(normalized)) {
+    return false;
+  }
+  return defaultValue;
+}
+
+export function getRequestedUserDataDir(): string | null {
+  const raw = process.env.CLAWX_USER_DATA_DIR?.trim();
+  return raw ? raw : null;
+}
+
+export function isLahSafeMode(): boolean {
+  return readEnvFlag('LAH_SAFE_MODE', false);
+}
+
+export function getExternalGatewayUrl(): string {
+  return process.env.CLAWX_EXTERNAL_GATEWAY_URL?.trim() || DEFAULT_EXTERNAL_GATEWAY_URL;
+}
+
+export function isExternalGatewayEnabled(): boolean {
+  if (isLahSafeMode()) {
+    return true;
+  }
+  if (readEnvFlag('CLAWX_EXTERNAL_GATEWAY_ENABLED', false)) {
+    return true;
+  }
+  return Boolean(process.env.CLAWX_EXTERNAL_GATEWAY_URL?.trim());
+}
+
+export function isGatewaySpawnEnabled(): boolean {
+  if (isExternalGatewayEnabled()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_GATEWAY_SPAWN_ENABLED', true);
+}
+
+export function isGatewayKillOnConflictEnabled(): boolean {
+  if (isExternalGatewayEnabled()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_GATEWAY_KILL_ON_CONFLICT', true);
+}
+
+export function isOpenClawConfigMutationEnabled(): boolean {
+  if (isLahSafeMode() || isExternalGatewayEnabled()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_OPENCLAW_CONFIG_MUTATION', true);
+}
+
+export function isTelemetryEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_TELEMETRY_ENABLED', true);
+}
+
+export function isUpdateChecksEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_UPDATE_CHECKS_ENABLED', true);
+}
+
+export function isProviderValidationEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_PROVIDER_VALIDATION_ENABLED', true);
+}
+
+export function isOAuthEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_OAUTH_ENABLED', true);
+}
+
+export function isExternalUrlOpeningEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_EXTERNAL_URL_OPENING_ENABLED', true);
+}
+
+export function isConnectivityProbeEnabledByRuntime(): boolean {
+  if (isLahSafeMode()) {
+    return false;
+  }
+  return readEnvFlag('CLAWX_CONNECTIVITY_PROBE_ENABLED', true);
+}
+

--- a/electron/utils/store.ts
+++ b/electron/utils/store.ts
@@ -6,6 +6,19 @@
 import { randomBytes } from 'crypto';
 import { app } from 'electron';
 import { resolveSupportedLanguage } from '@shared/language';
+import {
+  getExternalGatewayUrl,
+  isConnectivityProbeEnabledByRuntime,
+  isExternalGatewayEnabled,
+  isExternalUrlOpeningEnabledByRuntime,
+  isGatewayKillOnConflictEnabled,
+  isGatewaySpawnEnabled,
+  isOAuthEnabledByRuntime,
+  isOpenClawConfigMutationEnabled,
+  isProviderValidationEnabledByRuntime,
+  isTelemetryEnabledByRuntime,
+  isUpdateChecksEnabledByRuntime,
+} from './runtime-flags';
 
 // Lazy-load electron-store (ESM module)
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -41,6 +54,16 @@ export interface AppSettings {
   proxyHttpsServer: string;
   proxyAllServer: string;
   proxyBypassRules: string;
+  externalGatewayEnabled: boolean;
+  externalGatewayUrl: string;
+  gatewaySpawnEnabled: boolean;
+  gatewayKillOnConflictEnabled: boolean;
+  openclawConfigMutationEnabled: boolean;
+  updateChecksEnabled: boolean;
+  providerValidationEnabled: boolean;
+  oauthEnabled: boolean;
+  externalUrlOpeningEnabled: boolean;
+  connectivityProbeEnabled: boolean;
 
   // Update
   updateChannel: 'stable' | 'beta' | 'dev';
@@ -92,6 +115,16 @@ function createDefaultSettings(): AppSettings {
     proxyHttpsServer: '',
     proxyAllServer: '',
     proxyBypassRules: '<local>;localhost;127.0.0.1;::1',
+    externalGatewayEnabled: isExternalGatewayEnabled(),
+    externalGatewayUrl: getExternalGatewayUrl(),
+    gatewaySpawnEnabled: isGatewaySpawnEnabled(),
+    gatewayKillOnConflictEnabled: isGatewayKillOnConflictEnabled(),
+    openclawConfigMutationEnabled: isOpenClawConfigMutationEnabled(),
+    updateChecksEnabled: isUpdateChecksEnabledByRuntime(),
+    providerValidationEnabled: isProviderValidationEnabledByRuntime(),
+    oauthEnabled: isOAuthEnabledByRuntime(),
+    externalUrlOpeningEnabled: isExternalUrlOpeningEnabledByRuntime(),
+    connectivityProbeEnabled: isConnectivityProbeEnabledByRuntime(),
 
     // Update
     updateChannel: 'stable',

--- a/electron/utils/telemetry.ts
+++ b/electron/utils/telemetry.ts
@@ -3,6 +3,7 @@ import { machineIdSync } from 'node-machine-id';
 import { app } from 'electron';
 import { getSetting, setSetting } from './store';
 import { logger } from './logger';
+import { isTelemetryEnabledByRuntime } from './runtime-flags';
 
 const POSTHOG_API_KEY = 'phc_aGNegeJQP5FzNiF2rEoKqQbkuCpiiETMttplibXpB0n';
 const POSTHOG_HOST = 'https://us.i.posthog.com';
@@ -46,6 +47,11 @@ function isIgnorablePostHogShutdownError(error: unknown): boolean {
  */
 export async function initTelemetry(): Promise<void> {
     try {
+        if (!isTelemetryEnabledByRuntime()) {
+            logger.info('Telemetry is disabled in LAH safe mode or via runtime flags');
+            return;
+        }
+
         const telemetryEnabled = await getSetting('telemetryEnabled');
         if (!telemetryEnabled) {
             logger.info('Telemetry is disabled in settings');
@@ -95,7 +101,7 @@ export function trackMetric(event: string, properties: Record<string, unknown> =
 }
 
 export function captureTelemetryEvent(event: string, properties: Record<string, unknown> = {}): void {
-    if (!posthogClient || !distinctId) {
+    if (!isTelemetryEnabledByRuntime() || !posthogClient || !distinctId) {
         return;
     }
 

--- a/shared/host-api/contract.ts
+++ b/shared/host-api/contract.ts
@@ -110,6 +110,17 @@ export type SettingsSnapshot = Partial<{
   proxyHttpsServer: string;
   proxyAllServer: string;
   proxyBypassRules: string;
+  externalGatewayEnabled: boolean;
+  externalGatewayUrl: string;
+  gatewaySpawnEnabled: boolean;
+  gatewayKillOnConflictEnabled: boolean;
+  openclawConfigMutationEnabled: boolean;
+  telemetryEnabled: boolean;
+  updateChecksEnabled: boolean;
+  providerValidationEnabled: boolean;
+  oauthEnabled: boolean;
+  externalUrlOpeningEnabled: boolean;
+  connectivityProbeEnabled: boolean;
   updateChannel: 'stable' | 'beta' | 'dev';
   autoCheckUpdate: boolean;
   sidebarCollapsed: boolean;

--- a/src/stores/settings.ts
+++ b/src/stores/settings.ts
@@ -28,6 +28,16 @@ interface SettingsState {
   proxyHttpsServer: string;
   proxyAllServer: string;
   proxyBypassRules: string;
+  externalGatewayEnabled: boolean;
+  externalGatewayUrl: string;
+  gatewaySpawnEnabled: boolean;
+  gatewayKillOnConflictEnabled: boolean;
+  openclawConfigMutationEnabled: boolean;
+  updateChecksEnabled: boolean;
+  providerValidationEnabled: boolean;
+  oauthEnabled: boolean;
+  externalUrlOpeningEnabled: boolean;
+  connectivityProbeEnabled: boolean;
 
   // Update
   updateChannel: UpdateChannel;
@@ -79,6 +89,16 @@ const defaultSettings = {
   proxyHttpsServer: '',
   proxyAllServer: '',
   proxyBypassRules: '<local>;localhost;127.0.0.1;::1',
+  externalGatewayEnabled: false,
+  externalGatewayUrl: 'ws://127.0.0.1:4000/gateway',
+  gatewaySpawnEnabled: true,
+  gatewayKillOnConflictEnabled: true,
+  openclawConfigMutationEnabled: true,
+  updateChecksEnabled: true,
+  providerValidationEnabled: true,
+  oauthEnabled: true,
+  externalUrlOpeningEnabled: true,
+  connectivityProbeEnabled: true,
   updateChannel: 'stable' as UpdateChannel,
   autoCheckUpdate: true,
   sidebarCollapsed: false,

--- a/src/stores/update.ts
+++ b/src/stores/update.ts
@@ -13,6 +13,11 @@ import type {
   UpdateStatusSnapshot,
 } from '@shared/host-api/contract';
 
+function isSafeModeUpdateChecksDisabled(): boolean {
+  const value = (typeof process !== 'undefined' && process.env?.LAH_SAFE_MODE) ? String(process.env.LAH_SAFE_MODE).trim().toLowerCase() : '';
+  return value === '1' || value === 'true' || value === 'yes' || value === 'on';
+}
+
 export type UpdateInfo = UpdateInfoSnapshot;
 export type ProgressInfo = UpdateProgressSnapshot;
 export type UpdateStatus = UpdateStatusSnapshot['status'];
@@ -99,7 +104,7 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
 
       // Auto-check for updates on startup (respects user toggle)
       const autoCheckUpdate = useSettingsStore.getState().autoCheckUpdate;
-      if (autoCheckUpdate) {
+      if (autoCheckUpdate && !isSafeModeUpdateChecksDisabled()) {
         setTimeout(() => {
           get().checkForUpdates().catch(() => {});
         }, 10000);
@@ -116,6 +121,11 @@ export const useUpdateStore = create<UpdateState>((set, get) => ({
   },
 
   checkForUpdates: async () => {
+    if (isSafeModeUpdateChecksDisabled()) {
+      set({ status: 'not-available', error: null });
+      return;
+    }
+
     set({ status: 'checking', error: null });
     
     try {

--- a/tests/unit/channel-config.test.ts
+++ b/tests/unit/channel-config.test.ts
@@ -317,6 +317,68 @@ describe('WeCom plugin configuration', () => {
   });
 });
 
+describe('OpenClaw config writer guard', () => {
+  beforeEach(async () => {
+    vi.resetAllMocks();
+    vi.resetModules();
+    await rm(testHome, { recursive: true, force: true });
+    await rm(testUserData, { recursive: true, force: true });
+    delete process.env.LAH_SAFE_MODE;
+    delete process.env.CLAWX_OPENCLAW_CONFIG_MUTATION;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_URL;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_ENABLED;
+  });
+
+  it('skips writing openclaw.json in LAH safe mode', async () => {
+    process.env.LAH_SAFE_MODE = '1';
+    const { writeOpenClawConfig } = await import('@electron/utils/channel-config');
+
+    await writeOpenClawConfig({
+      channels: {
+        telegram: {
+          botToken: 'token',
+          proxy: 'socks5://127.0.0.1:7891',
+        },
+      },
+    });
+
+    expect(existsSync(join(testHome, '.openclaw', 'openclaw.json'))).toBe(false);
+    expect(mockLoggerInfo).toHaveBeenCalledWith('Skipping OpenClaw config write because config mutation is disabled');
+  });
+
+  it('skips writing openclaw.json when config mutation is disabled', async () => {
+    process.env.CLAWX_OPENCLAW_CONFIG_MUTATION = '0';
+    const { writeOpenClawConfig } = await import('@electron/utils/channel-config');
+
+    await writeOpenClawConfig({
+      channels: {
+        telegram: {
+          botToken: 'token',
+          proxy: 'socks5://127.0.0.1:7891',
+        },
+      },
+    });
+
+    expect(existsSync(join(testHome, '.openclaw', 'openclaw.json'))).toBe(false);
+  });
+
+  it('skips writing openclaw.json in external Gateway mode', async () => {
+    process.env.CLAWX_EXTERNAL_GATEWAY_URL = 'ws://127.0.0.1:4000/gateway';
+    const { writeOpenClawConfig } = await import('@electron/utils/channel-config');
+
+    await writeOpenClawConfig({
+      channels: {
+        telegram: {
+          botToken: 'token',
+          proxy: 'socks5://127.0.0.1:7891',
+        },
+      },
+    });
+
+    expect(existsSync(join(testHome, '.openclaw', 'openclaw.json'))).toBe(false);
+  });
+});
+
 describe('WeChat dangling plugin cleanup', () => {
   beforeEach(async () => {
     vi.resetAllMocks();

--- a/tests/unit/external-links.test.ts
+++ b/tests/unit/external-links.test.ts
@@ -1,0 +1,29 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const openExternalMock = vi.fn();
+
+vi.mock('electron', () => ({
+  shell: {
+    openExternal: openExternalMock,
+  },
+}));
+
+describe('openExternalUrl', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.LAH_SAFE_MODE = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
+  });
+
+  it('blocks browser opening in LAH safe mode', async () => {
+    const { openExternalUrl } = await import('@electron/utils/external-links');
+
+    await openExternalUrl('https://example.com');
+
+    expect(openExternalMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/gateway-config-sync-safe-mode.test.ts
+++ b/tests/unit/gateway-config-sync-safe-mode.test.ts
@@ -1,0 +1,93 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const syncProxyConfigToOpenClawMock = vi.fn();
+const sanitizeOpenClawConfigMock = vi.fn();
+const cleanupDanglingWeChatPluginStateMock = vi.fn();
+const loggerInfoMock = vi.fn();
+
+vi.mock('@electron/utils/runtime-flags', () => ({
+  isOpenClawConfigMutationEnabled: () => false,
+}));
+
+vi.mock('@electron/utils/openclaw-proxy', () => ({
+  syncProxyConfigToOpenClaw: syncProxyConfigToOpenClawMock,
+}));
+
+vi.mock('@electron/utils/openclaw-auth', () => ({
+  sanitizeOpenClawConfig: sanitizeOpenClawConfigMock,
+  batchSyncConfigFields: vi.fn(),
+}));
+
+vi.mock('@electron/utils/channel-config', () => ({
+  cleanupDanglingWeChatPluginState: cleanupDanglingWeChatPluginStateMock,
+  listConfiguredChannelsFromConfig: vi.fn(),
+  readOpenClawConfig: vi.fn(),
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    info: loggerInfoMock,
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('gateway config sync safe mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('skips prelaunch OpenClaw mutation work when config mutation is disabled', async () => {
+    const { syncGatewayConfigBeforeLaunch } = await import('@electron/gateway/config-sync');
+
+    const result = await syncGatewayConfigBeforeLaunch({
+      theme: 'system',
+      language: 'en',
+      startMinimized: false,
+      launchAtStartup: false,
+      telemetryEnabled: true,
+      machineId: '',
+      hasReportedInstall: false,
+      gatewayAutoStart: true,
+      gatewayPort: 18789,
+      gatewayToken: 'token',
+      proxyEnabled: false,
+      proxyServer: '',
+      proxyHttpServer: '',
+      proxyHttpsServer: '',
+      proxyAllServer: '',
+      proxyBypassRules: '',
+      externalGatewayEnabled: true,
+      externalGatewayUrl: 'ws://127.0.0.1:4000/gateway',
+      gatewaySpawnEnabled: false,
+      gatewayKillOnConflictEnabled: false,
+      openclawConfigMutationEnabled: false,
+      updateChecksEnabled: false,
+      providerValidationEnabled: false,
+      oauthEnabled: false,
+      externalUrlOpeningEnabled: false,
+      connectivityProbeEnabled: false,
+      updateChannel: 'stable',
+      autoCheckUpdate: true,
+      autoDownloadUpdate: false,
+      skippedVersions: [],
+      sidebarCollapsed: false,
+      devModeUnlocked: false,
+      selectedBundles: [],
+      enabledSkills: [],
+      disabledSkills: [],
+    }, '/tmp/clawx-openclaw');
+
+    expect(result.timingsMs).toEqual({});
+    expect(result.maintenance).toEqual({});
+    expect(result.configuredChannels).toEqual([]);
+    expect(syncProxyConfigToOpenClawMock).not.toHaveBeenCalled();
+    expect(sanitizeOpenClawConfigMock).not.toHaveBeenCalled();
+    expect(cleanupDanglingWeChatPluginStateMock).not.toHaveBeenCalled();
+    expect(loggerInfoMock).toHaveBeenCalledWith(
+      '[gateway-config-sync] Skipping prelaunch OpenClaw mutation because config mutation is disabled',
+    );
+  });
+});

--- a/tests/unit/gateway-external-mode.test.ts
+++ b/tests/unit/gateway-external-mode.test.ts
@@ -1,0 +1,108 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const wsState = vi.hoisted(() => ({
+  sockets: [] as Array<{ url: string; close: () => void; emit: (event: string, ...args: unknown[]) => void }>,
+  MockWebSocket: class MockWebSocket {
+    readonly listeners = new Map<string, Set<(...args: unknown[]) => void>>();
+    readyState = 1;
+    constructor(public readonly url: string) {
+      wsState.sockets.push(this);
+    }
+    on(event: string, callback: (...args: unknown[]) => void): this {
+      const current = this.listeners.get(event) ?? new Set();
+      current.add(callback);
+      this.listeners.set(event, current);
+      return this;
+    }
+    emit(event: string, ...args: unknown[]): void {
+      for (const callback of this.listeners.get(event) ?? []) {
+        callback(...args);
+      }
+    }
+    close(): void {
+      this.readyState = 3;
+      queueMicrotask(() => this.emit('close', 1000, Buffer.from('')));
+    }
+    terminate(): void {
+      this.readyState = 3;
+    }
+    send(): void {}
+  },
+}));
+
+vi.mock('ws', () => ({
+  default: wsState.MockWebSocket,
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@electron/utils/runtime-flags', () => ({
+  isGatewaySpawnEnabled: () => false,
+}));
+
+describe('gateway external mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    wsState.sockets.length = 0;
+  });
+
+  it('connects to the exact external Gateway URL without forcing /ws', async () => {
+    const { connectGatewaySocket } = await import('@electron/gateway/ws-client');
+
+    const pendingRequests = new Map();
+    const connection = connectGatewaySocket({
+      port: 18789,
+      wsUrl: 'ws://127.0.0.1:4000/gateway',
+      deviceIdentity: null,
+      platform: 'linux',
+      pendingRequests,
+      getToken: async () => 'token',
+      onHandshakeComplete: vi.fn(),
+      onMessage: vi.fn(),
+      onCloseAfterHandshake: vi.fn(),
+      challengeTimeoutMs: 10,
+      connectTimeoutMs: 10,
+    });
+
+    const socket = wsState.sockets[0];
+    expect(socket?.url).toBe('ws://127.0.0.1:4000/gateway');
+    expect(socket?.url).not.toContain('/ws');
+
+    socket?.close();
+    await expect(connection).rejects.toBeInstanceOf(Error);
+  });
+
+  it('blocks managed Gateway spawning when spawn is disabled', async () => {
+    const { launchGatewayProcess } = await import('@electron/gateway/process-launcher');
+
+    await expect(launchGatewayProcess({
+      port: 18789,
+      launchContext: {
+        appSettings: {} as never,
+        openclawDir: '/tmp/clawx-openclaw',
+        entryScript: '/tmp/clawx-openclaw/openclaw.mjs',
+        gatewayArgs: [],
+        forkEnv: {},
+        mode: 'dev',
+        binPathExists: false,
+        loadedProviderKeyCount: 0,
+        proxySummary: 'disabled',
+        channelStartupSummary: 'none',
+      },
+      sanitizeSpawnArgs: (args) => args,
+      getCurrentState: () => 'starting',
+      getShouldReconnect: () => false,
+      onStderrLine: vi.fn(),
+      onSpawn: vi.fn(),
+      onExit: vi.fn(),
+      onError: vi.fn(),
+    })).rejects.toThrow('Gateway spawning is disabled in external gateway / safe mode');
+  });
+});

--- a/tests/unit/gateway-supervisor-safe-mode.test.ts
+++ b/tests/unit/gateway-supervisor-safe-mode.test.ts
@@ -1,6 +1,12 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const mockExec = vi.fn();
+const mockProbeGatewayReady = vi.fn();
+const originalPlatform = process.platform;
+
+function setPlatform(platform: string): void {
+  Object.defineProperty(process, 'platform', { value: platform, writable: true });
+}
 
 vi.mock('electron', () => ({
   app: {
@@ -29,6 +35,10 @@ vi.mock('@electron/utils/runtime-flags', () => ({
   isGatewayKillOnConflictEnabled: () => false,
 }));
 
+vi.mock('@electron/gateway/ws-client', () => ({
+  probeGatewayReady: mockProbeGatewayReady,
+}));
+
 vi.mock('@electron/utils/logger', () => ({
   logger: {
     info: vi.fn(),
@@ -42,14 +52,51 @@ describe('gateway supervisor safe mode', () => {
   beforeEach(() => {
     vi.resetModules();
     vi.clearAllMocks();
+    mockProbeGatewayReady.mockReset();
+    setPlatform('win32');
+    mockExec.mockImplementation((cmd: string, _opts: object, cb: (err: Error | null, stdout: string) => void) => {
+      if (cmd.includes('netstat -ano')) {
+        cb(null, '  TCP    127.0.0.1:18789    0.0.0.0:0    LISTENING    4321\n');
+        return {} as never;
+      }
+      cb(null, '');
+      return {} as never;
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
   });
 
   it('skips orphan cleanup when kill-on-conflict is disabled', async () => {
+    mockProbeGatewayReady.mockResolvedValue(false);
     const { findExistingGatewayProcess } = await import('@electron/gateway/supervisor');
 
-    const result = await findExistingGatewayProcess({ port: 18789, ownedPid: 4321 });
+    const result = await findExistingGatewayProcess({ port: 18789, ownedPid: 9999 });
 
     expect(result).toBeNull();
-    expect(mockExec).not.toHaveBeenCalled();
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('netstat -ano'),
+      expect.objectContaining({ timeout: 5000, windowsHide: true }),
+      expect.any(Function),
+    );
+    expect(mockExec.mock.calls.some(([cmd]) => String(cmd).includes('taskkill'))).toBe(false);
+    expect(mockProbeGatewayReady).toHaveBeenCalledWith(18789, 5000);
+  });
+
+  it('still attaches to a healthy existing gateway when kill-on-conflict is disabled', async () => {
+    mockProbeGatewayReady.mockResolvedValue(true);
+    const { findExistingGatewayProcess } = await import('@electron/gateway/supervisor');
+
+    const result = await findExistingGatewayProcess({ port: 18789, ownedPid: 9999 });
+
+    expect(result).toEqual({ port: 18789 });
+    expect(mockExec).toHaveBeenCalledWith(
+      expect.stringContaining('netstat -ano'),
+      expect.objectContaining({ timeout: 5000, windowsHide: true }),
+      expect.any(Function),
+    );
+    expect(mockExec.mock.calls.some(([cmd]) => String(cmd).includes('taskkill'))).toBe(false);
+    expect(mockProbeGatewayReady).toHaveBeenCalledWith(18789, 5000);
   });
 });

--- a/tests/unit/gateway-supervisor-safe-mode.test.ts
+++ b/tests/unit/gateway-supervisor-safe-mode.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockExec = vi.fn();
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp',
+  },
+  utilityProcess: {},
+}));
+
+vi.mock('child_process', () => ({
+  exec: mockExec,
+  execSync: vi.fn(),
+  spawn: vi.fn(),
+  default: {
+    exec: mockExec,
+    execSync: vi.fn(),
+    spawn: vi.fn(),
+  },
+}));
+
+vi.mock('net', () => ({
+  createServer: vi.fn(),
+}));
+
+vi.mock('@electron/utils/runtime-flags', () => ({
+  isGatewayKillOnConflictEnabled: () => false,
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+describe('gateway supervisor safe mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+  });
+
+  it('skips orphan cleanup when kill-on-conflict is disabled', async () => {
+    const { findExistingGatewayProcess } = await import('@electron/gateway/supervisor');
+
+    const result = await findExistingGatewayProcess({ port: 18789, ownedPid: 4321 });
+
+    expect(result).toBeNull();
+    expect(mockExec).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/oauth-safe-mode.test.ts
+++ b/tests/unit/oauth-safe-mode.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const loginOpenAICodexOAuthMock = vi.fn();
+const loginMiniMaxPortalOAuthMock = vi.fn();
+
+vi.mock('@electron/utils/runtime-flags', () => ({
+  isOAuthEnabledByRuntime: () => false,
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
+}));
+
+vi.mock('@electron/utils/openai-codex-oauth', () => ({
+  loginOpenAICodexOAuth: loginOpenAICodexOAuthMock,
+}));
+
+vi.mock('@electron/utils/minimax-oauth', () => ({
+  loginMiniMaxPortalOAuth: loginMiniMaxPortalOAuthMock,
+}));
+
+vi.mock('electron', () => ({
+  BrowserWindow: class {},
+}));
+
+describe('oauth safe mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.LAH_SAFE_MODE = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
+  });
+
+  it('blocks browser OAuth flows', async () => {
+    const { browserOAuthManager } = await import('@electron/utils/browser-oauth');
+
+    await expect(browserOAuthManager.startFlow('openai')).resolves.toBe(false);
+    expect(loginOpenAICodexOAuthMock).not.toHaveBeenCalled();
+  });
+
+  it('blocks device OAuth flows', async () => {
+    const { deviceOAuthManager } = await import('@electron/utils/device-oauth');
+
+    await expect(deviceOAuthManager.startFlow('minimax-portal')).resolves.toBe(false);
+    expect(loginMiniMaxPortalOAuthMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/openclaw-auth-safe-mode.test.ts
+++ b/tests/unit/openclaw-auth-safe-mode.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { withConfigLockMock } = vi.hoisted(() => ({
+  withConfigLockMock: vi.fn(async (task: () => Promise<unknown>) => await task()),
+}));
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => '/tmp/clawx-openclaw-safe-mode-user-data',
+  },
+}));
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  const mocked = {
+    ...actual,
+    homedir: () => '/tmp/clawx-openclaw-safe-mode-home',
+  };
+  return {
+    ...mocked,
+    default: mocked,
+  };
+});
+
+vi.mock('@electron/utils/config-mutex', () => ({
+  withConfigLock: withConfigLockMock,
+}));
+
+vi.mock('@electron/utils/runtime-flags', () => ({
+  isOpenClawConfigMutationEnabled: () => false,
+}));
+
+describe('openclaw-auth safe mode', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    process.env.LAH_SAFE_MODE = '1';
+  });
+
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
+  });
+
+  it('short-circuits config mutation entry points without locking or writes', async () => {
+    const auth = await import('@electron/utils/openclaw-auth');
+
+    await auth.saveOAuthTokenToOpenClaw('openai', {
+      access: 'access',
+      refresh: 'refresh',
+      expires: Date.now() + 1000,
+    });
+
+    await auth.batchSyncConfigFields('token');
+    await auth.sanitizeOpenClawConfig();
+
+    expect(withConfigLockMock).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/openclaw-proxy.test.ts
+++ b/tests/unit/openclaw-proxy.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   readOpenClawConfigMock,
@@ -31,6 +31,17 @@ vi.mock('@electron/utils/logger', () => ({
 describe('syncProxyConfigToOpenClaw', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    delete process.env.LAH_SAFE_MODE;
+    delete process.env.CLAWX_OPENCLAW_CONFIG_MUTATION;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_URL;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_ENABLED;
+  });
+
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
+    delete process.env.CLAWX_OPENCLAW_CONFIG_MUTATION;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_URL;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_ENABLED;
   });
 
   it('preserves existing telegram proxy on startup-style sync when proxy is disabled', async () => {
@@ -85,5 +96,32 @@ describe('syncProxyConfigToOpenClaw', () => {
       channels: { telegram: Record<string, unknown> };
     };
     expect(updatedConfig.channels.telegram.proxy).toBeUndefined();
+  });
+
+  it('skips Telegram proxy sync when OpenClaw config mutation is disabled', async () => {
+    process.env.LAH_SAFE_MODE = '1';
+    readOpenClawConfigMock.mockResolvedValue({
+      channels: {
+        telegram: {
+          botToken: 'token',
+          proxy: 'socks5://127.0.0.1:7891',
+        },
+      },
+    });
+
+    const { syncProxyConfigToOpenClaw } = await import('@electron/utils/openclaw-proxy');
+
+    await syncProxyConfigToOpenClaw({
+      proxyEnabled: true,
+      proxyServer: '127.0.0.1:7891',
+      proxyHttpServer: '',
+      proxyHttpsServer: '',
+      proxyAllServer: '',
+      proxyBypassRules: '',
+    });
+
+    expect(readOpenClawConfigMock).not.toHaveBeenCalled();
+    expect(writeOpenClawConfigMock).not.toHaveBeenCalled();
+    expect(withConfigLockMock).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -1,4 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { tmpdir } from 'node:os';
 
 const testUserDataDir = '/tmp/clawx-paths-test-user-data';
 const testHomeDir = '/tmp/clawx-paths-test-home';
@@ -44,5 +47,19 @@ describe('path utilities', () => {
 
     expect(getOpenClawConfigDir()).toBe('/tmp/clawx-paths-test-home/.openclaw');
     expect(getOpenClawConfigDir()).not.toContain('/home/deploy/.openclaw');
+  });
+
+  it('creates missing directories with ensureDir', async () => {
+    const { ensureDir } = await import('@electron/utils/paths');
+    const root = mkdtempSync(join(tmpdir(), 'clawx-ensure-dir-'));
+    const nested = join(root, 'fresh', 'user-data');
+
+    try {
+      expect(existsSync(nested)).toBe(false);
+      ensureDir(nested);
+      expect(existsSync(nested)).toBe(true);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/tests/unit/paths.test.ts
+++ b/tests/unit/paths.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const testUserDataDir = '/tmp/clawx-paths-test-user-data';
+const testHomeDir = '/tmp/clawx-paths-test-home';
+
+vi.mock('os', async () => {
+  const actual = await vi.importActual<typeof import('os')>('os');
+  const mocked = {
+    ...actual,
+    homedir: () => testHomeDir,
+  };
+  return {
+    ...mocked,
+    default: mocked,
+  };
+});
+
+vi.mock('electron', () => ({
+  app: {
+    isPackaged: false,
+    getPath: () => testUserDataDir,
+    getAppPath: () => '/tmp/clawx-app',
+  },
+}));
+
+describe('path utilities', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    process.env.CLAWX_USER_DATA_DIR = '/tmp/clawx-override-user-data';
+  });
+
+  afterEach(() => {
+    delete process.env.CLAWX_USER_DATA_DIR;
+  });
+
+  it('prefers CLAWX_USER_DATA_DIR for data dir resolution', async () => {
+    const { getDataDir } = await import('@electron/utils/paths');
+
+    expect(getDataDir()).toBe('/tmp/clawx-override-user-data');
+  });
+
+  it('keeps OpenClaw config rooted under the isolated home directory', async () => {
+    const { getOpenClawConfigDir } = await import('@electron/utils/paths');
+
+    expect(getOpenClawConfigDir()).toBe('/tmp/clawx-paths-test-home/.openclaw');
+    expect(getOpenClawConfigDir()).not.toContain('/home/deploy/.openclaw');
+  });
+});

--- a/tests/unit/provider-validation.test.ts
+++ b/tests/unit/provider-validation.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const proxyAwareFetch = vi.fn();
 
@@ -15,6 +15,10 @@ describe('validateApiKeyWithProvider', () => {
         headers: { 'Content-Type': 'application/json' },
       })
     );
+  });
+
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
   });
 
   it('validates MiniMax CN keys with Anthropic headers', async () => {
@@ -402,5 +406,18 @@ describe('validateApiKeyWithProvider', () => {
         method: 'POST',
       })
     );
+  });
+
+  it('short-circuits when provider validation is disabled in LAH safe mode', async () => {
+    process.env.LAH_SAFE_MODE = '1';
+
+    const { validateApiKeyWithProvider } = await import('@electron/services/providers/provider-validation');
+    const result = await validateApiKeyWithProvider('openai', 'sk-safe-mode');
+
+    expect(result).toMatchObject({
+      valid: false,
+      error: 'Provider validation is disabled in LAH safe mode',
+    });
+    expect(proxyAwareFetch).not.toHaveBeenCalled();
   });
 });

--- a/tests/unit/runtime-flags.test.ts
+++ b/tests/unit/runtime-flags.test.ts
@@ -1,0 +1,82 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+const envKeys = [
+  'LAH_SAFE_MODE',
+  'CLAWX_EXTERNAL_GATEWAY_URL',
+  'CLAWX_EXTERNAL_GATEWAY_ENABLED',
+  'CLAWX_GATEWAY_SPAWN_ENABLED',
+  'CLAWX_GATEWAY_KILL_ON_CONFLICT',
+  'CLAWX_OPENCLAW_CONFIG_MUTATION',
+  'CLAWX_TELEMETRY_ENABLED',
+  'CLAWX_UPDATE_CHECKS_ENABLED',
+  'CLAWX_PROVIDER_VALIDATION_ENABLED',
+  'CLAWX_OAUTH_ENABLED',
+  'CLAWX_EXTERNAL_URL_OPENING_ENABLED',
+  'CLAWX_CONNECTIVITY_PROBE_ENABLED',
+] as const;
+
+const originalEnv = Object.fromEntries(envKeys.map((key) => [key, process.env[key]]));
+
+function resetEnv(): void {
+  for (const key of envKeys) {
+    const value = originalEnv[key];
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+}
+
+describe('runtime-flags', () => {
+  beforeEach(() => {
+    resetEnv();
+    vi.resetModules();
+  });
+
+  afterEach(() => {
+    resetEnv();
+  });
+
+  it('uses the LAH external gateway default when no override is present', async () => {
+    delete process.env.LAH_SAFE_MODE;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_URL;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_ENABLED;
+
+    const flags = await import('@electron/utils/runtime-flags');
+
+    expect(flags.getExternalGatewayUrl()).toBe('ws://127.0.0.1:4000/gateway');
+    expect(flags.isLahSafeMode()).toBe(false);
+    expect(flags.isExternalGatewayEnabled()).toBe(false);
+    expect(flags.isGatewaySpawnEnabled()).toBe(true);
+    expect(flags.isGatewayKillOnConflictEnabled()).toBe(true);
+    expect(flags.isOpenClawConfigMutationEnabled()).toBe(true);
+    expect(flags.isTelemetryEnabledByRuntime()).toBe(true);
+    expect(flags.isUpdateChecksEnabledByRuntime()).toBe(true);
+    expect(flags.isProviderValidationEnabledByRuntime()).toBe(true);
+    expect(flags.isOAuthEnabledByRuntime()).toBe(true);
+    expect(flags.isExternalUrlOpeningEnabledByRuntime()).toBe(true);
+    expect(flags.isConnectivityProbeEnabledByRuntime()).toBe(true);
+  });
+
+  it('forces safe-mode gates when LAH_SAFE_MODE=1', async () => {
+    process.env.LAH_SAFE_MODE = '1';
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_URL;
+    delete process.env.CLAWX_EXTERNAL_GATEWAY_ENABLED;
+
+    const flags = await import('@electron/utils/runtime-flags');
+
+    expect(flags.isLahSafeMode()).toBe(true);
+    expect(flags.isExternalGatewayEnabled()).toBe(true);
+    expect(flags.getExternalGatewayUrl()).toBe('ws://127.0.0.1:4000/gateway');
+    expect(flags.isGatewaySpawnEnabled()).toBe(false);
+    expect(flags.isGatewayKillOnConflictEnabled()).toBe(false);
+    expect(flags.isOpenClawConfigMutationEnabled()).toBe(false);
+    expect(flags.isTelemetryEnabledByRuntime()).toBe(false);
+    expect(flags.isUpdateChecksEnabledByRuntime()).toBe(false);
+    expect(flags.isProviderValidationEnabledByRuntime()).toBe(false);
+    expect(flags.isOAuthEnabledByRuntime()).toBe(false);
+    expect(flags.isExternalUrlOpeningEnabledByRuntime()).toBe(false);
+    expect(flags.isConnectivityProbeEnabledByRuntime()).toBe(false);
+  });
+});

--- a/tests/unit/telemetry.test.ts
+++ b/tests/unit/telemetry.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 const {
   shutdownMock,
@@ -69,6 +69,10 @@ describe('main telemetry shutdown', () => {
     captureMock.mockReturnValue(undefined);
   });
 
+  afterEach(() => {
+    delete process.env.LAH_SAFE_MODE;
+  });
+
   it('ignores PostHog network timeout errors during shutdown', async () => {
     shutdownMock.mockRejectedValueOnce(
       Object.assign(new Error('Network error while fetching PostHog'), {
@@ -88,5 +92,15 @@ describe('main telemetry shutdown', () => {
       'Ignored telemetry shutdown network error:',
       expect.objectContaining({ name: 'PostHogFetchNetworkError' }),
     );
+  });
+
+  it('does not initialize telemetry when LAH safe mode is enabled', async () => {
+    process.env.LAH_SAFE_MODE = '1';
+
+    const { initTelemetry } = await import('@electron/utils/telemetry');
+    await initTelemetry();
+
+    expect(captureMock).not.toHaveBeenCalled();
+    expect(shutdownMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
# CLAWX Phase 1 Isolated External Gateway Operator Packet

## Purpose
Prepare ClawX for a future isolated Phase 1 run that attaches to an existing LAH Gateway instead of spawning or mutating a production OpenClaw runtime.

## What Changed
- Added explicit external Gateway mode.
- Added LAH safe-mode runtime gates for telemetry, update checks, OAuth, provider validation, external URL opening, and connectivity probes.
- Added isolated userData and HOME-aware path resolution.
- Added offline tests for the new runtime gates and safety boundaries.

## Exact Env Vars
Use these for future isolated Phase 1 runs:

```bash
export LAH_SAFE_MODE=1
export HOME=/home/deploy/lah-stack-runtime/clawx-phase1/home
export CLAWX_USER_DATA_DIR=/home/deploy/lah-stack-runtime/clawx-phase1/userData
export CLAWX_EXTERNAL_GATEWAY_URL=ws://127.0.0.1:4000/gateway
export CLAWX_GATEWAY_SPAWN_ENABLED=0
export CLAWX_GATEWAY_KILL_ON_CONFLICT=0
export CLAWX_OPENCLAW_CONFIG_MUTATION=0
export CLAWX_TELEMETRY_ENABLED=0
export CLAWX_UPDATE_CHECKS_ENABLED=0
export CLAWX_PROVIDER_VALIDATION_ENABLED=0
export CLAWX_OAUTH_ENABLED=0
export CLAWX_EXTERNAL_URL_OPENING_ENABLED=0
export CLAWX_CONNECTIVITY_PROBE_ENABLED=0
```

## Exact Isolated Paths
- `/home/deploy/lah-stack-runtime/clawx-phase1/home`
- `/home/deploy/lah-stack-runtime/clawx-phase1/userData`
- `/home/deploy/lah-stack-runtime/clawx-phase1/logs`
- `/home/deploy/lah-stack-runtime/clawx-phase1/home/.openclaw`

## Forbidden Production Paths
- `/home/deploy/.openclaw`
- `/home/deploy/.hermes`
- any production provider secret store
- any production ClawX or OpenClaw runtime directory

## Allowed Future Commands
- `git status`
- `git diff`
- offline unit tests
- static type checks that do not install dependencies
- isolated-path smoke checks that do not launch Electron, Gateway, or OpenClaw

## Forbidden Commands
- `pnpm install`
- `npm install`
- `pnpm run init`
- Electron launch
- OpenClaw launch
- Gateway launch
- any network-dependent check
- any provider-secret import or migration
- any command that writes to production `~/.openclaw`

## Rollback Plan
- Remove only the isolated runtime directory tree if it was created for testing.
- Do not delete production `~/.openclaw`.
- Do not delete production credentials.
- Do not delete production agents.
- Do not delete production skills or extensions unless they were explicitly created inside the isolated ClawX env.
- Revert the branch with git if the patch must be removed.

## Tests Run
- Offline unit tests only.
- No runtime launches.
- No provider or network checks.

## Tests Not Run and Why
- Electron launch: forbidden by mission scope.
- Gateway launch: forbidden by mission scope.
- OpenClaw launch: forbidden by mission scope.
- Install scripts: forbidden by mission scope.
- Network checks: forbidden by mission scope.

## Residual Risks
- External Gateway support is still a pre-Phase 1 bridge, not a full production isolation boundary.
- OpenClaw secret storage remains a migration risk until keychain-backed storage exists.
- Install-chain verification is still pending checksum/signature hardening.

## Next BR Recommendation
- Hardening BR for install-chain verification and deterministic offline artifact handling.
- Secret-storage BR for keychain-backed provider secrets.
- Follow-up BR for any remaining direct OpenClaw runtime coupling discovered during Phase 1.
