### PR TITLE
fix: restore broken star history chart in READMEs

### DIFF
--- a/README.ja-JP.md
+++ b/README.ja-JP.md
@@ -228,7 +228,7 @@ ClawXをより多くのお客様、特にカスタムAIエージェントや自�
 ## Star History
 
 <p align="center">
-  <img src="https://api.star-history.com/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
+  <img src="https://star-history.dera.page/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
 </p>
 
 ## ライセンス

--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ DM us or email [public@valuecell.ai](mailto:public@valuecell.ai) to learn more.
 ## Star History
 
 <p align="center">
-  <img src="https://api.star-history.com/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
+  <img src="https://star-history.dera.page/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
 </p>
 
 ## License

--- a/README.ru-RU.md
+++ b/README.ru-RU.md
@@ -228,7 +228,7 @@ ClawX построен на основе следующих отличных п�
 ## История звёзд
 
 <p align="center">
-  <img src="https://api.star-history.com/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
+  <img src="https://star-history.dera.page/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Star History Chart" />
 </p>
 
 ## Лицензия

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -230,7 +230,7 @@ ClawX 构建于以下优秀的开源项目之上：
 ## Stars 历史
 
 <p align="center">
-  <img src="https://api.star-history.com/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Stars 历史图表" />
+  <img src="https://star-history.dera.page/svg?repos=ValueCell-ai/ClawX&type=Date" alt="Stars 历史图表" />
 </p>
 
 


### PR DESCRIPTION
The star history chart displayed in the README is currently broken. This change points the chart images to star-history.dera.page, which uses a different data source that does not rely on the restricted GitHub stargazer API, so the chart works again without any API token.