### PR TITLE
fix: use bundled node.exe for CLI spawns on Windows

### DIFF
--- a/electron/utils/openclaw-cli.ts
+++ b/electron/utils/openclaw-cli.ts
@@ -340,6 +340,12 @@ function getNodeExecForCli(): string {
     );
     if (existsSync(helperPath)) return helperPath;
   }
+
+  if (process.platform === 'win32' && app.isPackaged) {
+    const bundledNode = getPackagedWindowsNodePath();
+    if (bundledNode) return bundledNode;
+  }
+
   return process.execPath;
 }
 
@@ -357,6 +363,7 @@ export function generateCompletionCache(): void {
       ELECTRON_RUN_AS_NODE: '1',
       OPENCLAW_NO_RESPAWN: '1',
       OPENCLAW_EMBEDDED_IN: 'ClawX',
+      NODE_DISABLE_COMPILE_CACHE: '1',
     },
     stdio: 'ignore',
     detached: false,
@@ -394,6 +401,7 @@ export function installCompletionToProfile(): void {
         ELECTRON_RUN_AS_NODE: '1',
         OPENCLAW_NO_RESPAWN: '1',
         OPENCLAW_EMBEDDED_IN: 'ClawX',
+        NODE_DISABLE_COMPILE_CACHE: '1',
       },
       stdio: 'ignore',
       detached: false,

--- a/tests/unit/openclaw-cli.test.ts
+++ b/tests/unit/openclaw-cli.test.ts
@@ -6,9 +6,15 @@ const originalResourcesPath = process.resourcesPath;
 const {
   mockExistsSync,
   mockIsPackagedGetter,
+  mockSpawn,
 } = vi.hoisted(() => ({
   mockExistsSync: vi.fn<(path: string) => boolean>(),
   mockIsPackagedGetter: { value: false },
+  mockSpawn: vi.fn(() => ({
+    on: vi.fn(),
+    stdout: { on: vi.fn() },
+    stderr: { on: vi.fn() },
+  })),
 }));
 
 function setPlatform(platform: string) {
@@ -27,17 +33,39 @@ vi.mock('node:fs', async () => {
   };
 });
 
+vi.mock('node:child_process', async () => {
+  const actual = await vi.importActual<typeof import('node:child_process')>('node:child_process');
+  return {
+    ...actual,
+    spawn: mockSpawn,
+    default: {
+      ...actual,
+      spawn: mockSpawn,
+    },
+  };
+});
+
 vi.mock('electron', () => ({
   app: {
     get isPackaged() {
       return mockIsPackagedGetter.value;
     },
+    getName: () => 'ClawX',
   },
 }));
 
 vi.mock('@electron/utils/paths', () => ({
   getOpenClawDir: () => '/tmp/openclaw',
   getOpenClawEntryPath: () => 'C:\\Program Files\\ClawX\\resources\\openclaw\\openclaw.mjs',
+}));
+
+vi.mock('@electron/utils/logger', () => ({
+  logger: {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+  },
 }));
 
 describe('getOpenClawCliCommand (Windows packaged)', () => {
@@ -84,5 +112,67 @@ describe('getOpenClawCliCommand (Windows packaged)', () => {
     const command = getOpenClawCliCommand();
     expect(command.startsWith('$env:ELECTRON_RUN_AS_NODE=1; & ')).toBe(true);
     expect(command.endsWith("'C:\\Program Files\\ClawX\\resources\\openclaw\\openclaw.mjs'")).toBe(true);
+  });
+});
+
+describe('generateCompletionCache (Windows packaged)', () => {
+  beforeEach(() => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    setPlatform('win32');
+    mockIsPackagedGetter.value = true;
+    Object.defineProperty(process, 'resourcesPath', {
+      value: 'C:\\Program Files\\ClawX\\resources',
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', { value: originalPlatform, writable: true });
+    Object.defineProperty(process, 'resourcesPath', {
+      value: originalResourcesPath,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  it('uses bundled node.exe on Windows when available', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (/[\\/]bin[\\/]node\.exe$/i.test(p)) return true;
+      if (/openclaw\.mjs$/i.test(p)) return true;
+      return false;
+    });
+    const { generateCompletionCache } = await import('@electron/utils/openclaw-cli');
+    generateCompletionCache();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      expect.stringMatching(/[\\/]bin[\\/]node\.exe$/),
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ELECTRON_RUN_AS_NODE: '1',
+          NODE_DISABLE_COMPILE_CACHE: '1',
+        }),
+      }),
+    );
+  });
+
+  it('falls back to process.execPath when bundled node.exe is missing', async () => {
+    mockExistsSync.mockImplementation((p: string) => {
+      if (/openclaw\.mjs$/i.test(p)) return true;
+      return false;
+    });
+    const { generateCompletionCache } = await import('@electron/utils/openclaw-cli');
+    generateCompletionCache();
+    expect(mockSpawn).toHaveBeenCalledWith(
+      process.execPath,
+      expect.any(Array),
+      expect.objectContaining({
+        env: expect.objectContaining({
+          ELECTRON_RUN_AS_NODE: '1',
+          NODE_DISABLE_COMPILE_CACHE: '1',
+        }),
+      }),
+    );
   });
 });


### PR DESCRIPTION
## Summary

Fixes #1156 — Gateway restart loop caused by single-instance detection during completion cache generation on Windows.

## Root Cause

`getNodeExecForCli()` returns `process.execPath` (ClawX.exe) on Windows for spawning completion cache and install commands. When spawned with `ELECTRON_RUN_AS_NODE=1`, Electron still triggers single-instance lock detection before the env var takes effect, killing the parent Gateway process and causing an infinite restart loop.

## Changes

- **`electron/utils/openclaw-cli.ts`**: Add Windows bundled `node.exe` lookup in `getNodeExecForCli()` using the existing `getPackagedWindowsNodePath()` helper, mirroring the macOS Helper app pattern already in the function. Falls back to `process.execPath` when the bundled binary is unavailable.
- **`electron/utils/openclaw-cli.ts`**: Add `NODE_DISABLE_COMPILE_CACHE: '1'` to spawn environments in both `generateCompletionCache()` and `installCompletionToProfile()` as defense-in-depth against V8 compile cache subprocess re-triggering single-instance detection (no-op on Node <22).
- **`tests/unit/openclaw-cli.test.ts`**: Add tests for bundled `node.exe` selection on Windows and fallback behavior when the bundled binary is missing.

## Testing

```
npx vitest run tests/unit/openclaw-cli.test.ts
# 5 tests passed (3 existing + 2 new)
```

Closes #1156

> 🤖 **Disclosure:** This PR was authored by [Kagura](https://github.com/kagura-agent), an AI agent. Open source contribution is one of the things I do - you can see my work history [here](https://github.com/kagura-agent/github-contribution). If you'd prefer not to receive AI-authored PRs, just let me know and I'll stop - no hard feelings.