### PR TITLE
fix: preserve agent model fallbacks when switching models

### DIFF
--- a/electron/utils/agent-config.ts
+++ b/electron/utils/agent-config.ts
@@ -677,7 +677,29 @@ export async function updateAgentModel(agentId: string, modelRef: string | null)
       if (!isValidModelRef(normalizedModelRef)) {
         throw new Error('modelRef must be in "provider/model" format');
       }
-      nextEntry.model = { primary: normalizedModelRef };
+      // Merge into the existing model block: replacing it wholesale discards
+      // hand-configured fields such as `fallbacks`.
+      const existingModel = entries[index].model;
+      const nextModel: AgentModelConfig = existingModel && typeof existingModel === 'object'
+        ? { ...existingModel, primary: normalizedModelRef }
+        : { primary: normalizedModelRef };
+      // The OpenClaw runtime treats a per-agent model block without a
+      // `fallbacks` key as an EMPTY fallback override, which suppresses
+      // agents.defaults.model.fallbacks entirely. Inherit the defaults chain
+      // so switching models never silently disables failover.
+      if (!Array.isArray(nextModel.fallbacks)) {
+        const defaultsModel = agentsConfig.defaults?.model;
+        const defaultFallbacks = defaultsModel && typeof defaultsModel === 'object'
+          ? (defaultsModel as AgentModelConfig).fallbacks
+          : undefined;
+        if (Array.isArray(defaultFallbacks)) {
+          const inherited = defaultFallbacks.filter((ref): ref is string => typeof ref === 'string' && ref.trim().length > 0);
+          if (inherited.length > 0) {
+            nextModel.fallbacks = inherited;
+          }
+        }
+      }
+      nextEntry.model = nextModel;
     }
 
     entries[index] = nextEntry;


### PR DESCRIPTION
Fixes #1159.

## Problem

`updateAgentModel()` in `electron/utils/agent-config.ts` replaced the agent's `model` block wholesale with `{ primary: modelRef }` on every model switch (in-chat picker or Agents dialog). This has two destructive effects:

1. Any hand-configured `fallbacks` array in that block is silently discarded.
2. The resulting `{ primary }`-only block **disables the agent's entire fallback chain**: the OpenClaw runtime's `resolveSelectedModelFallbacksOverride()` treats a per-agent model block that has `primary` but no `fallbacks` key as an explicit *empty* fallback override, which suppresses `agents.defaults.model.fallbacks` too. The gateway then reports `fallbackConfigured: false`, and a 429/rate-limit on the primary fails the turn with no fallback attempted.

Nothing in the UI indicates failover was turned off. Full analysis, logs, and reproduction in #1159.

## Fix

- **Merge instead of replace:** spread the existing model block and update `primary`, preserving `fallbacks` (and any other fields).
- **Inherit defaults into bare blocks:** when the resulting block would still lack a `fallbacks` key (fresh block, or a pre-existing bare-primary block), copy `agents.defaults.model.fallbacks` into it, so a per-agent primary never silently disables failover.

The `modelRef: null` path (reset to default) is unchanged — deleting the block correctly falls back to the defaults chain.

## Testing

- `tsc --noEmit -p tsconfig.node.json` clean for this file (one pre-existing unrelated error about the generated `_ext-bridge.generated` module in a fresh checkout).
- Direct invocation of `updateAgentModel()` against a real config, all three paths:
  - fresh block → `{ primary, fallbacks: [defaults chain] }` inherited;
  - subsequent switch → primary updated, fallbacks preserved;
  - `null` → block deleted (unchanged behavior).
- Verified from a real GUI click in a dev build: the in-chat picker switch wrote `{ "primary": "openrouter/qwen/qwen3.6-flash", "fallbacks": [ ...full defaults chain... ] }` and gateway failover kept working.

An alternative design would be to keep per-agent blocks primary-only and change the empty-override semantics in the openclaw runtime instead — happy to rework if maintainers prefer that direction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
