### PR TITLE
fix(acp): bridge run-scoped cron streaming events to active session (#1211)

### DIFF
--- a/src/stores/acp-chat-session.ts
+++ b/src/stores/acp-chat-session.ts
@@ -44,7 +44,7 @@ import { buildCronHistoryAcpNotifications, fetchCronSessionHistory } from '@/lib
 import { hostApi } from '@/lib/host-api';
 import { hostEvents } from '@/lib/host-events';
 import type { AcpTimelineSnapshot, MessageSegmentItem, PermissionItem, RenderPart } from '@/lib/acp/timeline-types';
-import { isCronSessionKey } from './chat/cron-session-utils';
+import { isCronSessionKey, sessionKeysAreEquivalent } from './chat/cron-session-utils';
 
 const EMPTY_SESSION_ID = '';
 const CANCEL_PERMISSION_OPTION_ID = '__cancelled__';
@@ -1408,7 +1408,10 @@ export const useAcpChatSessionStore = create<AcpChatSessionState>((set, get) => 
 
   recordImageGenerationStart(event) {
     const state = get();
-    if (event.sessionKey !== state.activeSessionKey || event.generation !== state.generation) return;
+    if (
+      !sessionKeysAreEquivalent(event.sessionKey, state.activeSessionKey) ||
+      event.generation !== state.generation
+    ) return;
 
     const start = extractImageGenerationStartFromAcpEnvelope(event);
     if (!start) return;
@@ -1753,7 +1756,7 @@ export const useAcpChatSessionStore = create<AcpChatSessionState>((set, get) => 
   applyUpdateEnvelope(event) {
     const state = get();
     if (state.loading) {
-      if (event.sessionKey === state.activeSessionKey) {
+      if (sessionKeysAreEquivalent(event.sessionKey, state.activeSessionKey)) {
         const updates = pendingLoadUpdates.get(event.generation) ?? [];
         pendingLoadUpdates.set(event.generation, [...updates, event]);
       } else {
@@ -1771,7 +1774,10 @@ export const useAcpChatSessionStore = create<AcpChatSessionState>((set, get) => 
       }
       return;
     }
-    if (event.sessionKey !== state.activeSessionKey || event.generation !== state.generation) {
+    if (
+      !sessionKeysAreEquivalent(event.sessionKey, state.activeSessionKey) ||
+      event.generation !== state.generation
+    ) {
       const liveSnapshot = liveSessionSnapshots.get(event.sessionKey);
       if (liveSnapshot?.generation === event.generation) {
         liveSessionSnapshots.set(event.sessionKey, deferInactiveImageUpdate({
@@ -1802,7 +1808,10 @@ export const useAcpChatSessionStore = create<AcpChatSessionState>((set, get) => 
 
   applyPermissionRequest(event) {
     const state = get();
-    if (event.sessionKey !== state.activeSessionKey || event.generation !== state.generation) {
+    if (
+      !sessionKeysAreEquivalent(event.sessionKey, state.activeSessionKey) ||
+      event.generation !== state.generation
+    ) {
       const liveSnapshot = liveSessionSnapshots.get(event.sessionKey);
       if (liveSnapshot?.generation === event.generation) {
         liveSessionSnapshots.set(event.sessionKey, {


### PR DESCRIPTION
### Summary

Fixes #1211.

In ACP runtime mode (`acp-chat-session.ts`), cron job execution events stream under a run-scoped session key (`agent:<id>:cron:<jobId>:run:<sessionId>`). Because strict exact string equality (`===`) was used against `activeSessionKey` (`agent:<id>:cron:<jobId>`), live stream updates, image generations, and permission events were silently ignored until the task finished and history was reloaded.

### Changes
- Replaced strict `===` session key comparison with `sessionKeysAreEquivalent()` across ACP session update handlers (`recordImageGenerationStart`, `applyUpdateEnvelope`, `applyPermissionRequest`).
- Restores real-time thinking/streaming visibility for scheduled and triggered cron jobs in v0.5.x.