### PR TITLE
fix: use agent workspace in ArtifactPanel when no explicit workspace is set

### DIFF
--- a/src/pages/Chat/index.tsx
+++ b/src/pages/Chat/index.tsx
@@ -255,6 +255,33 @@ export function Chat() {
     [agents, currentAgentId],
   );
 
+  // When the effective workspace falls back to the default (~/.openclaw/workspace)
+  // but the current agent has its own dedicated workspace, prefer the agent's
+  // workspace for the ArtifactPanel file browser so users see their agent-specific
+  // files (AGENTS.md, TOOLS.md, etc.) rather than the generic defaults.
+  const artifactPanelWorkspace = useMemo(() => {
+    // If the workspace was explicitly chosen by the user (session-bound or
+    // a non-default global selection), respect that choice.
+    const isImplicitDefault =
+      effectiveWorkspace.source === 'default' ||
+      (effectiveWorkspace.source === 'global' && isDefaultWorkspacePath(cwd));
+    if (!isImplicitDefault) return cwd;
+    // Otherwise prefer the current agent's dedicated workspace if available.
+    const agentWs = currentAgent?.workspace;
+    if (agentWs && !isDefaultWorkspacePath(agentWs)) return agentWs;
+    return cwd;
+  }, [cwd, effectiveWorkspace.source, currentAgent?.workspace]);
+
+  const artifactPanelWorkspaceLabel = useMemo(() => {
+    if (artifactPanelWorkspace === cwd) return workspaceLabel;
+    return getWorkspaceDisplayLabel(
+      artifactPanelWorkspace,
+      t('workspace.defaultLabel'),
+      workspaceLabels,
+      allWorkspacePaths,
+    );
+  }, [artifactPanelWorkspace, cwd, workspaceLabel, t, workspaceLabels, allWorkspacePaths]);
+
   const acpTimeline = useAcpChatSessionStore((s) => s.timeline);
   const acpTurnTimings = useAcpChatSessionStore((s) => s.turnTimingsByUserMessageId);
   const acpLoading = useAcpChatSessionStore((s) => s.loading);
@@ -639,8 +666,8 @@ export function Chat() {
                 fileGroups={fileActivity.fileGroups}
                 uniqueFileCount={fileActivity.uniqueFileCount}
                 agent={currentAgent}
-                workspacePath={cwd}
-                workspaceLabel={workspaceLabel}
+                workspacePath={artifactPanelWorkspace}
+                workspaceLabel={artifactPanelWorkspaceLabel}
                 runStartedAt={null}
               />
             </Suspense>


### PR DESCRIPTION
## What Problem This Solves

When chatting with a non-default agent that has its own dedicated workspace (e.g., `~/.openclaw/workspace-laoa`), the ArtifactPanel workspace browser incorrectly displays files from the default workspace (`~/.openclaw/workspace`) instead of the agent's workspace.

This happens because `resolveEffectiveWorkspace()` falls back to the default workspace path when no session or global workspace is explicitly set. The non-empty default value (`~/.openclaw/workspace`) is passed to `WorkspaceBrowserBody` as `workspacePath`, which prevents the `agent?.workspace` fallback from ever triggering.

Fixes #1209

## Why This Change Was Made

The fix adds a computed `artifactPanelWorkspace` that checks: when the effective workspace source is `"default"` (i.e., no explicit user/session choice) AND the current agent has a non-default workspace, prefer the agent's workspace for the file browser panel.

This only affects the ArtifactPanel props. The ChatInput workspace selector, sidebar session grouping, and all other workspace-dependent logic remain unchanged.

## User Impact

- **Before**: Users with custom agents see generic default workspace files in the browser panel, missing their agent-specific TOOLS.md, AGENTS.md configurations
- **After**: The workspace browser correctly shows the current agent's dedicated workspace and its custom files

## Evidence

- `pnpm run typecheck:node` — passed (0 errors)
- `oxlint src/pages/Chat/index.tsx` — 0 errors, 0 warnings
- Change is minimal: 1 file, +23 lines (two `useMemo` hooks + prop update)